### PR TITLE
fix: reset context usage display after compaction

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -2554,6 +2554,15 @@ export class SessionStore {
         if (!replayOnly) {
           this.lastCompactedAt = Date.now();
         }
+        // Reset per-turn token counts so contextUtilization reflects the
+        // compacted state instead of showing stale pre-compact values.
+        // The next usage_update event will supply accurate post-compact numbers.
+        this.usage = {
+          ...this.usage,
+          inputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        };
         break;
       }
 


### PR DESCRIPTION
## Summary

- After a `compact_boundary` event, the context utilization progress bar remained at the pre-compact percentage (e.g. 100%) because per-turn token counts were not cleared
- Reset `inputTokens`, `cacheReadTokens`, and `cacheWriteTokens` to 0 in the `compact_boundary` handler so the UI reflects the compacted state until the next `usage_update` provides accurate numbers

## Test plan

- [ ] Trigger context compaction (fill context to near 100%, let auto-compact run)
- [ ] Verify the progress bar and percentage label drop after compaction
- [ ] Verify the next message updates the percentage to the correct post-compact value
- [ ] Verify micro-compact events don't break the display

**Tested on:** macOS (Apple Silicon). Not verified on Windows/Linux.