### PR TITLE
fix: handle paste when clipboardData text is empty

### DIFF
--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -1156,9 +1156,10 @@
     const text = e.clipboardData?.getData("text/plain");
 
     if (!text) {
-      // Empty text — likely Finder file paste (macOS puts file URLs, not text)
+      // Empty text — likely Finder file paste (macOS puts file URLs, not text),
+      // OR the webview didn't populate clipboardData (common in Tauri/WebKit).
       e.preventDefault();
-      tryNativeClipboardPaste();
+      handleEmptyClipboardPaste();
       return;
     }
 
@@ -1205,6 +1206,39 @@
       promise,
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
     ]);
+  }
+
+  async function handleEmptyClipboardPaste() {
+    // clipboardData was empty — try native file paste first, then Clipboard API text
+    try {
+      const files = await withTimeout(api.getClipboardFiles(), 250);
+      if (files.length > 0) {
+        dbg("prompt", "empty-clipboard-file-paste", { count: files.length });
+        await processClipboardPaths(files);
+        return;
+      }
+    } catch {
+      // File check failed — continue to text fallback
+    }
+    // No files found — try reading text via Clipboard API (handles Tauri/WebKit
+    // cases where clipboardData.getData returns empty but clipboard has text)
+    try {
+      const clipText = await navigator.clipboard.readText();
+      if (!clipText) return;
+      dbg("prompt", "clipboard-api-text-fallback", { len: clipText.length });
+      const start = textareaEl?.selectionStart ?? inputText.length;
+      const end = textareaEl?.selectionEnd ?? start;
+      inputText = inputText.slice(0, start) + clipText + inputText.slice(end);
+      requestAnimationFrame(() => {
+        autoResize();
+        if (textareaEl) {
+          const newPos = start + clipText.length;
+          textareaEl.selectionStart = textareaEl.selectionEnd = newPos;
+        }
+      });
+    } catch {
+      dbg("prompt", "clipboard-api-fallback-failed");
+    }
   }
 
   async function tryNativeClipboardPaste(snapshot?: string, cursorPos?: number) {


### PR DESCRIPTION
## Summary

- On macOS with Tauri's WebKit webview, `Cmd+V` may trigger a paste event where `clipboardData.getData("text/plain")` returns empty even though the clipboard contains text
- Previously, the code would `preventDefault` and only check for native file paste — if no files were found, nothing happened (paste silently failed)
- Add `handleEmptyClipboardPaste()` that first checks for clipboard files, then falls back to `navigator.clipboard.readText()` to insert text at the cursor position

## Test plan

- [ ] Copy text and paste with Cmd+V in the prompt input — text should appear
- [ ] Copy a file in Finder and paste — file should be processed as before
- [ ] Paste long text (>5 lines) — should create a paste block chip
- [ ] Paste short text — should insert inline
- [ ] Test on Windows/Linux to ensure no regression (Ctrl+V should work as before)

**Tested on:** macOS (Apple Silicon). Not verified on Windows/Linux.