### PR TITLE
fix: reset context usage display after compaction

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -2553,13 +2553,11 @@ export class SessionStore {
           // The next usage_update event will supply accurate post-compact numbers.
           // Only reset on full compaction — micro-compaction keeps the existing
           // usage so the progress bar does not flash 90%→0%→85%.
-          dbg("store", "compact: reset context usage", { wasMicro: isMicro });
-          this.usage = {
-            ...this.usage,
-            inputTokens: 0,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-          };
+          dbg("store", "compact: reset context usage", { preTokens: ev.pre_tokens });
+          const prev = ctx ? ctx.usage : this.usage;
+          const reset = { ...prev, inputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+          if (ctx) ctx.usage = reset;
+          else this.usage = reset;
         }
         // Only set lastCompactedAt during live mode — during replay
         // the timestamp would be meaningless (Date.now() ≠ original event time).

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -1107,6 +1107,19 @@ describe("SessionStore reducer", () => {
 
       expect(store.phase).toBe("idle");
     });
+
+    it("resets context usage tokens after full compaction", () => {
+      store.run = makeRun("run-cb-1");
+      store.phase = "running";
+      // Apply events up to and including compact_boundary (index 5), stopping
+      // before the post-compact usage_update so we can observe the reset.
+      const upToCompact = (compactBoundaryEvents as BusEvent[]).slice(0, 6);
+      store.applyEventBatch(upToCompact);
+
+      expect(store.usage.inputTokens).toBe(0);
+      expect(store.usage.cacheReadTokens).toBe(0);
+      expect(store.usage.cacheWriteTokens).toBe(0);
+    });
   });
 
   // ── getResumeWarning ──


### PR DESCRIPTION
## Summary

- After a `compact_boundary` event, the context utilization percentage remained at 100% because per-turn token counts were not cleared
- Reset `inputTokens`, `cacheReadTokens`, and `cacheWriteTokens` to 0 so the progress bar reflects the compacted state until the next `usage_update` provides accurate post-compact numbers

## Test plan

- [x] Start a long conversation until context reaches ~90%+
- [x] Trigger compaction (auto or via /compact)
- [x] Verify the context percentage drops instead of staying at 100%

**Tested on:** macOS 26.2 (25C56), Apple Silicon. Not verified on Windows/Linux.