### PR TITLE
feat: git branch switcher with color-coded badge

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -225,7 +225,6 @@ export async function getGitStatus(cwd: string): Promise<string> {
   return invoke<string>("get_git_status", { cwd });
 }
 
-
 // Export
 export async function exportConversation(runId: string): Promise<string> {
   dbg("api", "exportConversation", runId);


### PR DESCRIPTION
## Summary

- Display the current git branch as a clickable badge above the input box, aligned with quick action pills
- Click the badge to open a dropdown listing all local branches for switching
- Each branch gets a unique color from 7 rainbow colors (red, orange, yellow, green, blue, indigo, purple) based on name hash
- Poll every 10s to auto-detect branch changes made by CLI commands
- Add Rust backend commands: `get_git_branches` and `git_checkout`

## Test plan

- [x] Branch badge appears above input box with correct branch name
- [x] Click badge opens dropdown with all local branches
- [x] Switching branch updates badge text and color
- [x] CLI `git checkout` updates badge within 10s
- [x] Non-git directories show no badge

**Tested on:** macOS 26.2 (25C56), Apple Silicon. Not verified on Windows/Linux.