### PR TITLE
fix: git branch badge — dedicated command, race-safe poller

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -134,6 +134,97 @@ pub async fn get_git_summary(cwd: String) -> Result<GitSummary, String> {
 }
 
 #[tauri::command]
+pub async fn get_git_branch(cwd: String) -> Result<String, String> {
+    log::debug!("[git] get_git_branch: cwd={}", cwd);
+
+    // Step 1: structured probe (rev-parse plumbing, exit code semantics are well-defined)
+    let check = match Command::new("git")
+        .current_dir(&cwd)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+    {
+        Err(e) => {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                // git executable not installed → normal state, no branch badge
+                log::debug!("[git] get_git_branch: git not installed, cwd={}", cwd);
+                return Ok(String::new());
+            }
+            log::warn!("[git] get_git_branch I/O error: cwd={}, err={}", cwd, e);
+            return Err(e.to_string());
+        }
+        Ok(o) => o,
+    };
+
+    if check.status.success() {
+        let stdout = String::from_utf8_lossy(&check.stdout).trim().to_string();
+        if stdout != "true" {
+            // "false" → bare repo / inside .git dir → no branch badge
+            log::debug!("[git] get_git_branch: not a work tree, cwd={}", cwd);
+            return Ok(String::new());
+        }
+    } else {
+        let code = check.status.code().unwrap_or(-1);
+        let stderr = String::from_utf8_lossy(&check.stderr);
+        let stderr_trimmed = stderr.trim();
+        if code == 128 && stderr_trimmed.contains("not a git repository") {
+            // Genuinely not a git directory → Ok("") (normal state, not an error)
+            log::debug!("[git] get_git_branch: not a git repo, cwd={}", cwd);
+            return Ok(String::new());
+        }
+        // Other failures (safe.directory, corruption, permissions, etc) → Err
+        log::warn!(
+            "[git] get_git_branch: rev-parse error, cwd={}, code={}",
+            cwd,
+            code
+        );
+        return Err(format!(
+            "git rev-parse failed (code {}): {}",
+            code, stderr_trimmed
+        ));
+    }
+
+    // Step 2: get branch name
+    let output = Command::new("git")
+        .current_dir(&cwd)
+        .args(["branch", "--show-current"])
+        .output()
+        .map_err(|e| {
+            log::warn!("[git] get_git_branch: branch cmd I/O error: {}", e);
+            e.to_string()
+        })?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!(
+            "[git] get_git_branch: branch cmd failed: code={}",
+            output.status.code().unwrap_or(-1)
+        );
+        return Err(format!("git branch failed: {}", stderr.trim()));
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    // Step 3: detached HEAD → fallback to short SHA
+    if branch.is_empty() {
+        let sha = Command::new("git")
+            .current_dir(&cwd)
+            .args(["rev-parse", "--short", "HEAD"])
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+            .unwrap_or_default();
+        log::debug!(
+            "[git] get_git_branch: detached HEAD, sha={}, cwd={}",
+            sha,
+            cwd
+        );
+        return Ok(sha);
+    }
+
+    Ok(branch)
+}
+
+#[tauri::command]
 pub async fn get_git_diff(
     cwd: String,
     staged: bool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -80,6 +80,7 @@ pub fn run() {
             commands::fs::check_is_directory,
             commands::fs::read_file_base64,
             commands::git::get_git_summary,
+            commands::git::get_git_branch,
             commands::git::get_git_diff,
             commands::git::get_git_status,
             commands::export::export_conversation,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -223,6 +223,11 @@ export async function getGitSummary(cwd: string): Promise<GitSummary> {
   return invoke<GitSummary>("get_git_summary", { cwd });
 }
 
+export async function getGitBranch(cwd: string): Promise<string> {
+  dbg("api", "getGitBranch", cwd);
+  return invoke<string>("get_git_branch", { cwd });
+}
+
 export async function getGitDiff(cwd: string, staged: boolean, file?: string): Promise<string> {
   dbg("api", "getGitDiff", { cwd, staged, file });
   return invoke<string>("get_git_diff", { cwd, staged, file: file ?? null });

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -10,6 +10,7 @@
     PlatformCredential,
   } from "$lib/types";
   import * as api from "$lib/api";
+  import { createGitBranchPoller } from "$lib/utils/git-branch";
   import AgentSelector from "./AgentSelector.svelte";
   import AuthSourceBadge from "./AuthSourceBadge.svelte";
   import SkillSelector from "./SkillSelector.svelte";
@@ -154,6 +155,52 @@
         ? t("prompt_hasRunPlaceholder")
         : t("prompt_newPlaceholder"),
   );
+
+  // ── Git branch (fetched from cwd) ──
+  const branchPoller = createGitBranchPoller(api.getGitBranch);
+  let gitBranch = $state("");
+
+  // Fetch on cwd / isRemote change
+  $effect(() => {
+    void cwd;
+    void isRemote;
+    const effectiveCwd = isRemote ? "" : cwd;
+    branchPoller.refresh(effectiveCwd).then((b) => {
+      gitBranch = b;
+    });
+  });
+
+  // Poll every 10s to catch branch changes made by CLI commands
+  $effect(() => {
+    if (isRemote) return;
+    const interval = setInterval(() => {
+      branchPoller.refresh(cwd).then((b) => {
+        gitBranch = b;
+      });
+    }, 10_000);
+    return () => clearInterval(interval);
+  });
+
+  // ── Branch color (7 rainbow colors based on name hash) ──
+  const BRANCH_COLORS = [
+    { bg: "bg-red-500/15", text: "text-red-400" },
+    { bg: "bg-orange-500/15", text: "text-orange-400" },
+    { bg: "bg-yellow-500/15", text: "text-yellow-400" },
+    { bg: "bg-green-500/15", text: "text-green-400" },
+    { bg: "bg-blue-500/15", text: "text-blue-400" },
+    { bg: "bg-indigo-500/15", text: "text-indigo-400" },
+    { bg: "bg-purple-500/15", text: "text-purple-400" },
+  ];
+
+  function branchColor(name: string) {
+    let hash = 0;
+    for (let i = 0; i < name.length; i++) {
+      hash = (hash * 31 + name.charCodeAt(i)) | 0;
+    }
+    return BRANCH_COLORS[Math.abs(hash) % BRANCH_COLORS.length];
+  }
+
+  let currentBranchColor = $derived(branchColor(gitBranch));
 
   // ── Permission mode selector ──
   const PERMISSION_MODES = [
@@ -1761,29 +1808,57 @@
     </div>
   {/if}
 
-  <!-- L3: Quick action pills (above input container) -->
-  {#if slashEnabled && quickActions.length > 0}
-    <div class="flex items-center gap-1 px-1 pb-1.5 overflow-x-auto scrollbar-hide">
-      {#each quickActions as cmd (cmd.name)}
-        <button
-          class="shrink-0 rounded-md border border-border/50 px-2 py-0.5 text-[11px]
-            text-muted-foreground/70 hover:text-foreground hover:bg-accent
-            hover:border-border transition-colors whitespace-nowrap"
-          onclick={() => handleQuickAction(cmd)}
-          title={cmd.description}
-        >
-          {t(`quickAction_${cmd.name}` as MessageKey)}
-        </button>
-      {/each}
-      <button
-        class="shrink-0 rounded-md border border-border/50 px-2 py-0.5 text-[11px]
-          text-muted-foreground/70 hover:text-foreground hover:bg-accent
-          hover:border-border transition-colors whitespace-nowrap"
-        onclick={openSlashMenuFromButton}
-        title={t("quickAction_moreTitle")}
-      >
-        {t("quickAction_more")}
-      </button>
+  <!-- L3: Quick action pills + git branch (above input container) -->
+  {#if (slashEnabled && quickActions.length > 0) || gitBranch}
+    <div class="flex items-center gap-1 px-1 pb-1.5">
+      {#if slashEnabled && quickActions.length > 0}
+        <div class="flex items-center gap-1 overflow-x-auto scrollbar-hide">
+          {#each quickActions as cmd (cmd.name)}
+            <button
+              class="shrink-0 rounded-md border border-border/50 px-2 py-0.5 text-[11px]
+                text-muted-foreground/70 hover:text-foreground hover:bg-accent
+                hover:border-border transition-colors whitespace-nowrap"
+              onclick={() => handleQuickAction(cmd)}
+              title={cmd.description}
+            >
+              {t(`quickAction_${cmd.name}` as MessageKey)}
+            </button>
+          {/each}
+          <button
+            class="shrink-0 rounded-md border border-border/50 px-2 py-0.5 text-[11px]
+              text-muted-foreground/70 hover:text-foreground hover:bg-accent
+              hover:border-border transition-colors whitespace-nowrap"
+            onclick={openSlashMenuFromButton}
+            title={t("quickAction_moreTitle")}
+          >
+            {t("quickAction_more")}
+          </button>
+        </div>
+      {/if}
+      {#if gitBranch}
+        <div class="ml-auto shrink-0">
+          <span
+            class="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium {currentBranchColor.bg} {currentBranchColor.text} max-w-[200px]"
+            title={gitBranch}
+          >
+            <svg
+              class="w-3 h-3 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="6" y1="3" x2="6" y2="15" />
+              <circle cx="18" cy="6" r="3" />
+              <circle cx="6" cy="18" r="3" />
+              <path d="M18 9a9 9 0 0 1-9 9" />
+            </svg>
+            <span class="truncate">{gitBranch}</span>
+          </span>
+        </div>
+      {/if}
     </div>
   {/if}
 

--- a/src/lib/utils/__tests__/git-branch.test.ts
+++ b/src/lib/utils/__tests__/git-branch.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGitBranchPoller } from "../git-branch";
+
+// Mock debug utils
+vi.mock("$lib/utils/debug", () => ({
+  dbg: vi.fn(),
+  dbgWarn: vi.fn(),
+}));
+
+import { dbgWarn } from "$lib/utils/debug";
+
+describe("createGitBranchPoller", () => {
+  it("returns branch name on success", async () => {
+    const fetch = vi.fn().mockResolvedValue("main");
+    const poller = createGitBranchPoller(fetch);
+
+    const result = await poller.refresh("/project");
+    expect(result).toBe("main");
+    expect(poller.current).toBe("main");
+  });
+
+  it("skips fetch when cwd is empty", async () => {
+    const fetch = vi.fn();
+    const poller = createGitBranchPoller(fetch);
+
+    const result = await poller.refresh("");
+    expect(result).toBe("");
+    expect(poller.current).toBe("");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("discards stale response when rapid A→B switch (A slow, B fast)", async () => {
+    let resolveA: (v: string) => void;
+    const promiseA = new Promise<string>((r) => {
+      resolveA = r;
+    });
+    const fetch = vi.fn().mockReturnValueOnce(promiseA).mockResolvedValueOnce("feature-b");
+
+    const poller = createGitBranchPoller(fetch);
+
+    // Fire A then immediately B
+    const resultA = poller.refresh("/projectA");
+    const resultB = poller.refresh("/projectB");
+
+    // B resolves first
+    expect(await resultB).toBe("feature-b");
+    expect(poller.current).toBe("feature-b");
+
+    // A resolves late — should be discarded
+    resolveA!("feature-a");
+    expect(await resultA).toBe("feature-b"); // returns current, not stale
+    expect(poller.current).toBe("feature-b");
+  });
+
+  it("clears current when refresh('') is called while A is in-flight", async () => {
+    let resolveA: (v: string) => void;
+    const promiseA = new Promise<string>((r) => {
+      resolveA = r;
+    });
+    const fetch = vi.fn().mockReturnValueOnce(promiseA);
+    const poller = createGitBranchPoller(fetch);
+
+    const resultA = poller.refresh("/project");
+    // Clear via empty cwd
+    const cleared = await poller.refresh("");
+    expect(cleared).toBe("");
+    expect(poller.current).toBe("");
+
+    // A resolves late — should be discarded
+    resolveA!("main");
+    expect(await resultA).toBe(""); // returns current (empty)
+    expect(poller.current).toBe("");
+  });
+
+  it("handles fetch error gracefully", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("git not found"));
+    const poller = createGitBranchPoller(fetch);
+
+    const result = await poller.refresh("/project");
+    expect(result).toBe("");
+    expect(poller.current).toBe("");
+  });
+
+  it("does not overwrite new success with stale error", async () => {
+    let rejectA: (e: Error) => void;
+    const promiseA = new Promise<string>((_, r) => {
+      rejectA = r;
+    });
+    const fetch = vi.fn().mockReturnValueOnce(promiseA).mockResolvedValueOnce("develop");
+
+    const poller = createGitBranchPoller(fetch);
+
+    const resultA = poller.refresh("/old");
+    const resultB = poller.refresh("/new");
+
+    // B succeeds first
+    expect(await resultB).toBe("develop");
+    expect(poller.current).toBe("develop");
+
+    // A errors late — stale, should not override
+    rejectA!(new Error("timeout"));
+    expect(await resultA).toBe("develop");
+    expect(poller.current).toBe("develop");
+  });
+
+  it("suppresses repeated identical error warnings", async () => {
+    vi.mocked(dbgWarn).mockClear();
+    const fetch = vi.fn().mockRejectedValue(new Error("permission denied"));
+    const poller = createGitBranchPoller(fetch);
+
+    await poller.refresh("/project");
+    await poller.refresh("/project");
+
+    // Should only warn once for the same cwd + error combo
+    expect(dbgWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets error suppression after a success", async () => {
+    vi.mocked(dbgWarn).mockClear();
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce("main") // success
+      .mockRejectedValueOnce(new Error("permission denied")); // then error
+
+    const poller = createGitBranchPoller(fetch);
+
+    await poller.refresh("/project"); // success
+    await poller.refresh("/project"); // error → should warn
+
+    expect(dbgWarn).toHaveBeenCalledTimes(1);
+    expect(dbgWarn).toHaveBeenCalledWith("git-branch", "fetch error", expect.any(Object));
+  });
+});

--- a/src/lib/utils/git-branch.ts
+++ b/src/lib/utils/git-branch.ts
@@ -1,0 +1,51 @@
+import { dbg, dbgWarn } from "$lib/utils/debug";
+
+type FetchBranch = (cwd: string) => Promise<string>;
+
+export function createGitBranchPoller(fetchBranch: FetchBranch) {
+  let reqId = 0;
+  let current = "";
+  let suppressedKey = "";
+
+  function refresh(cwd: string): Promise<string> {
+    const id = ++reqId;
+    if (!cwd) {
+      current = "";
+      suppressedKey = "";
+      dbg("git-branch", "skip: no cwd");
+      return Promise.resolve("");
+    }
+    return fetchBranch(cwd)
+      .then((branch) => {
+        if (id !== reqId) {
+          dbg("git-branch", "discard stale", { id, current: reqId, cwd });
+          return current;
+        }
+        current = branch;
+        suppressedKey = "";
+        dbg("git-branch", "updated", { branch, cwd });
+        return branch;
+      })
+      .catch((err) => {
+        if (id !== reqId) return current;
+        const category = String(err).split("\n")[0]; // handle non-Error types
+        const errKey = `${cwd}:${category}`;
+        if (errKey !== suppressedKey) {
+          dbgWarn("git-branch", "fetch error", { cwd, error: category });
+          suppressedKey = errKey;
+        }
+        current = "";
+        return "";
+      });
+  }
+
+  return {
+    refresh,
+    get current() {
+      return current;
+    },
+    get reqId() {
+      return reqId;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add `get_git_branch` Rust command with structured `rev-parse` probe, detached HEAD fallback to short SHA, and robust error semantics (git not installed → silent `Ok("")`, exit 128 distinguished by stderr, `safe.directory` violations → `Err`)
- Add `createGitBranchPoller` utility with reqId-based stale response discard and per-cwd error log suppression
- Refactor PromptInput to use dedicated poller instead of `getGitSummary`, skip polling for remote sessions, remove unused `BRANCH_COLORS.check` field

## Test plan
- [x] 8 new unit tests: success, empty cwd skip, A→B race discard, in-flight clear, error handling, stale error discard, error dedup, suppression reset
- [ ] Manual: badge shows branch name → switch branch updates → non-git dir no badge → remote session no badge → detached HEAD shows short SHA → git not installed no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)