### PR TITLE
chore: tool render levels, responsive chat width, border colors

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -321,6 +321,7 @@
   "common_collapse": "Collapse",
   "common_showAllLines": "Show all ({count} lines)",
   "common_showAllItems": "Show all ({count} items)",
+  "common_showAll": "Show all",
   "common_dismiss": "dismiss",
 
   "chat_examplePrompt1": "Build a login page with email and password",
@@ -798,6 +799,7 @@
   "inline_permissionRequired": "Permission Required",
   "inline_claudeWantsToUse": "Claude wants to use",
   "inline_starting": "starting...",
+  "inline_loadDetails": "Load full output",
   "inline_alwaysAllow": "Always Allow",
   "inline_switchToMode": "Switch to {mode} mode",
   "inline_addDirectory": "Add directory: {dir}",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -321,6 +321,7 @@
   "common_collapse": "折叠",
   "common_showAllLines": "显示全部（{count} 行）",
   "common_showAllItems": "显示全部（{count} 项）",
+  "common_showAll": "显示全部",
   "common_dismiss": "关闭",
 
   "chat_examplePrompt1": "构建一个包含邮箱和密码的登录页面",
@@ -798,6 +799,7 @@
   "inline_permissionRequired": "需要权限",
   "inline_claudeWantsToUse": "Claude 想要使用",
   "inline_starting": "启动中...",
+  "inline_loadDetails": "加载完整输出",
   "inline_alwaysAllow": "始终允许",
   "inline_switchToMode": "切换到 {mode} 模式",
   "inline_addDirectory": "添加目录：{dir}",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.23"
+version = "0.1.26"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src/app.css
+++ b/src/app.css
@@ -619,11 +619,11 @@
 
 /* Code block — dark mode deeper backgrounds (terminal-like) */
 .dark .code-block {
-  background: hsl(0 0% 8%);
-  border-color: hsl(0 0% 18%);
+  background: hsl(var(--muted));
+  border-color: transparent;
 }
 .dark .code-block-header {
-  background: hsl(0 0% 12%);
+  background: hsl(var(--muted) / 0.8);
 }
 
 /* Diff section — dark mode deeper background */
@@ -667,4 +667,33 @@ code.hljs {
 }
 .cm-editor.cm-focused {
   outline: none;
+}
+
+/* Responsive chat content width — replaces fixed max-w-5xl */
+@layer components {
+  .chat-content-width {
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: 2rem;
+    padding-right: 2rem;
+    max-width: 64rem; /* 1024px baseline */
+  }
+}
+
+@media (min-width: 1400px) {
+  .chat-content-width {
+    max-width: 72rem; /* 1152px — 14" MacBook starts benefiting */
+  }
+}
+
+@media (min-width: 1600px) {
+  .chat-content-width {
+    max-width: 80rem; /* 1280px */
+  }
+}
+
+@media (min-width: 1920px) {
+  .chat-content-width {
+    max-width: 92rem; /* 1472px */
+  }
 }

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -62,7 +62,7 @@
   onmouseenter={() => (hovered = true)}
   onmouseleave={() => (hovered = false)}
 >
-  <div class="mx-auto max-w-5xl px-8 py-4">
+  <div class="chat-content-width py-4">
     <!-- Header: icon + name + copy button + timestamp -->
     <div class="mb-1.5 flex items-center gap-2">
       {#if isUser}

--- a/src/lib/components/MarkdownContent.svelte
+++ b/src/lib/components/MarkdownContent.svelte
@@ -68,7 +68,7 @@
     prose-p:text-foreground prose-p:leading-relaxed
     prose-a:text-primary prose-a:underline prose-a:underline-offset-2
     prose-code:rounded prose-code:bg-muted/70 prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:font-mono prose-code:before:content-none prose-code:after:content-none
-    prose-pre:m-0 prose-pre:p-0 prose-pre:bg-transparent
+    prose-pre:m-0 prose-pre:p-0 prose-pre:bg-transparent prose-pre:border-0
     prose-li:text-foreground
     {className}"
 >

--- a/src/lib/utils/__tests__/tool-rendering.test.ts
+++ b/src/lib/utils/__tests__/tool-rendering.test.ts
@@ -14,6 +14,7 @@ import {
   planFileSuffix,
   extractPlanContent,
   applyPlanEditsForward,
+  getToolRenderLevel,
 } from "../tool-rendering";
 
 // ── extractOutputText ──
@@ -846,5 +847,90 @@ describe("detectToolBursts", () => {
     const tl = [read("r1"), grep("g1"), bash("b1"), read("r2")];
     const bursts = detectToolBursts(tl);
     expect(bursts.size).toBe(0);
+  });
+});
+
+// ── getToolRenderLevel ──
+
+describe("getToolRenderLevel", () => {
+  // Level 3: interactive
+  it("returns 3 for AskUserQuestion regardless of status", () => {
+    expect(getToolRenderLevel("AskUserQuestion", "running")).toBe(3);
+    expect(getToolRenderLevel("AskUserQuestion", "success")).toBe(3);
+    expect(getToolRenderLevel("AskUserQuestion", "denied")).toBe(3);
+  });
+  it("returns 3 for permission_prompt on any tool", () => {
+    expect(getToolRenderLevel("Bash", "permission_prompt")).toBe(3);
+    expect(getToolRenderLevel("Read", "permission_prompt")).toBe(3);
+  });
+  it("returns 3 for permission_denied on any tool", () => {
+    expect(getToolRenderLevel("Bash", "permission_denied")).toBe(3);
+    expect(getToolRenderLevel("Write", "permission_denied")).toBe(3);
+  });
+  it("returns 3 for ExitPlanMode only in permission_prompt", () => {
+    expect(getToolRenderLevel("ExitPlanMode", "permission_prompt")).toBe(3);
+  });
+  it("returns 1 for ExitPlanMode running/success/error (no Level 3 template for these)", () => {
+    // ExitPlanMode running must NOT be Level 3 — Level 3 has no branch for it,
+    // which would render a blank line. It uses Level 1 one-liner instead.
+    expect(getToolRenderLevel("ExitPlanMode", "running")).toBe(1);
+    expect(getToolRenderLevel("ExitPlanMode", "success")).toBe(1);
+    expect(getToolRenderLevel("ExitPlanMode", "error")).toBe(1);
+  });
+
+  // Level 2: output-focused
+  it("returns 2 for Bash/Edit/Write and aliases", () => {
+    expect(getToolRenderLevel("Bash", "success")).toBe(2);
+    expect(getToolRenderLevel("bash", "running")).toBe(2);
+    expect(getToolRenderLevel("Edit", "success")).toBe(2);
+    expect(getToolRenderLevel("edit_file", "success")).toBe(2);
+    expect(getToolRenderLevel("Write", "success")).toBe(2);
+    expect(getToolRenderLevel("write_file", "success")).toBe(2);
+  });
+
+  // Level 1: info tools
+  it("returns 1 for Read, Glob, Grep, etc.", () => {
+    expect(getToolRenderLevel("Read", "success")).toBe(1);
+    expect(getToolRenderLevel("read_file", "success")).toBe(1);
+    expect(getToolRenderLevel("Glob", "success")).toBe(1);
+    expect(getToolRenderLevel("Grep", "running")).toBe(1);
+    expect(getToolRenderLevel("Task", "success")).toBe(1);
+    expect(getToolRenderLevel("WebFetch", "error")).toBe(1);
+  });
+
+  // Level 2 tools with interactive status → Level 3 wins
+  it("returns 3 when Level 2 tool has interactive status", () => {
+    expect(getToolRenderLevel("Bash", "permission_prompt")).toBe(3);
+    expect(getToolRenderLevel("Edit", "permission_denied")).toBe(3);
+  });
+
+  // ── Template-alignment regression tests ──
+  // These verify that every Level 3 classification has a matching template branch
+  // in InlineToolCard.svelte. Level 3 branches:
+  //   B1: isAsk && (running|ask_pending)
+  //   B2: isAsk && !(running|ask_pending|permission_prompt) — covers success/error/denied/permission_denied
+  //   B3: isAsk && permission_prompt
+  //   B4: ExitPlanMode && permission_prompt
+  //   B5: generic permission_prompt
+  //   B6: generic permission_denied
+  // Any Level 3 classification that doesn't match B1-B6 renders blank.
+
+  it("ExitPlanMode running is Level 1 (no Level 3 template branch for it)", () => {
+    // This was the original bug: ExitPlanMode + running → Level 3 → blank
+    expect(getToolRenderLevel("ExitPlanMode", "running")).not.toBe(3);
+  });
+
+  it("AskUserQuestion permission_denied is Level 3 (caught by B2 exclusion-based condition)", () => {
+    // B2 uses !(running && !ask_pending && !permission_prompt) which covers permission_denied
+    expect(getToolRenderLevel("AskUserQuestion", "permission_denied")).toBe(3);
+  });
+
+  it("non-Ask non-ExitPlanMode permission_denied is Level 3 (caught by B6)", () => {
+    expect(getToolRenderLevel("Read", "permission_denied")).toBe(3);
+    expect(getToolRenderLevel("Glob", "permission_denied")).toBe(3);
+  });
+
+  it("ExitPlanMode permission_denied is Level 3 (caught by B6 generic denied)", () => {
+    expect(getToolRenderLevel("ExitPlanMode", "permission_denied")).toBe(3);
   });
 });

--- a/src/lib/utils/tool-colors.ts
+++ b/src/lib/utils/tool-colors.ts
@@ -2,6 +2,7 @@ export interface ToolColor {
   bg: string;
   text: string;
   icon: string;
+  border: string;
 }
 
 export const toolColors: Record<string, ToolColor> = {
@@ -9,142 +10,175 @@ export const toolColors: Record<string, ToolColor> = {
     bg: "bg-blue-500/10",
     text: "text-blue-500 dark:text-blue-400",
     icon: "M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2zM22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z",
+    border: "border-blue-500/30",
   },
   Read: {
     bg: "bg-blue-500/10",
     text: "text-blue-500 dark:text-blue-400",
     icon: "M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2zM22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z",
+    border: "border-blue-500/30",
   },
   write_file: {
     bg: "bg-amber-500/10",
     text: "text-amber-600 dark:text-amber-400",
     icon: "M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z",
+    border: "border-amber-500/30",
   },
   Write: {
     bg: "bg-amber-500/10",
     text: "text-amber-600 dark:text-amber-400",
     icon: "M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z",
+    border: "border-amber-500/30",
   },
   edit_file: {
     bg: "bg-amber-500/10",
     text: "text-amber-600 dark:text-amber-400",
     icon: "M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z",
+    border: "border-amber-500/30",
   },
   Edit: {
     bg: "bg-amber-500/10",
     text: "text-amber-600 dark:text-amber-400",
     icon: "M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z",
+    border: "border-amber-500/30",
   },
   bash: {
     bg: "bg-emerald-500/10",
     text: "text-emerald-600 dark:text-emerald-400",
     icon: "M4 17l6-6-6-6M12 19h8",
+    border: "border-emerald-500/30",
   },
   Bash: {
     bg: "bg-emerald-500/10",
     text: "text-emerald-600 dark:text-emerald-400",
     icon: "M4 17l6-6-6-6M12 19h8",
+    border: "border-emerald-500/30",
   },
   list_directory: {
     bg: "bg-purple-500/10",
     text: "text-purple-600 dark:text-purple-400",
     icon: "M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z",
+    border: "border-purple-500/30",
   },
   search_files: {
     bg: "bg-purple-500/10",
     text: "text-purple-600 dark:text-purple-400",
     icon: "M11 3a8 8 0 1 0 0 16 8 8 0 0 0 0-16zM21 21l-4.35-4.35",
+    border: "border-purple-500/30",
   },
   Grep: {
     bg: "bg-purple-500/10",
     text: "text-purple-600 dark:text-purple-400",
     icon: "M11 3a8 8 0 1 0 0 16 8 8 0 0 0 0-16zM21 21l-4.35-4.35",
+    border: "border-purple-500/30",
   },
   Glob: {
     bg: "bg-purple-500/10",
     text: "text-purple-600 dark:text-purple-400",
     icon: "M11 3a8 8 0 1 0 0 16 8 8 0 0 0 0-16zM21 21l-4.35-4.35",
+    border: "border-purple-500/30",
   },
   Task: {
     bg: "bg-cyan-500/10",
     text: "text-cyan-600 dark:text-cyan-400",
     icon: "M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2",
+    border: "border-cyan-500/30",
   },
   AskUserQuestion: {
     bg: "bg-yellow-500/10",
     text: "text-yellow-600 dark:text-yellow-400",
     icon: "M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20z",
+    border: "border-yellow-500/30",
   },
   WebFetch: {
     bg: "bg-sky-500/10",
     text: "text-sky-600 dark:text-sky-400",
     icon: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z",
+    border: "border-sky-500/30",
   },
   WebSearch: {
     bg: "bg-sky-500/10",
     text: "text-sky-600 dark:text-sky-400",
     icon: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zM2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z",
+    border: "border-sky-500/30",
   },
   TaskOutput: {
     bg: "bg-cyan-500/10",
     text: "text-cyan-600 dark:text-cyan-400",
     icon: "M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M7 10l5 5 5-5M12 15V3",
+    border: "border-cyan-500/30",
   },
-  TaskStop: { bg: "bg-red-500/10", text: "text-red-600 dark:text-red-400", icon: "M6 6h12v12H6z" },
+  TaskStop: {
+    bg: "bg-red-500/10",
+    text: "text-red-600 dark:text-red-400",
+    icon: "M6 6h12v12H6z",
+    border: "border-red-500/30",
+  },
   TaskCreate: {
     bg: "bg-teal-500/10",
     text: "text-teal-600 dark:text-teal-400",
     icon: "M12 5v14M5 12h14",
+    border: "border-cyan-500/30",
   },
   TaskGet: {
     bg: "bg-cyan-500/10",
     text: "text-cyan-600 dark:text-cyan-400",
     icon: "M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8zM12 9a3 3 0 1 0 0 6 3 3 0 0 0 0-6z",
+    border: "border-cyan-500/30",
   },
   TaskUpdate: {
     bg: "bg-cyan-500/10",
     text: "text-cyan-600 dark:text-cyan-400",
     icon: "M23 4v6h-6M1 20v-6h6M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15",
+    border: "border-cyan-500/30",
   },
   TaskList: {
     bg: "bg-cyan-500/10",
     text: "text-cyan-600 dark:text-cyan-400",
     icon: "M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01",
+    border: "border-cyan-500/30",
   },
   NotebookEdit: {
     bg: "bg-violet-500/10",
     text: "text-violet-600 dark:text-violet-400",
     icon: "M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8zM14 2v6h6M8 13l2 2 4-4",
+    border: "border-violet-500/30",
   },
   EnterPlanMode: {
     bg: "bg-indigo-500/10",
     text: "text-indigo-600 dark:text-indigo-400",
     icon: "M12 2l4 4-4 4M12 22l-4-4 4-4M20 12H4",
+    border: "border-indigo-500/30",
   },
   ExitPlanMode: {
     bg: "bg-indigo-500/10",
     text: "text-indigo-600 dark:text-indigo-400",
     icon: "M9 11l3 3L22 4M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11",
+    border: "border-indigo-500/30",
   },
   Skill: {
     bg: "bg-rose-500/10",
     text: "text-rose-600 dark:text-rose-400",
     icon: "M13 2L3 14h9l-1 8 10-12h-9l1-8z",
+    border: "border-rose-500/30",
   },
   TeamCreate: {
     bg: "bg-teal-500/10",
     text: "text-teal-600 dark:text-teal-400",
     icon: "M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 7a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM23 21v-2a4 4 0 0 1-3-3.87M16 3.13a4 4 0 0 1 0 7.75",
+    border: "border-teal-500/30",
   },
   TeamDelete: {
     bg: "bg-red-500/10",
     text: "text-red-600 dark:text-red-400",
     icon: "M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2M9 7a4 4 0 1 0 0 8 4 4 0 0 0 0-8zM23 6l-6 6M17 6l6 6",
+    border: "border-red-500/30",
   },
   SendMessage: {
     bg: "bg-violet-500/10",
     text: "text-violet-600 dark:text-violet-400",
     icon: "M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z",
+    border: "border-violet-500/30",
   },
 };
 
@@ -152,6 +186,7 @@ export const defaultToolColor: ToolColor = {
   bg: "bg-muted",
   text: "text-muted-foreground",
   icon: "M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5",
+  border: "border-border/30",
 };
 
 export function getToolColor(name: string): ToolColor {

--- a/src/lib/utils/tool-rendering.ts
+++ b/src/lib/utils/tool-rendering.ts
@@ -551,6 +551,29 @@ export function applyPlanEditsForward(
   return content;
 }
 
+// ── Tool Render Level ──
+
+/** Tools whose output is the primary content (auto-expand, accent border). */
+const LEVEL_2_TOOLS = new Set(["Bash", "bash", "Edit", "edit_file", "Write", "write_file"]);
+
+/**
+ * Determine the render level for a tool card.
+ * Level 1 = one-liner (info tools), Level 2 = inline content (output tools), Level 3 = interactive card.
+ */
+export function getToolRenderLevel(toolName: string, status: BusToolItem["status"]): 1 | 2 | 3 {
+  // AskUserQuestion is always Level 3 (all states: active, done, denied)
+  if (toolName === "AskUserQuestion") return 3;
+  // Interactive statuses: user must approve/deny/retry
+  if (status === "permission_prompt" || status === "permission_denied") return 3;
+  // ExitPlanMode only needs Level 3 when it's a permission_prompt (plan approval card)
+  // Other states (running, success, error) use Level 1 one-liner
+  if (toolName === "ExitPlanMode" && status === "permission_prompt") return 3;
+  // Output-focused tools (including cross-provider aliases)
+  if (LEVEL_2_TOOLS.has(toolName)) return 2;
+  // Everything else
+  return 1;
+}
+
 /** Copy text to clipboard with legacy fallback for Tauri WebView. */
 export async function copyToClipboard(text: string): Promise<void> {
   if (navigator.clipboard) {


### PR DESCRIPTION
## Summary
- Add `getToolRenderLevel()` for 3-tier tool card classification (Level 1: info one-liner, Level 2: output-focused, Level 3: interactive)
- Add `border` property to all tool color entries for accent borders
- Responsive `chat-content-width` CSS class replaces fixed `max-w-5xl` (scales with viewport: 1024→1472px)
- Code block dark mode uses semantic CSS vars instead of hardcoded HSL
- i18n: add `common_showAll`, `inline_loadDetails` keys
- 88 lines of tests for `getToolRenderLevel` covering all level/status combinations

## Test plan
- [x] `npm run lint:fix` — 0 errors
- [x] `npm run format` — clean
- [x] `npm test` — 932 tests pass
- [x] `npm run build` — success