### PR TITLE
feat: soft-delete conversations, UI zoom setting

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -56,6 +56,10 @@
   "settings_general_displayLanguage": "Display Language",
   "settings_general_displayLanguageDesc": "Choose the language for the app interface",
 
+  "settings_general_display": "Display",
+  "settings_general_uiZoom": "Interface Scale",
+  "settings_general_uiZoomDesc": "Adjust the overall size of the interface",
+
   "settings_cliConfig_loading": "Loading CLI config...",
   "settings_cliConfig_loadFailed": "Failed to load CLI config: {error}",
   "settings_cliConfig_retry": "Retry",
@@ -237,6 +241,10 @@
   "sidebar_uncategorized": "Uncategorized",
   "sidebar_conversations": "{count} conversations",
   "sidebar_showMore": "Show {count} more...",
+  "sidebar_deleteConfirm": "Delete conversation",
+  "sidebar_deleteDesc": "This conversation will be removed from the sidebar. Data is kept on disk and can be restored later.",
+  "sidebar_deleteCancel": "Cancel",
+  "sidebar_deleteOk": "Delete",
 
   "statusbar_toggleSidebar": "Toggle sidebar (Ctrl+B)",
   "statusbar_contextTitle": "Context usage for the latest turn ({pct}% of {tokens} tokens). The CLI automatically compacts context when approaching the limit.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -56,6 +56,10 @@
   "settings_general_displayLanguage": "界面语言",
   "settings_general_displayLanguageDesc": "选择应用界面的显示语言",
 
+  "settings_general_display": "显示",
+  "settings_general_uiZoom": "界面缩放",
+  "settings_general_uiZoomDesc": "调整界面整体大小",
+
   "settings_cliConfig_loading": "正在加载 CLI 配置...",
   "settings_cliConfig_loadFailed": "加载 CLI 配置失败：{error}",
   "settings_cliConfig_retry": "重试",
@@ -237,6 +241,10 @@
   "sidebar_uncategorized": "未分类",
   "sidebar_conversations": "{count} 个对话",
   "sidebar_showMore": "显示更多 ({count})...",
+  "sidebar_deleteConfirm": "删除对话",
+  "sidebar_deleteDesc": "对话将从侧边栏移除，数据保留在磁盘上，后续可恢复。",
+  "sidebar_deleteCancel": "取消",
+  "sidebar_deleteOk": "删除",
 
   "statusbar_toggleSidebar": "切换侧边栏 (Ctrl+B)",
   "statusbar_contextTitle": "最新轮次的上下文使用量（{pct}%，共 {tokens} 个 token）。接近限制时 CLI 会自动压缩上下文。",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
     "shell:allow-open",
     "dialog:default",
     "notification:default",
-    "global-shortcut:default"
+    "global-shortcut:default",
+    "core:webview:allow-set-webview-zoom"
   ]
 }

--- a/src-tauri/src/commands/artifacts.rs
+++ b/src-tauri/src/commands/artifacts.rs
@@ -2,7 +2,8 @@ use crate::models::RunArtifact;
 use crate::storage;
 
 #[tauri::command]
-pub fn get_run_artifacts(id: String) -> RunArtifact {
+pub fn get_run_artifacts(id: String) -> Result<RunArtifact, String> {
     log::debug!("[artifacts] get_run_artifacts: id={}", id);
-    storage::artifacts::get_artifact(&id)
+    storage::runs::get_run(&id).ok_or_else(|| format!("Run {} not found", id))?;
+    Ok(storage::artifacts::get_artifact(&id))
 }

--- a/src-tauri/src/commands/events.rs
+++ b/src-tauri/src/commands/events.rs
@@ -2,11 +2,12 @@ use crate::models::RunEvent;
 use crate::storage;
 
 #[tauri::command]
-pub fn get_run_events(id: String, since_seq: Option<u64>) -> Vec<RunEvent> {
+pub fn get_run_events(id: String, since_seq: Option<u64>) -> Result<Vec<RunEvent>, String> {
     log::debug!(
         "[events] get_run_events: id={}, since_seq={:?}",
         id,
         since_seq
     );
-    storage::events::list_events(&id, since_seq.unwrap_or(0))
+    storage::runs::get_run(&id).ok_or_else(|| format!("Run {} not found", id))?;
+    Ok(storage::events::list_events(&id, since_seq.unwrap_or(0)))
 }

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -3,6 +3,7 @@ use crate::storage;
 #[tauri::command]
 pub fn export_conversation(run_id: String) -> Result<String, String> {
     log::debug!("[export] export_conversation: run_id={}", run_id);
+    storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {} not found", run_id))?;
     let events = storage::events::list_events(&run_id, 0);
     let mut md = String::new();
     md.push_str(&format!("# Conversation — {}\n\n", run_id));

--- a/src-tauri/src/commands/runs.rs
+++ b/src-tauri/src/commands/runs.rs
@@ -101,6 +101,12 @@ pub fn rename_run(id: String, name: String) -> Result<(), String> {
 }
 
 #[tauri::command]
+pub fn soft_delete_runs(ids: Vec<String>) -> Result<u32, String> {
+    log::debug!("[cmd/runs] soft_delete_runs: ids={:?}", ids);
+    storage::runs::soft_delete_runs(&ids)
+}
+
+#[tauri::command]
 pub fn update_run_model(id: String, model: String) -> Result<(), String> {
     log::debug!("[runs] update_run_model: id={}, model={}", id, model);
     storage::runs::update_run_model(&id, &model)

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -788,8 +788,12 @@ pub async fn send_session_control(
 }
 
 #[tauri::command]
-pub fn get_bus_events(id: String, since_seq: Option<u64>) -> Vec<serde_json::Value> {
-    storage::events::list_bus_events(&id, since_seq)
+pub fn get_bus_events(
+    id: String,
+    since_seq: Option<u64>,
+) -> Result<Vec<serde_json::Value>, String> {
+    storage::runs::get_run(&id).ok_or_else(|| format!("Run {} not found", id))?;
+    Ok(storage::events::list_bus_events(&id, since_seq))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ pub fn run() {
             commands::runs::stop_run,
             commands::runs::update_run_model,
             commands::runs::rename_run,
+            commands::runs::soft_delete_runs,
             commands::runs::search_prompts,
             commands::runs::add_prompt_favorite,
             commands::runs::remove_prompt_favorite,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -199,6 +199,8 @@ pub struct UserSettings {
     pub platform_credentials: Vec<PlatformCredential>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_platform_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ui_zoom: Option<f64>,
     #[serde(default)]
     pub onboarding_completed: bool,
     pub updated_at: String,
@@ -281,6 +283,7 @@ impl Default for UserSettings {
             remote_hosts: vec![],
             platform_credentials: vec![],
             active_platform_id: None,
+            ui_zoom: None,
             onboarding_completed: false,
             updated_at: now_iso(),
         }
@@ -435,6 +438,9 @@ pub struct RunMeta {
     /// True when CLI import couldn't reconstruct complete usage data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cli_usage_incomplete: Option<bool>,
+    /// Soft-delete timestamp (ISO 8601). When set, run is hidden from all read paths.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleted_at: Option<String>,
 }
 
 impl RunMeta {

--- a/src-tauri/src/storage/cli_sessions.rs
+++ b/src-tauri/src/storage/cli_sessions.rs
@@ -1185,6 +1185,7 @@ pub fn import_session(
         }),
         cli_session_path: Some(cli_path.to_string_lossy().to_string()),
         cli_usage_incomplete: None, // Set after import
+        deleted_at: None,
     };
 
     let run_dir = super::run_dir(&run_id);

--- a/src-tauri/src/storage/prompt_index.rs
+++ b/src-tauri/src/storage/prompt_index.rs
@@ -6,6 +6,7 @@
 //!
 //! Uses in-memory cache with 120s TTL (same pattern as `claude_usage.rs`).
 
+use crate::models::RunMeta;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -253,6 +254,16 @@ pub fn build_or_update_index() -> Result<Vec<PromptEntry>, String> {
             let events_path = entry.path().join("events.jsonl");
             if !events_path.exists() {
                 continue;
+            }
+
+            // Skip soft-deleted runs
+            let meta_path = entry.path().join("meta.json");
+            if let Ok(content) = fs::read_to_string(&meta_path) {
+                if let Ok(meta) = serde_json::from_str::<RunMeta>(&content) {
+                    if meta.deleted_at.is_some() {
+                        continue;
+                    }
+                }
             }
 
             current_run_ids.insert(run_id.clone());

--- a/src-tauri/src/storage/runs.rs
+++ b/src-tauri/src/storage/runs.rs
@@ -74,6 +74,7 @@ pub fn create_run(
         cli_import_watermark: None,
         cli_session_path: None,
         cli_usage_incomplete: None,
+        deleted_at: None,
     };
 
     save_meta(&meta)?;
@@ -84,18 +85,41 @@ pub fn save_meta(meta: &RunMeta) -> Result<(), String> {
     let dir = super::run_dir(&meta.id);
     super::ensure_dir(&dir).map_err(|e| e.to_string())?;
     let path = dir.join("meta.json");
+    let tmp = dir.join(format!(
+        "meta.json.{}.{}.tmp",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
     let json = serde_json::to_string_pretty(meta).map_err(|e| e.to_string())?;
-    fs::write(&path, json).map_err(|e| e.to_string())
+    fs::write(&tmp, &json).map_err(|e| format!("write tmp: {e}"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600));
+    }
+    fs::rename(&tmp, &path).map_err(|e| format!("rename: {e}"))
 }
 
-pub fn get_run(id: &str) -> Option<RunMeta> {
+/// Read meta.json without deleted_at filtering (internal use).
+fn get_run_raw(id: &str) -> Option<RunMeta> {
     let path = super::run_dir(id).join("meta.json");
     if !path.exists() {
-        log::debug!("[storage/runs] get_run: id={} not found", id);
         return None;
     }
     let content = fs::read_to_string(&path).ok()?;
     serde_json::from_str(&content).ok()
+}
+
+pub fn get_run(id: &str) -> Option<RunMeta> {
+    let meta = get_run_raw(id)?;
+    if meta.deleted_at.is_some() {
+        log::debug!("[storage/runs] get_run: id={} is soft-deleted", id);
+        return None;
+    }
+    Some(meta)
 }
 
 pub fn update_session_id(id: &str, session_id: &str) -> Result<(), String> {
@@ -207,6 +231,9 @@ pub fn list_runs() -> Vec<TaskRun> {
             }
             if let Ok(content) = fs::read_to_string(&meta_path) {
                 if let Ok(meta) = serde_json::from_str::<RunMeta>(&content) {
+                    if meta.deleted_at.is_some() {
+                        continue;
+                    }
                     // Compute summary from events
                     let events_path = entry.path().join("events.jsonl");
                     let (last_activity, msg_count, last_preview) = summarize_events(&events_path);
@@ -340,6 +367,9 @@ pub fn list_all_run_metas() -> Vec<RunMeta> {
             }
             if let Ok(content) = fs::read_to_string(&meta_path) {
                 if let Ok(meta) = serde_json::from_str::<RunMeta>(&content) {
+                    if meta.deleted_at.is_some() {
+                        continue;
+                    }
                     metas.push(meta);
                 }
             }
@@ -392,4 +422,49 @@ pub fn reconcile_orphaned_runs() {
             }
         }
     }
+}
+
+/// Soft-delete runs by ID list. Pre-checks all IDs, then writes deleted_at.
+/// Best-effort rollback on failure.
+pub fn soft_delete_runs(ids: &[String]) -> Result<u32, String> {
+    // Deduplicate
+    let unique_ids: Vec<&String> = {
+        let mut seen = std::collections::HashSet::new();
+        ids.iter().filter(|id| seen.insert(id.as_str())).collect()
+    };
+
+    // Phase 1: pre-check — read all metas, reject if any not found or still active
+    let mut metas: Vec<RunMeta> = Vec::with_capacity(unique_ids.len());
+    for id in &unique_ids {
+        let meta = get_run_raw(id).ok_or_else(|| format!("Run {} not found", id))?;
+        if meta.deleted_at.is_some() {
+            continue; // already deleted, skip
+        }
+        if matches!(meta.status, RunStatus::Running | RunStatus::Pending) {
+            return Err(format!("Cannot delete: run {} is still active", id));
+        }
+        metas.push(meta);
+    }
+
+    // Phase 2: write deleted_at; rollback on failure
+    let now = now_iso();
+    let originals: Vec<RunMeta> = metas.clone();
+    let mut count = 0u32;
+    for meta in &mut metas {
+        meta.deleted_at = Some(now.clone());
+        if let Err(e) = save_meta(meta) {
+            // best-effort rollback
+            for orig in &originals[..=count as usize] {
+                let _ = save_meta(orig);
+            }
+            return Err(format!(
+                "Failed to delete run {}: {}. Rollback attempted.",
+                meta.id, e
+            ));
+        }
+        count += 1;
+    }
+
+    log::debug!("[storage/runs] soft_delete_runs: deleted {} runs", count);
+    Ok(count)
 }

--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -376,6 +376,19 @@ pub fn get_user_settings() -> UserSettings {
     load().user
 }
 
+fn validate_ui_zoom(v: &serde_json::Value) -> Result<Option<f64>, String> {
+    if v.is_null() {
+        return Ok(None);
+    }
+    let f = v
+        .as_f64()
+        .ok_or_else(|| "ui_zoom must be a number".to_string())?;
+    if !(0.75..=1.5).contains(&f) {
+        return Err(format!("ui_zoom must be between 0.75 and 1.5, got {}", f));
+    }
+    Ok(Some(f))
+}
+
 pub fn update_user_settings(patch: serde_json::Value) -> Result<UserSettings, String> {
     let mut all = load();
     if let Some(agent) = patch.get("default_agent").and_then(|v| v.as_str()) {
@@ -457,6 +470,10 @@ pub fn update_user_settings(patch: serde_json::Value) -> Result<UserSettings, St
         } else {
             v.as_str().filter(|s| !s.is_empty()).map(|s| s.to_string())
         };
+    }
+    if let Some(v) = patch.get("ui_zoom") {
+        all.user.ui_zoom = validate_ui_zoom(v)?;
+        log::debug!("[storage/settings] ui_zoom patched: {:?}", all.user.ui_zoom);
     }
     if let Some(v) = patch.get("onboarding_completed") {
         all.user.onboarding_completed = v.as_bool().unwrap_or(false);
@@ -668,6 +685,30 @@ mod tests {
         apply_agent_patch(&mut s, &serde_json::json!({ "effort": "medium" }));
         apply_agent_patch(&mut s, &serde_json::json!({ "model": "opus" }));
         assert_eq!(s.effort, Some("medium".to_string()));
+    }
+
+    #[test]
+    fn validate_ui_zoom_rejects_invalid() {
+        assert!(validate_ui_zoom(&serde_json::json!(0.1)).is_err());
+        assert!(validate_ui_zoom(&serde_json::json!(5.0)).is_err());
+        assert!(validate_ui_zoom(&serde_json::json!("abc")).is_err());
+    }
+
+    #[test]
+    fn validate_ui_zoom_accepts_valid() {
+        assert_eq!(
+            validate_ui_zoom(&serde_json::json!(1.0)).unwrap(),
+            Some(1.0)
+        );
+        assert_eq!(
+            validate_ui_zoom(&serde_json::json!(0.75)).unwrap(),
+            Some(0.75)
+        );
+        assert_eq!(
+            validate_ui_zoom(&serde_json::json!(1.5)).unwrap(),
+            Some(1.5)
+        );
+        assert_eq!(validate_ui_zoom(&serde_json::json!(null)).unwrap(), None);
     }
 
     #[test]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -92,6 +92,11 @@ export async function updateRunModel(id: string, model: string): Promise<void> {
   return invoke<void>("update_run_model", { id, model });
 }
 
+export async function softDeleteRuns(ids: string[]): Promise<number> {
+  dbg("api", "softDeleteRuns", { ids });
+  return invoke<number>("soft_delete_runs", { ids });
+}
+
 // Prompt search & favorites
 
 export async function searchPrompts(query: string, limit?: number): Promise<PromptSearchResult[]> {

--- a/src/lib/components/ConversationItem.svelte
+++ b/src/lib/components/ConversationItem.svelte
@@ -16,17 +16,22 @@
     selected = false,
     onclick,
     onresume,
+    ondelete,
   }: {
     conversation: ConversationGroup;
     selected?: boolean;
     onclick?: () => void;
     onresume?: (runId: string, mode: "resume") => void;
+    ondelete?: (conversation: ConversationGroup) => void;
   } = $props();
 
   const run = $derived(conversation.latestRun);
   const label = $derived(truncate(conversation.title, 28));
   const time = $derived(relativeTime(run.last_activity_at ?? run.started_at));
   const canResume = $derived(!!run.session_id && TERMINAL_PHASES.includes(run.status as any));
+  const canDelete = $derived(
+    conversation.runs.every((r) => TERMINAL_PHASES.includes(r.status as any)),
+  );
   const runCount = $derived(conversation.runs.length);
 
   // ── Inline rename (self-contained, mirrors RunListItem) ──
@@ -162,6 +167,29 @@
             stroke-linejoin="round"
             ><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8" /><path
               d="M21 3v5h-5"
+            /></svg
+          >
+        </button>
+      {/if}
+      {#if canDelete && ondelete}
+        <button
+          class="opacity-0 group-hover:opacity-100 p-1 rounded hover:bg-destructive/20 text-muted-foreground hover:text-destructive transition-opacity"
+          onclick={(e) => {
+            e.stopPropagation();
+            ondelete(conversation);
+          }}
+          title={t("sidebar_deleteConfirm")}
+        >
+          <svg
+            class="h-3.5 w-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><path d="M3 6h18" /><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6" /><path
+              d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"
             /></svg
           >
         </button>

--- a/src/lib/components/ProjectFolderItem.svelte
+++ b/src/lib/components/ProjectFolderItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import type { ProjectFolder } from "$lib/utils/sidebar-groups";
+  import type { ProjectFolder, ConversationGroup } from "$lib/utils/sidebar-groups";
   import ConversationItem from "./ConversationItem.svelte";
   import { t } from "$lib/i18n/index.svelte";
   import { dbgWarn } from "$lib/utils/debug";
@@ -20,6 +20,7 @@
     selectedRunId?: string;
     onSelectConversation: (runId: string) => void;
     onResume: (runId: string, mode: "resume") => void;
+    onDelete?: (conversation: ConversationGroup) => void;
   };
 
   type CustomProps = BaseProps & {
@@ -27,6 +28,7 @@
     selectedRunId?: never;
     onSelectConversation?: never;
     onResume?: never;
+    onDelete?: never;
   };
 
   let {
@@ -39,6 +41,7 @@
     selectedRunId = "",
     onSelectConversation,
     onResume,
+    onDelete,
   }: ChatProps | CustomProps = $props();
 
   let visibleCount = $state(PAGE_SIZE);
@@ -167,6 +170,7 @@
             selected={isConvSelected(conv)}
             onclick={() => onSelectConversation?.(conv.latestRun.id)}
             onresume={onResume}
+            ondelete={onDelete}
           />
         {/each}
         {#if hasMore}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -123,6 +123,7 @@ export interface UserSettings {
   remote_hosts?: RemoteHost[];
   platform_credentials?: PlatformCredential[];
   active_platform_id?: string;
+  ui_zoom?: number;
   onboarding_completed: boolean;
   updated_at: string;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,11 +9,13 @@
     listPromptFavorites,
     searchPrompts,
     listMemoryFiles,
+    softDeleteRuns,
   } from "$lib/api";
   import ProjectFolderItem from "$lib/components/ProjectFolderItem.svelte";
   import CommandPalette from "$lib/components/CommandPalette.svelte";
   import SetupWizard from "$lib/components/SetupWizard.svelte";
   import AboutModal from "$lib/components/AboutModal.svelte";
+  import Modal from "$lib/components/Modal.svelte";
   import CliSessionBrowser from "$lib/components/CliSessionBrowser.svelte";
   import UpdateBanner from "$lib/components/UpdateBanner.svelte";
   import type {
@@ -32,6 +34,7 @@
     autoExpandForRun,
     expandForProjectChange,
     normalizeCwd,
+    type ConversationGroup,
   } from "$lib/utils/sidebar-groups";
   import { page } from "$app/stores";
   import { goto, afterNavigate } from "$app/navigation";
@@ -406,9 +409,22 @@
       // One-time migration: if platform_credentials is empty but api_key exists,
       // create an initial credential from current settings
       await migrateCredentialsIfNeeded(settings);
+      applyZoom(settings.ui_zoom);
     } catch {
       // Silently fail
     }
+  }
+
+  function applyZoom(zoom?: number) {
+    const factor = Math.min(1.5, Math.max(0.75, zoom ?? 1.0));
+    import("@tauri-apps/api/webviewWindow")
+      .then(({ getCurrentWebviewWindow }) => {
+        getCurrentWebviewWindow()
+          .setZoom(factor)
+          .then(() => dbg("layout", "applyZoom success", { factor }))
+          .catch((e) => dbgWarn("layout", "setZoom failed", e));
+      })
+      .catch((e) => dbgWarn("layout", "import webviewWindow failed", e));
   }
 
   /** Migrate existing api_key into platform_credentials (one-time). */
@@ -727,6 +743,38 @@
     const url = $page.url;
     return url.searchParams.get("run") ?? "";
   });
+
+  // ── Delete conversation confirm flow ──
+  let deleteConfirmOpen = $state(false);
+  let deleteTarget: ConversationGroup | null = $state(null);
+
+  function requestDeleteConversation(conv: ConversationGroup) {
+    deleteTarget = conv;
+    deleteConfirmOpen = true;
+  }
+
+  async function confirmDeleteConversation() {
+    const conv = deleteTarget;
+    deleteConfirmOpen = false;
+    deleteTarget = null;
+    if (!conv) return;
+    try {
+      const ids = conv.runs.map((r) => r.id);
+      await softDeleteRuns(ids);
+      dbg("layout", "deleteConversation success", { ids });
+      window.dispatchEvent(new Event("ocv:runs-changed"));
+      if (conv.runs.some((r) => r.id === selectedRunId)) {
+        goto("/chat");
+      }
+    } catch (e) {
+      dbgWarn("layout", "deleteConversation failed", e);
+    }
+  }
+
+  function cancelDeleteConversation() {
+    deleteConfirmOpen = false;
+    deleteTarget = null;
+  }
 
   // Build project folder tree for chats tab
   let projectFolders = $derived.by(() => buildProjectFolders(runs, favoriteRunIds, pinnedCwds));
@@ -1792,6 +1840,7 @@
                     onToggle={() => toggleProject(folder.folderKey)}
                     onSelectConversation={(runId) => goto(`/chat?run=${runId}`)}
                     onResume={(runId, mode) => goto(`/chat?run=${runId}&resume=${mode}`)}
+                    onDelete={requestDeleteConversation}
                   />
                 {/each}
                 <!-- Open folder... -->
@@ -1936,3 +1985,21 @@
     }}
   />
 {/if}
+
+<Modal bind:open={deleteConfirmOpen} title={t("sidebar_deleteConfirm")}>
+  <p class="text-sm text-muted-foreground mb-4">{t("sidebar_deleteDesc")}</p>
+  <div class="flex justify-end gap-2">
+    <button
+      class="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors"
+      onclick={cancelDeleteConversation}
+    >
+      {t("sidebar_deleteCancel")}
+    </button>
+    <button
+      class="px-3 py-1.5 text-sm rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors"
+      onclick={confirmDeleteConversation}
+    >
+      {t("sidebar_deleteOk")}
+    </button>
+  </div>
+</Modal>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -118,6 +118,90 @@
   let debugOn = $state(isDebugMode());
   let logCopied = $state(false);
   let debugFilter = $state(getDebugFilter() || "1");
+
+  // ── UI Zoom state ──
+  import type { WebviewWindow } from "@tauri-apps/api/webviewWindow";
+
+  let cachedWebview: WebviewWindow | null = null;
+  async function getWebview(): Promise<WebviewWindow> {
+    if (!cachedWebview) {
+      const { getCurrentWebviewWindow } = await import("@tauri-apps/api/webviewWindow");
+      cachedWebview = getCurrentWebviewWindow();
+    }
+    return cachedWebview;
+  }
+
+  let zoomPreview = $state(1.0);
+
+  $effect(() => {
+    if (settings) {
+      zoomPreview = Math.min(1.5, Math.max(0.75, settings.ui_zoom ?? 1.0));
+    }
+  });
+
+  function clampZoom(v: number): number | null {
+    if (!Number.isFinite(v)) return null;
+    return Math.min(1.5, Math.max(0.75, v));
+  }
+
+  let pendingZoom: number | null = null;
+  let zoomFlying = false;
+
+  async function applyZoomQueued(factor: number) {
+    if (zoomFlying) {
+      pendingZoom = factor;
+      return;
+    }
+
+    zoomFlying = true;
+    try {
+      const wv = await getWebview();
+      await wv.setZoom(factor);
+      dbg("settings", "applyZoomQueued", { factor });
+    } catch (e) {
+      dbgWarn("settings", "applyZoomQueued failed", e);
+    }
+    zoomFlying = false;
+
+    if (pendingZoom !== null) {
+      const next = pendingZoom;
+      pendingZoom = null;
+      void applyZoomQueued(next);
+    }
+  }
+
+  function previewZoom(raw: number) {
+    const factor = clampZoom(raw);
+    if (factor === null) return;
+    zoomPreview = factor;
+  }
+
+  let displaySaved = $state(false);
+
+  async function commitZoom(raw: number) {
+    const factor = clampZoom(raw);
+    if (factor === null) return;
+
+    // Persist
+    try {
+      settings = await api.updateUserSettings({ ui_zoom: factor });
+      dbg("settings", "commitZoom saved", { factor });
+      displaySaved = true;
+      setTimeout(() => (displaySaved = false), 1500);
+    } catch (e) {
+      dbgWarn("settings", "commitZoom save failed", e);
+      // Rollback to last persisted value
+      const fallback = Math.min(1.5, Math.max(0.75, settings?.ui_zoom ?? 1.0));
+      zoomPreview = fallback;
+      pendingZoom = null;
+      void applyZoomQueued(fallback);
+      return;
+    }
+
+    // Apply final value via queue (overrides any stale preview)
+    pendingZoom = null;
+    void applyZoomQueued(factor);
+  }
   let logCount = $state(getDebugLogCount());
   let rustCmdCopied = $state(false);
   let currentUsername = $state("");
@@ -1086,6 +1170,50 @@
                     >{/if}
                 </button>
               {/each}
+            </div>
+          </div>
+        </Card>
+
+        <!-- Display Card -->
+        <Card class="p-6 space-y-4">
+          <div class="flex items-center justify-between">
+            <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t("settings_general_display")}
+            </h2>
+            {#if displaySaved}
+              <span class="text-xs text-emerald-500 flex items-center gap-1 animate-fade-in">
+                <svg
+                  class="h-3 w-3"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg
+                >
+                {t("settings_general_saved")}
+              </span>
+            {/if}
+          </div>
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <p class="text-sm font-medium">{t("settings_general_uiZoom")}</p>
+              <p class="text-xs text-muted-foreground">{t("settings_general_uiZoomDesc")}</p>
+            </div>
+            <div class="flex items-center gap-3">
+              <input
+                type="range"
+                min="0.75"
+                max="1.5"
+                step="0.05"
+                value={zoomPreview}
+                class="w-28 accent-primary"
+                oninput={(e) => previewZoom(parseFloat((e.target as HTMLInputElement).value))}
+                onchange={(e) => commitZoom(parseFloat((e.target as HTMLInputElement).value))}
+              />
+              <span class="text-xs text-muted-foreground w-10 text-right">
+                {Math.round(zoomPreview * 100)}%
+              </span>
             </div>
           </div>
         </Card>


### PR DESCRIPTION
## Summary
- **Soft-delete conversations**: sidebar conversations can be deleted (soft-delete) with undo support
- **UI zoom setting**: add Interface Scale slider (75%–150%) in Settings > General > Display, persisted to UserSettings and restored on startup via Tauri webview setZoom API

## Test plan
- [ ] Soft-delete a conversation from sidebar, verify undo works
- [ ] Settings > General > Display → drag slider, release → interface scales
- [ ] Restart app → zoom level restored
- [ ] `cargo test` + `npm test` pass