### PR TITLE
fix: distinguish CLI version from app version in UI

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -628,6 +628,7 @@
 
   "release_goBack": "Go back",
   "release_title": "Release Notes",
+  "release_cliChangelog": "Claude Code Changelog",
   "release_searchPlaceholder": "Search changes...",
   "release_github": "GitHub",
   "release_loadFailed": "Failed to load release notes",
@@ -761,6 +762,7 @@
   "mcp_sessionInactive": "Session inactive — actions disabled",
 
   "notes_title": "Release Notes",
+  "notes_cliTitle": "CLI Release Notes",
   "notes_latest": "latest",
   "notes_viewAll": "View all {count} versions",
 

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -628,6 +628,7 @@
 
   "release_goBack": "返回",
   "release_title": "发布说明",
+  "release_cliChangelog": "Claude Code 更新日志",
   "release_searchPlaceholder": "搜索更改...",
   "release_github": "GitHub",
   "release_loadFailed": "加载发布说明失败",
@@ -761,6 +762,7 @@
   "mcp_sessionInactive": "会话未激活 — 操作已禁用",
 
   "notes_title": "发布说明",
+  "notes_cliTitle": "CLI 更新日志",
   "notes_latest": "最新",
   "notes_viewAll": "查看全部 {count} 个版本",
 

--- a/src/lib/components/AboutModal.svelte
+++ b/src/lib/components/AboutModal.svelte
@@ -92,7 +92,9 @@
       <!-- Header -->
       <div class="flex items-center justify-between border-b border-border px-6 py-4">
         <div class="flex items-center gap-3">
-          <span class="text-xs text-muted-foreground">{appVersion ? `v${appVersion}` : ""}</span>
+          <span class="text-xs text-muted-foreground"
+            >{appVersion ? `OpenCovibe v${appVersion}` : ""}</span
+          >
           <button
             class="rounded-md border border-border px-2.5 py-1 text-xs font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
             onclick={updateToLatest}

--- a/src/lib/components/ReleaseNotesCard.svelte
+++ b/src/lib/components/ReleaseNotesCard.svelte
@@ -52,7 +52,7 @@
         d="M14 2v4a2 2 0 0 0 2 2h4"
       /><path d="M10 9H8" /><path d="M16 13H8" /><path d="M16 17H8" /></svg
     >
-    <span class="font-medium">{t("notes_title")}</span>
+    <span class="font-medium">{t("notes_cliTitle")}</span>
   </div>
 
   {#each visibleEntries as entry, i}

--- a/src/lib/components/SessionStatusBar.svelte
+++ b/src/lib/components/SessionStatusBar.svelte
@@ -801,7 +801,7 @@
           <button
             class="text-foreground/30 hover:text-foreground/60 transition-colors hidden sm:inline"
             title={t("statusbar_cliVersionTitle", { version: cliVersion ?? "" })}
-            onclick={() => goto("/release-notes")}>v{cliVersion}</button
+            onclick={() => goto("/release-notes")}>CLI v{cliVersion}</button
           >
         {/if}
       </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -827,9 +827,12 @@
   });
 
   // Breadcrumb for non-chat pages
-  let pageName = $derived(
-    navItems.find((n) => currentPath.startsWith(n.path))?.label() ?? t("layout_appName"),
-  );
+  let pageName = $derived.by(() => {
+    const nav = navItems.find((n) => currentPath.startsWith(n.path));
+    if (nav) return nav.label();
+    if (currentPath.startsWith("/release-notes")) return t("release_cliChangelog");
+    return t("layout_appName");
+  });
 
   function newChat() {
     goto("/chat");

--- a/src/routes/release-notes/+page.svelte
+++ b/src/routes/release-notes/+page.svelte
@@ -78,12 +78,12 @@
           d="M14 2v4a2 2 0 0 0 2 2h4"
         /><path d="M10 9H8" /><path d="M16 13H8" /><path d="M16 17H8" /></svg
       >
-      <h1 class="text-sm font-medium">{t("release_title")}</h1>
+      <h1 class="text-sm font-medium">{t("release_cliChangelog")}</h1>
       {#if currentVersion}
         <span
           class="rounded bg-primary/15 px-1.5 py-0.5 text-[10px] font-mono font-medium text-primary"
         >
-          v{currentVersion}
+          Claude Code v{currentVersion}
         </span>
       {/if}
     </div>


### PR DESCRIPTION
## Summary
- Release Notes page title → "Claude Code Changelog", badge → "Claude Code vX.Y.Z"
- ReleaseNotesCard title → "CLI Release Notes"
- Status bar version → "CLI vX.Y.Z"
- About modal version → "OpenCovibe vX.Y.Z"
- Breadcrumb on release-notes page → "OpenCovibe > Claude Code Changelog" (was "OpenCovibe > OpenCovibe")
- New i18n keys: `release_cliChangelog`, `notes_cliTitle` (en + zh-CN)

Closes #36

## Test plan
- [ ] Release Notes page: title shows "Claude Code Changelog", badge shows "Claude Code v2.x.x"
- [ ] About modal shows "OpenCovibe v0.1.27"
- [ ] Status bar shows "CLI v2.x.x"
- [ ] ReleaseNotesCard title shows "CLI Release Notes"
- [ ] Breadcrumb on release-notes page shows page name, not app name
- [ ] zh-CN locale displays correctly