### PR TITLE
fix: clear stale provider URL when switching to CLI auth mode

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -155,10 +155,15 @@ fn resolve_auth_env(remote: &Option<RemoteHost>, settings: &UserSettings) -> Res
         }
     }
 
+    // CLI mode: never inject a stale base_url — CLI manages its own connection
     ResolvedAuth {
         api_key: None,
         auth_token: None,
-        base_url,
+        base_url: if settings.auth_mode == "cli" {
+            None
+        } else {
+            base_url
+        },
         default_model: None,
         extra_env: None,
     }

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1251,7 +1251,12 @@
                   : 'hover:bg-accent hover:border-ring/30'}"
                 onclick={() => {
                   authMode = "cli";
-                  saveGeneralPatch({ auth_mode: "cli" });
+                  saveGeneralPatch({
+                    auth_mode: "cli",
+                    anthropic_base_url: null,
+                    active_platform_id: null,
+                    auth_env_var: null,
+                  });
                   api
                     .getAuthOverview()
                     .then((ov) => (authOverview = ov))


### PR DESCRIPTION
## Summary
- When switching from a third-party provider (e.g. ccswitch) back to CLI auth mode, the global `anthropic_base_url` was not cleared, causing persistent "Provider is unreachable" errors
- **Frontend**: switching to CLI mode now clears `anthropic_base_url`, `active_platform_id`, and `auth_env_var`
- **Backend**: `resolve_auth_env()` ignores global `base_url` when `auth_mode == "cli"` (defense-in-depth)

Closes #40

## Test plan
- [ ] Configure a third-party provider with a custom base URL
- [ ] Switch back to CLI auth mode in Settings
- [ ] Start a new session — should use CLI's own auth, no "Provider unreachable" error
- [ ] Verify `~/.opencovibe/settings.json` has `anthropic_base_url: null` after switching