### PR TITLE
fix: Windows CLI spawn error 193, update .zip download, add macOS entitlements

### DIFF
--- a/src-tauri/entitlements.plist
+++ b/src-tauri/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/src/agent/claude_stream.rs
+++ b/src-tauri/src/agent/claude_stream.rs
@@ -207,9 +207,20 @@ fn which_binary_inner(name: &str) -> Option<String> {
             .ok()?;
         if output.status.success() {
             let out = String::from_utf8_lossy(&output.stdout);
-            out.lines()
+            let lines: Vec<&str> = out
+                .lines()
                 .map(|l| l.trim())
-                .find(|l| !l.is_empty())
+                .filter(|l| !l.is_empty())
+                .collect();
+            // Prefer .cmd/.exe/.bat over bare name (which may be a Unix shell script → error 193)
+            let lo = |s: &str| s.to_ascii_lowercase();
+            lines
+                .iter()
+                .find(|l| {
+                    let l = lo(l);
+                    l.ends_with(".cmd") || l.ends_with(".exe") || l.ends_with(".bat")
+                })
+                .or_else(|| lines.first())
                 .map(|l| l.to_string())
         } else {
             None

--- a/src-tauri/src/commands/updates.rs
+++ b/src-tauri/src/commands/updates.rs
@@ -109,7 +109,7 @@ fn select_download_url(body: &serde_json::Value) -> String {
     #[cfg(target_os = "macos")]
     let exts: &[&str] = &[".dmg"];
     #[cfg(target_os = "windows")]
-    let exts: &[&str] = &[".msi", ".exe"];
+    let exts: &[&str] = &[".msi", ".exe", ".zip"];
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let exts: &[&str] = &[".appimage", ".deb"];
 
@@ -286,6 +286,22 @@ mod tests {
         assert_eq!(
             select_download_url_for_exts(&body, &[".msi", ".exe"]),
             "https://example.com/a.exe"
+        );
+    }
+
+    #[test]
+    fn test_select_download_url_zip_fallback_on_windows() {
+        // No .msi or .exe → should fall back to .zip
+        let body = json!({
+            "html_url": "https://github.com/AnyiWang/OpenCovibe/releases/tag/v0.1.31",
+            "assets": [
+                { "name": "OpenCovibe_0.1.31_universal.dmg", "browser_download_url": "https://example.com/a.dmg" },
+                { "name": "OpenCovibe_0.1.31_x64-setup.zip", "browser_download_url": "https://example.com/a.zip" }
+            ]
+        });
+        assert_eq!(
+            select_download_url_for_exts(&body, &[".msi", ".exe", ".zip"]),
+            "https://example.com/a.zip"
         );
     }
 


### PR DESCRIPTION
## Summary
- **Windows CLI spawn error 193**: `which_binary` now prefers `.cmd/.exe/.bat` over bare `claude` (Unix shell script) to avoid `ERROR_BAD_EXE_FORMAT`
- **Windows update check**: Add `.zip` to preferred extensions so update downloads the correct Windows installer instead of falling back to `.dmg`
- **macOS entitlements**: Add missing `entitlements.plist` for hardened runtime (JIT, unsigned memory, library validation)

## Test plan
- [ ] Windows: verify Claude CLI spawns without error 193
- [ ] Windows: verify "Update to Latest" downloads `.zip` not `.dmg`
- [ ] macOS: verify app launches and functions normally with new entitlements

🤖 Generated with [Claude Code](https://claude.com/claude-code)