### PR TITLE
fix(macos): add TCC usage descriptions to persist folder access permissions

### DIFF
--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSDocumentsFolderUsageDescription</key>
+    <string>OpenCovibe needs access to your Documents folder to open and manage coding projects.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>OpenCovibe needs access to your Downloads folder to open and manage coding projects.</string>
+    <key>NSDesktopFolderUsageDescription</key>
+    <string>OpenCovibe needs access to your Desktop folder to open and manage coding projects.</string>
+    <key>NSRemovableVolumesUsageDescription</key>
+    <string>OpenCovibe needs access to removable volumes to open and manage coding projects on external drives.</string>
+    <key>NSNetworkVolumesUsageDescription</key>
+    <string>OpenCovibe needs access to network volumes to open and manage coding projects on shared drives.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Add `src-tauri/Info.plist` with 5 `NS*UsageDescription` keys (Documents, Downloads, Desktop, removable volumes, network volumes)
- Tauri v2 auto-merges this with its generated Info.plist at build time
- Fixes macOS TCC permission dialogs reappearing on every launch for signed release builds

## Context
Without these keys, macOS TCC cannot persist user-granted folder access permissions, causing the "OpenCovibe wants to access your Documents folder" dialog to appear repeatedly.

## Test plan
- [ ] `plutil -lint src-tauri/Info.plist` passes
- [ ] After `cargo tauri build`, verify keys exist in the output bundle's Info.plist
- [ ] On a signed release build, grant folder access once and confirm the dialog does not reappear after restart