### PR TITLE
fix: classify 60s response timeout as server_issue instead of auth_issue

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -312,7 +312,7 @@ export class SessionStore {
         !this.thinkingText
       ) {
         this._isTimeoutError = true;
-        this.error = "No response from API after 60s. Check your API key and network.";
+        this.error = "No response after 60s — still waiting for API.";
         dbgWarn("store", "response timeout: no content after 60s");
       }
     }, SessionStore._RESPONSE_TIMEOUT_MS);

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -1345,6 +1345,20 @@ describe("SessionStore reducer", () => {
       expect(classifyError().category).toBe("unknown");
       expect(classifyError("", "").category).toBe("unknown");
     });
+
+    it("classifies frontend 60s timeout as server_issue, not auth_issue", () => {
+      const c = classifyError(undefined, "No response after 60s — still waiting for API.");
+      expect(c.category).toBe("server_issue");
+      expect(c.canRetry).toBe(true);
+      expect(c.settingsLink).toBe("");
+    });
+
+    it("still classifies real auth errors by subtype even if msg mentions API", () => {
+      expect(classifyError("error_api_key_invalid", "Invalid API key provided").category).toBe(
+        "auth_issue",
+      );
+      expect(classifyError(undefined, "Received 401 Unauthorized").category).toBe("auth_issue");
+    });
   });
 
   // ── taskNotifications Map ──


### PR DESCRIPTION
## Summary

Fixes #44. The 60s response timeout error message contained "API key", which caused `classifyError` to match it as `auth_issue` (🔑) instead of `server_issue` (☁️). This misled users to the Settings page, potentially causing session loss.

- Changed timeout message to `"No response after 60s — still waiting for API."` — no longer triggers the `api.?key` regex
- Now correctly classified as `server_issue` with `canRetry: true` and no settings link
- Added 2 regression tests for the new classification behavior

## Test plan

- [x] `npm test` — 1061/1061 pass
- [x] `npm run build` — clean
- [x] `cargo clippy` — 0 warnings
- [ ] Manual: send long-context message → wait 60s → verify ☁️ icon, no "Check Settings" button, auto-clears when response arrives