### PR TITLE
feat: multi-feature batch (btw, loop, keybindings, stickers, task-notification, plugin)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/agent/claude_protocol.rs
+++ b/src-tauri/src/agent/claude_protocol.rs
@@ -124,6 +124,23 @@ pub struct ProtocolState {
     strict_mode: bool,
 }
 
+/// Extract text content between simple XML tags: `<tag>content</tag>`.
+/// Returns `None` if tag not found or content is empty — callers use
+/// `None` → JSON `null` so frontend `??` correctly falls back to existing values.
+fn extract_xml_tag<'a>(text: &'a str, tag: &str) -> Option<&'a str> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let start = text.find(&open)?;
+    let content_start = start + open.len();
+    let end = text[content_start..].find(&close)?;
+    let value = text[content_start..content_start + end].trim();
+    if value.is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
 impl ProtocolState {
     pub fn is_resume(&self) -> bool {
         self.is_resume
@@ -837,6 +854,61 @@ impl ProtocolState {
                     }
                 }
 
+                // Background agent task notification (e.g., /batch worker completion).
+                // Format: <task-notification><task-id>...</task-id>...</task-notification>
+                // Require both open and close tags to avoid false positives from
+                // user-pasted XML tutorial text.
+                // TODO: CLI currently sends as content string. If it changes to
+                // content array with text blocks, also check array items.
+                if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
+                    if text.contains("<task-notification>") && text.contains("</task-notification>")
+                    {
+                        let task_id = extract_xml_tag(text, "task-id");
+                        let status = extract_xml_tag(text, "status");
+
+                        // task_id and status are required — skip event if missing
+                        // to avoid empty-key pollution in frontend taskNotifications Map
+                        if let (Some(tid), Some(st)) = (task_id, status) {
+                            let tool_use_id = extract_xml_tag(text, "tool-use-id");
+                            let summary = extract_xml_tag(text, "summary");
+                            let result_text = extract_xml_tag(text, "result");
+                            let output_file = extract_xml_tag(text, "output-file");
+
+                            // Build data object — Option<&str> serializes to null when
+                            // None, ensuring frontend ?? falls back to existing values
+                            let data = serde_json::json!({
+                                "task_id": tid,
+                                "tool_use_id": tool_use_id,
+                                "status": st,
+                                "summary": summary,
+                                "result": result_text,
+                                "output_file": output_file,
+                            });
+
+                            log::debug!(
+                                "[protocol] task_notification (XML): task_id={}, status={}, tool_use_id={}",
+                                tid,
+                                st,
+                                tool_use_id.unwrap_or("none")
+                            );
+
+                            events.push(BusEvent::TaskNotification {
+                                run_id: run_id.to_string(),
+                                task_id: tid.to_string(),
+                                status: st.to_string(),
+                                data,
+                            });
+                        } else {
+                            log::warn!(
+                                "[protocol] task_notification XML missing required fields: task_id={:?}, status={:?}",
+                                task_id,
+                                status
+                            );
+                        }
+                        return events;
+                    }
+                }
+
                 if let Some(content) = message.get("content").and_then(|v| v.as_array()) {
                     for block in content {
                         let block_type = block.get("type").and_then(|v| v.as_str()).unwrap_or("");
@@ -1370,6 +1442,120 @@ mod tests {
         match &events[0] {
             BusEvent::HookProgress { hook_id, .. } => assert_eq!(hook_id, "h1"),
             other => panic!("expected HookProgress, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_user_task_notification_xml() {
+        let mut ps = ProtocolState::new(false);
+        let xml = concat!(
+            "<task-notification>\n",
+            "<task-id>a9bb95555169d1db3</task-id>\n",
+            "<tool-use-id>toolu_01KEqmg7q9uc7ZWouxEvYeHM</tool-use-id>\n",
+            "<output-file>/tmp/tasks/a9bb9.output</output-file>\n",
+            "<status>completed</status>\n",
+            "<summary>Agent \"JSDoc for src/a.ts\" completed</summary>\n",
+            "<result>PR: none — permission denied</result>\n",
+            "</task-notification>"
+        );
+        let raw = json!({
+            "type": "user",
+            "message": { "content": xml }
+        });
+        let events = ps.map_event(RUN, &raw);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            BusEvent::TaskNotification {
+                task_id,
+                status,
+                data,
+                ..
+            } => {
+                assert_eq!(task_id, "a9bb95555169d1db3");
+                assert_eq!(status, "completed");
+                assert_eq!(data["tool_use_id"], "toolu_01KEqmg7q9uc7ZWouxEvYeHM");
+                assert_eq!(data["summary"], "Agent \"JSDoc for src/a.ts\" completed");
+                assert_eq!(data["output_file"], "/tmp/tasks/a9bb9.output");
+                assert_eq!(data["result"], "PR: none — permission denied");
+            }
+            other => panic!("expected TaskNotification, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_user_task_notification_xml_missing_task_id() {
+        let mut ps = ProtocolState::new(false);
+        let xml = concat!(
+            "<task-notification>\n",
+            "<status>completed</status>\n",
+            "<summary>Agent completed</summary>\n",
+            "</task-notification>"
+        );
+        let raw = json!({
+            "type": "user",
+            "message": { "content": xml }
+        });
+        let events = ps.map_event(RUN, &raw);
+        assert_eq!(
+            events.len(),
+            0,
+            "should not emit event when task-id is missing"
+        );
+    }
+
+    #[test]
+    fn test_user_task_notification_xml_missing_status() {
+        let mut ps = ProtocolState::new(false);
+        let xml = concat!(
+            "<task-notification>\n",
+            "<task-id>t1</task-id>\n",
+            "<summary>Agent completed</summary>\n",
+            "</task-notification>"
+        );
+        let raw = json!({
+            "type": "user",
+            "message": { "content": xml }
+        });
+        let events = ps.map_event(RUN, &raw);
+        assert_eq!(
+            events.len(),
+            0,
+            "should not emit event when status is missing"
+        );
+    }
+
+    #[test]
+    fn test_user_task_notification_xml_missing_optional_fields() {
+        let mut ps = ProtocolState::new(false);
+        let xml = concat!(
+            "<task-notification>\n",
+            "<task-id>t42</task-id>\n",
+            "<status>running</status>\n",
+            "</task-notification>"
+        );
+        let raw = json!({
+            "type": "user",
+            "message": { "content": xml }
+        });
+        let events = ps.map_event(RUN, &raw);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            BusEvent::TaskNotification {
+                task_id,
+                status,
+                data,
+                ..
+            } => {
+                assert_eq!(task_id, "t42");
+                assert_eq!(status, "running");
+                assert!(
+                    data["tool_use_id"].is_null(),
+                    "missing optional field should be null, not empty string"
+                );
+                assert!(data["summary"].is_null());
+                assert!(data["output_file"].is_null());
+            }
+            other => panic!("expected TaskNotification, got {:?}", other),
         }
     }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1708,6 +1708,289 @@ async fn spawn_cli_process(
     Ok((child, stdin, stdout, stderr))
 }
 
+// ── Side question (BTW) ──
+
+/// Spawn a one-shot forked CLI process to answer a side question without
+/// polluting the original session. Streams text deltas back via Tauri events.
+#[tauri::command]
+pub async fn side_question(
+    app: tauri::AppHandle,
+    run_id: String,
+    question: String,
+) -> Result<String, String> {
+    use serde_json::Value;
+    use tokio::io::{AsyncBufReadExt, BufReader};
+    use tokio::process::Command;
+
+    let btw_id = uuid::Uuid::new_v4().to_string();
+    log::debug!(
+        "[btw] side_question: run_id={}, btw_id={}, question={}",
+        run_id,
+        btw_id,
+        truncate_str(&question, 80)
+    );
+
+    // 1. Read source run metadata
+    let source =
+        storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {} not found", run_id))?;
+    let session_id = source
+        .session_id
+        .clone()
+        .ok_or_else(|| "No session_id available for side question".to_string())?;
+
+    // 2. Resolve auth
+    let user_settings = storage::settings::get_user_settings();
+    let remote = resolve_remote_host(&source)?;
+    let effective_pid = if user_settings.auth_mode == "cli" {
+        None
+    } else {
+        source.platform_id.as_deref()
+    };
+    let resolved = resolve_auth_env_for_platform(&remote, &user_settings, effective_pid);
+    let resolved = augment_with_shell_auth(
+        resolved,
+        &user_settings.auth_mode,
+        remote.is_some(),
+        &source.cwd,
+    );
+
+    // 3. Wrap question in system-reminder (matches CLI's side question prompt)
+    let wrapped_question = format!(
+        "<system-reminder>\nThe user is asking a side question. Answer it concisely. \
+         This answer will NOT be added to the conversation history.\n</system-reminder>\n\n{}",
+        question
+    );
+
+    // 4. Build CLI args
+    let claude_bin = claude_stream::resolve_claude_path();
+    let effective_cwd = source.remote_cwd.as_deref().unwrap_or(&source.cwd);
+
+    let mut claude_args: Vec<String> = vec![
+        "--resume".into(),
+        session_id.clone(),
+        "--fork-session".into(),
+        "--no-session-persistence".into(),
+        "-p".into(),
+        wrapped_question,
+        "--output-format".into(),
+        "stream-json".into(),
+        "--verbose".into(),
+        "--max-turns".into(),
+        "1".into(),
+    ];
+
+    // Add adapter flags (model overrides, etc.)
+    let agent_settings = storage::settings::get_agent_settings(&source.agent);
+    let adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
+    let flag_args = adapter::build_settings_args(&adapter, false);
+    claude_args.extend(flag_args.iter().cloned());
+
+    // 5. Spawn CLI process
+    let mut cmd = if let Some(ref remote_host) = remote {
+        let remote_cmd = crate::agent::ssh::build_remote_claude_command(
+            remote_host,
+            effective_cwd,
+            &claude_args,
+            resolved.api_key.as_deref(),
+            resolved.auth_token.as_deref(),
+            resolved.base_url.as_deref(),
+            resolved.default_model.as_deref(),
+            resolved.extra_env.as_ref(),
+        );
+        let mut ssh_cmd = crate::agent::ssh::build_ssh_command(remote_host, &remote_cmd);
+        ssh_cmd
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        ssh_cmd
+    } else {
+        let mut local_cmd = Command::new(&claude_bin);
+        for arg in &claude_args {
+            local_cmd.arg(arg);
+        }
+        let path_env = claude_stream::augmented_path();
+        local_cmd
+            .current_dir(effective_cwd)
+            .env("PATH", &path_env)
+            .env_remove("CLAUDECODE")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+        // Auth env (mutually exclusive)
+        if let Some(key) = &resolved.api_key {
+            local_cmd.env("ANTHROPIC_API_KEY", key);
+            local_cmd.env_remove("ANTHROPIC_AUTH_TOKEN");
+        }
+        if let Some(token) = &resolved.auth_token {
+            local_cmd.env("ANTHROPIC_AUTH_TOKEN", token);
+            local_cmd.env_remove("ANTHROPIC_API_KEY");
+        }
+        if let Some(url) = &resolved.base_url {
+            local_cmd.env("ANTHROPIC_BASE_URL", url);
+        }
+        if let Some(model) = &resolved.default_model {
+            local_cmd.env("ANTHROPIC_MODEL", model);
+            local_cmd.env("ANTHROPIC_DEFAULT_HAIKU_MODEL", model);
+            local_cmd.env("ANTHROPIC_DEFAULT_SONNET_MODEL", model);
+            local_cmd.env("ANTHROPIC_DEFAULT_OPUS_MODEL", model);
+        }
+        if let Some(extra) = &resolved.extra_env {
+            for (k, v) in extra {
+                local_cmd.env(k, v);
+            }
+        }
+        local_cmd
+    };
+
+    cmd.hide_console().kill_on_drop(true);
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to spawn side question CLI: {}", e))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or("Failed to capture CLI stdout for side question")?;
+
+    let stderr = child.stderr.take();
+
+    // 6. Stream text deltas back via Tauri events
+    let btw_id_clone = btw_id.clone();
+    let app_clone = app.clone();
+    tokio::spawn(async move {
+        use tauri::Emitter;
+
+        // Drain stderr in background for debugging
+        if let Some(stderr) = stderr {
+            let btw_id_err = btw_id_clone.clone();
+            tokio::spawn(async move {
+                let mut err_reader = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = err_reader.next_line().await {
+                    log::debug!("[btw] stderr ({}): {}", btw_id_err, line);
+                }
+            });
+        }
+
+        let mut reader = BufReader::new(stdout).lines();
+        let mut got_content = false;
+        while let Ok(Some(line)) = reader.next_line().await {
+            log::trace!("[btw] stdout line: {}", &line[..line.len().min(200)]);
+            if let Ok(obj) = serde_json::from_str::<Value>(&line) {
+                // Unwrap stream_event envelope: CLI wraps API events as
+                // {"type":"stream_event","event":{"type":"content_block_delta",...}}
+                let event = if obj.get("type").and_then(|t| t.as_str()) == Some("stream_event") {
+                    obj.get("event").cloned().unwrap_or(obj.clone())
+                } else {
+                    obj.clone()
+                };
+
+                let event_type = event.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                match event_type {
+                    // Streaming text chunks (standard API streaming)
+                    "content_block_delta" => {
+                        if let Some(text) = event.pointer("/delta/text").and_then(|v| v.as_str()) {
+                            got_content = true;
+                            log::debug!("[btw] delta: {} chars", text.len());
+                            let _ = app_clone.emit(
+                                "btw-delta",
+                                serde_json::json!({
+                                    "btw_id": btw_id_clone,
+                                    "text": text
+                                }),
+                            );
+                        }
+                    }
+                    // Complete assistant message (CLI may batch text in -p mode)
+                    "assistant" => {
+                        let message = event.get("message").unwrap_or(&event);
+                        if let Some(content) = message.get("content").and_then(|c| c.as_array()) {
+                            for block in content {
+                                if block.get("type").and_then(|t| t.as_str()) == Some("text") {
+                                    if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                        if !text.is_empty() {
+                                            got_content = true;
+                                            log::debug!(
+                                                "[btw] assistant text block: {} chars",
+                                                text.len()
+                                            );
+                                            let _ = app_clone.emit(
+                                                "btw-delta",
+                                                serde_json::json!({
+                                                    "btw_id": btw_id_clone,
+                                                    "text": text
+                                                }),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    "result" => {
+                        log::debug!(
+                            "[btw] received result event, completing btw_id={}",
+                            btw_id_clone
+                        );
+                        break;
+                    }
+                    "error" => {
+                        let msg = event
+                            .get("error")
+                            .and_then(|e| e.as_str())
+                            .unwrap_or("unknown error");
+                        log::error!("[btw] CLI error: {}", msg);
+                        let _ = app_clone.emit(
+                            "btw-error",
+                            serde_json::json!({
+                                "btw_id": btw_id_clone,
+                                "error": msg
+                            }),
+                        );
+                        break;
+                    }
+                    other => {
+                        log::debug!("[btw] event type: {}", other);
+                    }
+                }
+            }
+        }
+
+        // If no content was received, the CLI likely failed — check exit status
+        if !got_content {
+            let status = child.wait().await;
+            let code = status.as_ref().ok().and_then(|s| s.code());
+            log::error!(
+                "[btw] no content received, exit={:?}, btw_id={}",
+                code,
+                btw_id_clone
+            );
+            let _ = app_clone.emit(
+                "btw-error",
+                serde_json::json!({
+                    "btw_id": btw_id_clone,
+                    "error": format!("Side question failed (exit code: {:?})", code)
+                }),
+            );
+        } else {
+            // Emit completion
+            let _ = app_clone.emit(
+                "btw-complete",
+                serde_json::json!({ "btw_id": btw_id_clone }),
+            );
+        }
+
+        // Clean up child process
+        let _ = child.kill().await;
+        log::debug!(
+            "[btw] side question process finished, btw_id={}",
+            btw_id_clone
+        );
+    });
+
+    log::debug!("[btw] spawned side question stream, btw_id={}", btw_id);
+    Ok(btw_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -201,6 +201,7 @@ pub fn run() {
             commands::session::send_session_control,
             commands::session::get_bus_events,
             commands::session::fork_session,
+            commands::session::side_question,
             commands::session::approve_session_tool,
             commands::session::cancel_control_request,
             commands::session::respond_permission,

--- a/src-tauri/src/storage/cli_sessions.rs
+++ b/src-tauri/src/storage/cli_sessions.rs
@@ -314,6 +314,9 @@ impl TranscriptImporter {
             if text.contains("<command-name>") {
                 return false;
             }
+            if text.contains("<task-notification>") && text.contains("</task-notification>") {
+                return false;
+            }
             return true;
         }
         false
@@ -801,6 +804,14 @@ fn build_imported_index() -> HashMap<(String, String), String> {
     index
 }
 
+/// Check if a user message's text content is a candidate for "first prompt" extraction.
+/// Returns false for CLI-injected XML messages (command output, slash commands, task notifications).
+fn is_first_prompt_text(text: &str) -> bool {
+    !(text.starts_with("<local-command-stdout>")
+        || text.contains("<command-name>")
+        || text.contains("<task-notification>") && text.contains("</task-notification>"))
+}
+
 fn extract_summary(
     path: &Path,
     size: u64,
@@ -874,7 +885,7 @@ fn extract_summary(
         if first_prompt.is_none() && json_val.get("type").and_then(|v| v.as_str()) == Some("user") {
             let message = json_val.get("message").unwrap_or(&json_val);
             if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
-                if !text.starts_with("<local-command-stdout>") && !text.contains("<command-name>") {
+                if is_first_prompt_text(text) {
                     let truncated = if text.len() > 200 {
                         let end = text.floor_char_boundary(200);
                         format!("{}...", &text[..end])
@@ -1097,9 +1108,7 @@ pub fn import_session(
             if first_prompt.is_empty() && etype == "user" {
                 let message = json_val.get("message").unwrap_or(&json_val);
                 if let Some(text) = message.get("content").and_then(|v| v.as_str()) {
-                    if !text.starts_with("<local-command-stdout>")
-                        && !text.contains("<command-name>")
-                    {
+                    if is_first_prompt_text(text) {
                         first_prompt = if text.len() > 200 {
                             let end = text.floor_char_boundary(200);
                             format!("{}...", &text[..end])
@@ -1827,12 +1836,44 @@ mod tests {
         });
         assert!(!TranscriptImporter::is_real_user_prompt(&slash));
 
+        // Task notification
+        let task_notif = json!({
+            "type": "user",
+            "message": {"content": "<task-notification>\n<task-id>t1</task-id>\n<status>completed</status>\n</task-notification>"}
+        });
+        assert!(!TranscriptImporter::is_real_user_prompt(&task_notif));
+
         // Array content (not a real prompt)
         let array = json!({
             "type": "user",
             "message": {"content": [{"type": "tool_result"}]}
         });
         assert!(!TranscriptImporter::is_real_user_prompt(&array));
+    }
+
+    #[test]
+    fn test_is_first_prompt_text() {
+        // Real user prompts → true
+        assert!(is_first_prompt_text("Hello, help me fix a bug"));
+        assert!(is_first_prompt_text("Implement a new feature"));
+
+        // Command output → false
+        assert!(!is_first_prompt_text(
+            "<local-command-stdout>$ ls\nfile.txt</local-command-stdout>"
+        ));
+
+        // Slash command → false
+        assert!(!is_first_prompt_text("<command-name>/cost</command-name>"));
+
+        // Task notification → false
+        assert!(!is_first_prompt_text(
+            "<task-notification>\n<task-id>t1</task-id>\n<status>completed</status>\n</task-notification>"
+        ));
+
+        // Only open tag without close → true (user discussing XML, not a real notification)
+        assert!(is_first_prompt_text(
+            "The <task-notification> tag is used for..."
+        ));
     }
 
     #[test]

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -497,6 +497,11 @@ export async function forkSession(runId: string): Promise<string> {
   return invoke<string>("fork_session", { runId });
 }
 
+export async function sideQuestion(runId: string, question: string): Promise<string> {
+  dbg("api", "sideQuestion", { runId, question: question.slice(0, 50) });
+  return invoke<string>("side_question", { runId, question });
+}
+
 export async function approveSessionTool(runId: string, toolName: string): Promise<void> {
   dbg("api", "approveSessionTool", { runId, toolName });
   return invoke("approve_session_tool", { runId, toolName });

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -104,6 +104,7 @@
     showAuthBadge = true,
     pendingPermission = false,
     hasStash = false,
+    onBtwSend,
     onRestoreStash,
     onShortcutHelp,
     userHistory = [] as string[],
@@ -145,18 +146,29 @@
     showAuthBadge?: boolean; // TODO: remove unused auth props after hero migration
     pendingPermission?: boolean;
     hasStash?: boolean;
+    onBtwSend?: (question: string) => void;
     onRestoreStash?: () => void;
     onShortcutHelp?: () => void;
     userHistory?: string[];
     runId?: string;
   } = $props();
 
+  // ── BTW mode (side question) ──
+  let btwMode = $state(false);
+
+  // Auto-close BTW mode when agent stops running
+  $effect(() => {
+    if (!running) btwMode = false;
+  });
+
   let effectivePlaceholder = $derived(
-    pendingPermission
-      ? t("prompt_pendingPermission")
-      : hasRun
-        ? t("prompt_hasRunPlaceholder")
-        : t("prompt_newPlaceholder"),
+    btwMode
+      ? "Ask a side question..."
+      : pendingPermission
+        ? t("prompt_pendingPermission")
+        : hasRun
+          ? t("prompt_hasRunPlaceholder")
+          : t("prompt_newPlaceholder"),
   );
 
   // ── Git branch (fetched from cwd) ──
@@ -1109,6 +1121,15 @@
           goto(vDef["_navigate"] as string);
           return;
         }
+        // Side question virtual command (/btw <question>)
+        if (vDef && vDef["_action"] === "side-question" && onBtwSend) {
+          if (virtual.args) {
+            inputText = "";
+            if (textareaEl) textareaEl.style.height = "auto";
+            onBtwSend(virtual.args);
+          }
+          return;
+        }
         // Action virtual commands (e.g. /copy → copy-last)
         if (vDef && typeof vDef["_action"] === "string" && onVirtualCommand) {
           inputText = "";
@@ -1163,6 +1184,15 @@
 
     // Reset textarea height
     if (textareaEl) textareaEl.style.height = "auto";
+  }
+
+  function handleBtwSend() {
+    const question = inputText.trim();
+    if (!question || !onBtwSend) return;
+    dbg("prompt", "btwSend", { len: question.length });
+    inputText = "";
+    if (textareaEl) textareaEl.style.height = "auto";
+    onBtwSend(question);
   }
 
   async function processFiles(files: FileList | File[]) {
@@ -1913,8 +1943,10 @@
 
   <!-- Unified input container -->
   <div
-    class="rounded-xl border bg-background shadow-sm transition-colors {currentMode.borderCls ||
-      'border-border focus-within:border-ring/50 focus-within:shadow-[0_0_0_1px_hsl(var(--ring)/0.15)]'}"
+    class="rounded-xl border bg-background shadow-sm transition-colors {btwMode
+      ? 'border-blue-500/50 shadow-[0_0_0_1px_rgba(59,130,246,0.15)]'
+      : currentMode.borderCls ||
+        'border-border focus-within:border-ring/50 focus-within:shadow-[0_0_0_1px_hsl(var(--ring)/0.15)]'}"
   >
     {#if pendingPermission}
       <div
@@ -2168,11 +2200,54 @@
 
         {#if running && onInterrupt}
           {#if canSend}
-            <!-- Mid-turn send: allow injecting a message while agent is running -->
+            {#if btwMode}
+              <!-- BTW send: blue theme -->
+              <button
+                class="flex h-7 w-7 items-center justify-center rounded-lg transition-colors bg-blue-500 text-white hover:bg-blue-600"
+                onclick={handleBtwSend}
+                title="Send side question"
+              >
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+                </svg>
+              </button>
+            {:else}
+              <!-- Mid-turn send: allow injecting a message while agent is running -->
+              <button
+                class="flex h-7 w-7 items-center justify-center rounded-lg transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
+                onclick={handleSend}
+                title={t("prompt_send")}
+              >
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+                </svg>
+              </button>
+            {/if}
+          {/if}
+          <!-- BTW toggle button (only during running) -->
+          {#if onBtwSend}
             <button
-              class="flex h-7 w-7 items-center justify-center rounded-lg transition-colors bg-primary text-primary-foreground hover:bg-primary/90"
-              onclick={handleSend}
-              title={t("prompt_send")}
+              onclick={() => (btwMode = !btwMode)}
+              title="Side question (btw)"
+              class="flex h-7 w-7 items-center justify-center rounded-lg transition-colors {btwMode
+                ? 'text-blue-500 bg-blue-500/10'
+                : 'text-muted-foreground/60 hover:text-foreground hover:bg-accent'}"
             >
               <svg
                 class="h-4 w-4"
@@ -2183,7 +2258,7 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
               >
-                <path d="M5 12h14" /><path d="m12 5 7 7-7 7" />
+                <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z" />
               </svg>
             </button>
           {/if}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1278,6 +1278,19 @@ export interface PlatformCredential {
   extra_env?: Record<string, string>;
 }
 
+/** BTW side question streaming events (from Tauri) */
+export interface BtwDelta {
+  btw_id: string;
+  text: string;
+}
+export interface BtwComplete {
+  btw_id: string;
+}
+export interface BtwError {
+  btw_id: string;
+  error: string;
+}
+
 export interface AgentDefinitionSummary {
   file_name: string;
   name: string;

--- a/src/lib/utils/__tests__/slash-commands.test.ts
+++ b/src/lib/utils/__tests__/slash-commands.test.ts
@@ -1026,3 +1026,112 @@ describe("/clear virtual command", () => {
     expect(parseVirtualAction("/clear")).toEqual({ name: "clear", args: "" });
   });
 });
+
+// ── /plugin virtual command ──
+
+describe("/plugin virtual command", () => {
+  it("parseVirtualAction recognizes /plugin", () => {
+    expect(parseVirtualAction("/plugin")).toEqual({ name: "plugin", args: "" });
+  });
+
+  it("parseVirtualAction recognizes /plugins alias", () => {
+    expect(parseVirtualAction("/plugins")).toEqual({ name: "plugin", args: "" });
+  });
+
+  it("VIRTUAL_COMMANDS includes plugin with _navigate", () => {
+    const cmd = VIRTUAL_COMMANDS.find((c) => c.name === "plugin");
+    expect(cmd).toBeDefined();
+    expect(cmd!["_navigate"]).toBe("/plugins");
+  });
+
+  it('getCommandCategory returns "config" for plugin', () => {
+    expect(getCommandCategory("plugin")).toBe("config");
+  });
+
+  it("mergeWithVirtual appends /plugin when not in CLI", () => {
+    const cli: CliCommand[] = [{ name: "compact", description: "Compact", aliases: [] }];
+    const merged = mergeWithVirtual(cli);
+    const cmd = merged.find((c) => c.name === "plugin");
+    expect(cmd).toBeDefined();
+    expect(cmd!["_virtual"]).toBe(true);
+    expect(cmd!["_navigate"]).toBe("/plugins");
+  });
+
+  it("mergeWithVirtual merges when CLI also provides plugin", () => {
+    const cli: CliCommand[] = [{ name: "plugin", description: "CLI plugin manager", aliases: [] }];
+    const merged = mergeWithVirtual(cli);
+    const cmd = merged.find((c) => c.name === "plugin")!;
+    expect(cmd["_virtual"]).toBe(true);
+    expect(cmd["_navigate"]).toBe("/plugins");
+    expect(cmd.description).toBe("CLI plugin manager");
+  });
+
+  it('getCommandInteraction returns "immediate" for /plugin', () => {
+    const cmd = VIRTUAL_COMMANDS.find((c) => c.name === "plugin")!;
+    expect(getCommandInteraction(cmd)).toBe("immediate");
+  });
+});
+
+// ── /btw virtual command ──
+
+describe("/btw virtual command", () => {
+  it("parseVirtualAction recognizes /btw with question", () => {
+    expect(parseVirtualAction("/btw what does this do?")).toEqual({
+      name: "btw",
+      args: "what does this do?",
+    });
+  });
+
+  it("parseVirtualAction recognizes /btw without args", () => {
+    expect(parseVirtualAction("/btw")).toEqual({ name: "btw", args: "" });
+  });
+
+  it("VIRTUAL_COMMANDS includes btw with _action", () => {
+    const cmd = VIRTUAL_COMMANDS.find((c) => c.name === "btw");
+    expect(cmd).toBeDefined();
+    expect(cmd!["_action"]).toBe("side-question");
+  });
+
+  it('getCommandCategory returns "session" for btw', () => {
+    expect(getCommandCategory("btw")).toBe("session");
+  });
+
+  it('getCommandInteraction returns "free-text" for /btw', () => {
+    const cmd = VIRTUAL_COMMANDS.find((c) => c.name === "btw")!;
+    expect(getCommandInteraction(cmd)).toBe("free-text");
+  });
+});
+
+// ── /loop command (CLI slash command with argumentHint overlay) ──
+
+describe("/loop command", () => {
+  it("mergeWithVirtual applies argumentHint to CLI loop command", () => {
+    // Simulate CLI returning loop without argumentHint (as observed)
+    const merged = mergeWithVirtual([{ name: "loop", description: "", aliases: [] }]);
+    const cmd = merged.find((c) => c.name === "loop");
+    expect(cmd?.["argumentHint"]).toBe("[interval] <prompt>");
+  });
+
+  it("mergeWithVirtual applies fallback description to CLI loop command", () => {
+    const merged = mergeWithVirtual([{ name: "loop", description: "", aliases: [] }]);
+    const cmd = merged.find((c) => c.name === "loop");
+    expect(cmd?.description).toContain("recurring");
+  });
+
+  it('getCommandInteraction returns "free-text" for loop with hint', () => {
+    const merged = mergeWithVirtual([{ name: "loop", description: "", aliases: [] }]);
+    const cmd = merged.find((c) => c.name === "loop")!;
+    expect(getCommandInteraction(cmd)).toBe("free-text");
+  });
+
+  it("loop does NOT appear when CLI does not return it", () => {
+    // Simulate CLI without loop (feature flag off)
+    const merged = mergeWithVirtual([{ name: "compact", description: "Compact", aliases: [] }]);
+    const cmd = merged.find((c) => c.name === "loop");
+    expect(cmd).toBeUndefined();
+  });
+
+  it('getCommandCategory returns "session" for loop', () => {
+    expect(getCommandCategory("loop")).toBe("session");
+  });
+});

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -21,6 +21,7 @@ const KNOWN_COMMAND_DESCRIPTIONS: Record<string, string> = {
   fork: "Create a fork of the current conversation at this point",
   help: "Show help and available commands",
   hooks: "Manage hook configurations for tool events",
+  plugin: "Manage plugins, skills, MCP servers, and hooks",
   ide: "Manage IDE integrations and show status",
   init: "Initialize a new CLAUDE.md file with codebase documentation",
   insights: "View AI insights",
@@ -45,6 +46,15 @@ const KNOWN_COMMAND_DESCRIPTIONS: Record<string, string> = {
   usage: "Show plan usage limits",
   vim: "Toggle between Vim and Normal editing modes",
   "add-dir": "Add a directory to the workspace",
+  btw: "Ask a side question without interrupting the current task",
+  loop: "Run a prompt or slash command on a recurring interval",
+};
+
+// ── Fallback argumentHints for known CLI commands ──
+// Some CLI commands need argumentHint to prevent immediate execution.
+// Unlike VIRTUAL_COMMANDS, these only apply when CLI actually returns the command.
+const KNOWN_ARGUMENT_HINTS: Record<string, string> = {
+  loop: "[interval] <prompt>",
 };
 
 /** Marker for context-cleared separators. Used by reducer, renderer, and dimming logic. */
@@ -178,6 +188,35 @@ export const VIRTUAL_COMMANDS: CliCommand[] = [
     _virtual: true,
     _action: "open-permissions",
   },
+  {
+    name: "plugin",
+    description: "Manage plugins, skills, MCP servers, and hooks",
+    aliases: ["plugins"],
+    _virtual: true,
+    _navigate: "/plugins",
+  },
+  {
+    name: "btw",
+    description: "Ask a side question without interrupting the current task",
+    aliases: [],
+    _virtual: true,
+    _action: "side-question",
+    argumentHint: "<question>",
+  },
+  {
+    name: "stickers",
+    description: "Get Claude Code stickers",
+    aliases: ["sticker"],
+    _virtual: true,
+    _action: "open-stickers",
+  },
+  {
+    name: "keybindings",
+    description: "Open keybindings settings",
+    aliases: [],
+    _virtual: true,
+    _navigate: "/settings?tab=shortcuts",
+  },
 ];
 
 /**
@@ -190,13 +229,18 @@ export function mergeWithVirtual(cliCommands: CliCommand[]): CliCommand[] {
   const cliMap = new Map(cliCommands.map((c) => [c.name, c]));
   const result = cliCommands.map((c) => {
     const virtual = VIRTUAL_COMMANDS.find((v) => v.name === c.name);
-    const merged = virtual
+    let merged = virtual
       ? { ...virtual, ...c, _virtual: true, _enum: virtual["_enum"] ?? false }
       : c;
     // Apply fallback description if empty (works for both virtual-merged and plain CLI commands)
     if (!merged.description) {
       const fallback = KNOWN_COMMAND_DESCRIPTIONS[merged.name];
-      if (fallback) return { ...merged, description: fallback };
+      if (fallback) merged = { ...merged, description: fallback };
+    }
+    // Apply fallback argumentHint if missing (prevents immediate execution for commands that need args)
+    const hintFallback = KNOWN_ARGUMENT_HINTS[merged.name];
+    if (hintFallback && !merged["argumentHint"]) {
+      merged = { ...merged, argumentHint: hintFallback };
     }
     return merged;
   });
@@ -242,9 +286,11 @@ export type CommandInteraction = "immediate" | "free-text" | "enum";
 /** Classify how a command should be interacted with in the slash menu. */
 export function getCommandInteraction(cmd: CliCommand): CommandInteraction {
   if (cmd["_enum"] === true) return "enum";
+  // Action commands with required arguments (e.g. /btw <question>) need free-text input
+  const hint = cmd["argumentHint"];
+  if (cmd["_action"] && typeof hint === "string" && hint.startsWith("<")) return "free-text";
   // Virtual action commands execute immediately (args are optional)
   if (cmd["_action"]) return "immediate";
-  const hint = cmd["argumentHint"];
   if (typeof hint === "string" && hint.trim().length > 0) return "free-text";
   return "immediate";
 }
@@ -341,6 +387,8 @@ const COMMAND_CATEGORY_MAP: Record<string, SlashCategory> = {
   cost: "session",
   resume: "session",
   fork: "session",
+  btw: "session",
+  loop: "session",
   copy: "session",
   fast: "session",
   files: "session",
@@ -369,6 +417,7 @@ const COMMAND_CATEGORY_MAP: Record<string, SlashCategory> = {
   color: "config",
   keybindings: "config",
   hooks: "config",
+  plugin: "config",
   ide: "config",
   "add-dir": "config",
   // Help

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -198,6 +198,16 @@
       ),
   );
 
+  // ── BTW side question ──
+  let btwState = $state<{
+    active: boolean;
+    btwId: string | null;
+    question: string;
+    answer: string;
+    error: string | null;
+    loading: boolean;
+  }>({ active: false, btwId: null, question: "", answer: "", error: null, loading: false });
+
   // ── Shortcut help panel ──
   let shortcutHelpOpen = $state(false);
   let statusBarRef: SessionStatusBar | undefined = $state();
@@ -1321,6 +1331,41 @@
     };
   });
 
+  // ── BTW event listeners ──
+  // NOTE: Don't filter by btw_id — events may arrive before the IPC call returns
+  // the btw_id (race condition). Only one BTW is active at a time, so checking
+  // btwState.active is sufficient.
+  onMount(() => {
+    const transport = getTransport();
+    const deltaUnlisten = transport.listen<import("$lib/types").BtwDelta>("btw-delta", (ev) => {
+      if (btwState.active) {
+        dbg("chat", "btw-delta", { len: ev.text.length });
+        btwState.answer += ev.text;
+      }
+    });
+    const completeUnlisten = transport.listen<import("$lib/types").BtwComplete>(
+      "btw-complete",
+      (ev) => {
+        if (btwState.active) {
+          dbg("chat", "btw-complete", { btwId: ev.btw_id });
+          btwState.loading = false;
+        }
+      },
+    );
+    const errorUnlisten = transport.listen<import("$lib/types").BtwError>("btw-error", (ev) => {
+      if (btwState.active) {
+        dbgWarn("chat", "btw-error", { error: ev.error });
+        btwState.error = ev.error;
+        btwState.loading = false;
+      }
+    });
+    return () => {
+      deltaUnlisten.then((f) => f());
+      completeUnlisten.then((f) => f());
+      errorUnlisten.then((f) => f());
+    };
+  });
+
   // Auto-scroll chat (only when user is near bottom)
   let prevTl = 0;
   let prevSt = 0;
@@ -1941,6 +1986,19 @@
     }
   }
 
+  async function handleBtwSend(question: string) {
+    if (!store.run?.id) return;
+    dbg("chat", "btwSend", { runId: store.run.id, question: question.slice(0, 50) });
+    btwState = { active: true, btwId: null, question, answer: "", error: null, loading: true };
+    try {
+      const btwId = await api.sideQuestion(store.run.id, question);
+      btwState.btwId = btwId;
+    } catch (e) {
+      btwState.error = String(e);
+      btwState.loading = false;
+    }
+  }
+
   async function handleVirtualCommand(action: string, args: string) {
     dbg("chat", "virtualCommand", { action, args });
     if (action === "copy-last") {
@@ -2301,6 +2359,17 @@
       }
     } else if (action === "open-permissions") {
       window.dispatchEvent(new CustomEvent("ocv:open-permissions"));
+    } else if (action === "open-stickers") {
+      const url = "https://www.stickermule.com/claudecode";
+      dbg("chat", "open-stickers", { url });
+      try {
+        const { open } = await import("@tauri-apps/plugin-shell");
+        await open(url);
+      } catch (err) {
+        dbgWarn("chat", "open-stickers: plugin-shell failed, fallback", err);
+        window.open(url, "_blank");
+      }
+      appendCommandOutput("Opening sticker page in browser…");
     }
   }
 
@@ -3961,6 +4030,48 @@
       />
     {/if}
 
+    <!-- BTW side question drawer -->
+    {#if btwState.active}
+      <div
+        class="border-t border-blue-500/30 bg-blue-500/5"
+        style="max-height: 40vh; overflow-y: auto;"
+      >
+        <div class="flex items-center justify-between px-4 py-2 border-b border-border/50">
+          <span class="text-xs font-medium text-blue-400">BTW</span>
+          <button
+            onclick={() => (btwState = { ...btwState, active: false })}
+            title="Close side question"
+            class="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <svg
+              class="h-3.5 w-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+            </svg>
+          </button>
+        </div>
+        <div class="px-4 py-3 space-y-2">
+          <p class="text-xs text-muted-foreground">Q: {btwState.question}</p>
+          <div class="text-sm">
+            {#if btwState.error}
+              <p class="text-destructive">{btwState.error}</p>
+            {:else if btwState.answer}
+              <MarkdownContent text={btwState.answer} streaming={btwState.loading} />
+            {/if}
+            {#if btwState.loading}
+              <span class="inline-block w-2 h-4 bg-blue-400 animate-pulse rounded-sm"></span>
+            {/if}
+          </div>
+        </div>
+      </div>
+    {/if}
+
     <!-- Input bar -->
     {#if !store.ptySpawned || store.sessionAlive}
       <PromptInput
@@ -3985,6 +4096,7 @@
         platformId={store.platformId ?? "anthropic"}
         platformCredentials={settings?.platform_credentials ?? []}
         onSend={sendMessage}
+        onBtwSend={handleBtwSend}
         onAgentChange={undefined}
         onInterrupt={() => store.interrupt()}
         onModelSwitch={handleModelChange}


### PR DESCRIPTION
## Summary
- **`/btw` side question**: Virtual command with bottom drawer UI, streaming response via `--fork-session --no-session-persistence`
- **`/loop` slash command**: `KNOWN_ARGUMENT_HINTS` overlay for CLI-returned `loop` command (feature-flag aware, no VIRTUAL_COMMANDS entry)
- **`/keybindings` virtual command**: Navigates to shortcuts settings page
- **`/plugin` virtual command**: Navigates to plugins page
- **open-stickers action**: Opens sticker page in browser
- **task-notification XML parsing**: Parse `<task-notification>` from user messages
- **cargo fmt**: Apply Rust formatting fixes

## Test plan
- [x] `npm run lint:fix` — 0 errors
- [x] `npm run format` — clean
- [x] `npm test` — 1096 tests pass
- [x] `npm run build` — frontend build ok
- [x] `cargo fmt` + `cargo clippy` — 0 warnings