### PR TITLE
feat: add Ralph Loop and warm/neutral color scheme

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -252,6 +252,8 @@
   "layout_themeTitle_dark": "Theme: Dark (click for Light)",
   "layout_themeTitle_light": "Theme: Light (click for System)",
   "layout_themeTitle_system": "Theme: System (click for Dark)",
+  "layout_schemeTitle_warm": "Color scheme: Warm (click for Neutral)",
+  "layout_schemeTitle_neutral": "Color scheme: Neutral (click for Warm)",
 
   "sidebar_skills": "Skills",
   "sidebar_mcpServers": "MCP Servers",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -252,6 +252,8 @@
   "layout_themeTitle_dark": "主题：深色（点击切换为浅色）",
   "layout_themeTitle_light": "主题：浅色（点击切换为跟随系统）",
   "layout_themeTitle_system": "主题：跟随系统（点击切换为深色）",
+  "layout_schemeTitle_warm": "配色：暖色（点击切换为中性灰）",
+  "layout_schemeTitle_neutral": "配色：中性灰（点击切换为暖色）",
 
   "sidebar_skills": "技能",
   "sidebar_mcpServers": "MCP 服务器",

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -15,7 +15,8 @@ use crate::agent::turn_engine::{
     QUARANTINE_DEADLINE, TICK_INTERVAL, USER_HARD_TIMEOUT, USER_SOFT_TIMEOUT,
 };
 use crate::models::{
-    max_attachment_size, now_iso, BusEvent, RunStatus, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES,
+    max_attachment_size, now_iso, BusEvent, RalphCompleteReason, RunStatus, ALLOWED_DOC_TYPES,
+    ALLOWED_IMAGE_TYPES,
 };
 use crate::storage;
 use crate::storage::runs;
@@ -23,11 +24,22 @@ use crate::web_server::broadcaster::BroadcastEmitter;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
+use std::time::Duration;
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
+
+/// Extract content from `<promise>...</promise>` tag in text.
+fn extract_promise_tag(text: &str) -> Option<&str> {
+    let start = text.find("<promise>")?;
+    let end = text.find("</promise>")?;
+    if end <= start + 9 {
+        return None;
+    }
+    Some(text[start + 9..end].trim())
+}
 
 /// Truncate a string to at most `max` bytes, snapping to a char boundary.
 fn truncate_str(s: &str, max: usize) -> &str {
@@ -39,6 +51,37 @@ fn truncate_str(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+// ── Ralph Loop types ──
+
+#[derive(Debug, Clone, PartialEq)]
+enum RalphPhase {
+    Running,
+    WaitingRetry,
+    PausedByUser { was: Box<RalphPhase> },
+    CancelPending,
+}
+
+#[allow(dead_code)] // started_at is stored for potential future use
+struct RalphLoopState {
+    prompt: String,
+    phase: RalphPhase,
+    iteration: u32,
+    max_iterations: u32,
+    completion_promise: Option<String>,
+    started_at: String,
+    consecutive_failures: u32,
+    max_consecutive_failures: u32,
+    retry_after: Option<Instant>,
+    turn_toplevel_texts: Vec<String>,
+}
+
+/// Result returned by cancel_ralph_loop IPC command.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RalphCancelResult {
+    pub iteration: u32,
+    pub immediate: bool,
 }
 
 // ── Public types ──
@@ -90,6 +133,17 @@ pub enum ActorCommand {
         request_id: String,
         response: Value,
         reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Start a Ralph loop (auto-iterate same prompt until completion).
+    StartRalphLoop {
+        prompt: String,
+        max_iterations: u32,
+        completion_promise: Option<String>,
+        reply: oneshot::Sender<Result<(), String>>,
+    },
+    /// Cancel an active Ralph loop.
+    CancelRalphLoop {
+        reply: oneshot::Sender<Result<RalphCancelResult, String>>,
     },
 }
 
@@ -155,6 +209,12 @@ struct SessionActor {
     /// JSON parse failures in handle_stdout_line (before map_event).
     /// Complements ParserStats.parse_warn_count (field-level malformation).
     json_parse_fail_count: u32,
+
+    // ── Ralph Loop fields ──
+    /// Ralph loop state (None = inactive / completed).
+    ralph_loop: Option<RalphLoopState>,
+    /// Flag set by on_tick_timeout when WaitingRetry expires, consumed by main loop.
+    ralph_needs_dispatch: bool,
 }
 
 // ── Spawn entry point ──
@@ -222,6 +282,8 @@ pub fn spawn_actor(
         quarantine_from_internal: false,
         terminated: false,
         json_parse_fail_count: 0,
+        ralph_loop: None,
+        ralph_needs_dispatch: false,
     };
 
     let join_handle = tokio::spawn(async move {
@@ -302,6 +364,66 @@ impl SessionActor {
                             let result = self.write_control_response(&request_id, response).await;
                             let _ = reply.send(result);
                         }
+                        Some(ActorCommand::StartRalphLoop { prompt, max_iterations, completion_promise, reply }) => {
+                            if self.ralph_loop.is_some() {
+                                let _ = reply.send(Err("Ralph loop already active".into()));
+                            } else {
+                                let started_at = crate::models::now_iso();
+                                self.ralph_loop = Some(RalphLoopState {
+                                    prompt: prompt.clone(),
+                                    phase: RalphPhase::Running,
+                                    iteration: 0,
+                                    max_iterations,
+                                    completion_promise: completion_promise.clone(),
+                                    started_at: started_at.clone(),
+                                    consecutive_failures: 0,
+                                    max_consecutive_failures: 3,
+                                    retry_after: None,
+                                    turn_toplevel_texts: Vec::new(),
+                                });
+                                self.persist_and_emit(&BusEvent::RalphStarted {
+                                    run_id: self.run_id.clone(),
+                                    prompt,
+                                    max_iterations,
+                                    completion_promise,
+                                    started_at,
+                                });
+                                log::info!("[ralph] loop started: run_id={}, max_iterations={}", self.run_id, max_iterations);
+                                let _ = reply.send(Ok(()));
+                                self.try_dispatch().await;
+                            }
+                        }
+                        Some(ActorCommand::CancelRalphLoop { reply }) => {
+                            match &self.ralph_loop {
+                                None => {
+                                    let _ = reply.send(Err("No active ralph loop".into()));
+                                }
+                                Some(ralph) => {
+                                    let iteration = ralph.iteration;
+                                    let has_active_ralph_turn = self
+                                        .active_turn
+                                        .as_ref()
+                                        .map(|t| matches!(t.origin, TurnOrigin::Ralph))
+                                        .unwrap_or(false);
+
+                                    if has_active_ralph_turn {
+                                        self.ralph_loop.as_mut().unwrap().phase =
+                                            RalphPhase::CancelPending;
+                                        log::info!("[ralph] cancel pending (active turn running)");
+                                        let _ = reply.send(Ok(RalphCancelResult {
+                                            iteration,
+                                            immediate: false,
+                                        }));
+                                    } else {
+                                        let _ = reply.send(Ok(RalphCancelResult {
+                                            iteration,
+                                            immediate: true,
+                                        }));
+                                        self.emit_ralph_complete(RalphCompleteReason::Cancelled);
+                                    }
+                                }
+                            }
+                        }
                         None => {
                             // All senders dropped — actor should exit
                             log::debug!("[actor] cmd_rx closed, exiting: run_id={}", self.run_id);
@@ -342,6 +464,11 @@ impl SessionActor {
                 // 4. Independent timeout clock (HC #4)
                 _ = tick.tick() => {
                     self.on_tick_timeout().await;
+                    // Ralph: dispatch retry after backoff expires
+                    if self.ralph_needs_dispatch {
+                        self.ralph_needs_dispatch = false;
+                        self.try_dispatch().await;
+                    }
                 }
                 // 5. External cancellation (app exit)
                 _ = self.cancel.cancelled() => {
@@ -432,11 +559,53 @@ impl SessionActor {
             }
         }
 
-        // Try user queue first (unless barrier blocks)
+        // Try user queue first (unless barrier blocks). Ralph yields to user messages.
         if self.must_run_internal_for_turn.is_none() {
             if let Some(ticket) = self.queued_user.pop_front() {
+                // Pause Ralph if it's active
+                if let Some(ref mut ralph) = self.ralph_loop {
+                    match &ralph.phase {
+                        RalphPhase::Running => {
+                            ralph.phase = RalphPhase::PausedByUser {
+                                was: Box::new(RalphPhase::Running),
+                            };
+                            log::debug!("[ralph] paused by user message");
+                        }
+                        RalphPhase::WaitingRetry => {
+                            ralph.phase = RalphPhase::PausedByUser {
+                                was: Box::new(RalphPhase::WaitingRetry),
+                            };
+                            log::debug!("[ralph] paused by user message (was WaitingRetry)");
+                        }
+                        _ => {} // CancelPending — don't touch
+                    }
+                }
                 self.start_user_turn(ticket).await;
                 return;
+            }
+        }
+
+        // Ralph loop: dispatch ralph prompt when user queue is empty and phase is Running
+        if let Some(ref ralph) = self.ralph_loop {
+            match ralph.phase {
+                RalphPhase::Running => {
+                    let prompt = ralph.prompt.clone();
+                    self.start_ralph_turn(prompt).await;
+                    return;
+                }
+                RalphPhase::WaitingRetry => {
+                    if let Some(deadline) = ralph.retry_after {
+                        if Instant::now() >= deadline {
+                            // Backoff expired — transition to Running and dispatch
+                            self.ralph_loop.as_mut().unwrap().phase = RalphPhase::Running;
+                            self.ralph_loop.as_mut().unwrap().retry_after = None;
+                            let prompt = self.ralph_loop.as_ref().unwrap().prompt.clone();
+                            self.start_ralph_turn(prompt).await;
+                            return;
+                        }
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -601,6 +770,210 @@ impl SessionActor {
         }
     }
 
+    // ── Ralph Loop methods ──
+
+    /// Start a Ralph loop turn: write prompt to stdin, set active_turn with TurnOrigin::Ralph.
+    async fn start_ralph_turn(&mut self, prompt: String) {
+        let turn_index = self.next_turn_index;
+        self.next_turn_index += 1;
+        // Ralph turns don't allocate auto_ctx_id (no auto-context)
+
+        let seq = self.next_turn_seq;
+        self.next_turn_seq += 1;
+
+        // Clear per-turn text buffer
+        if let Some(ref mut ralph) = self.ralph_loop {
+            ralph.turn_toplevel_texts.clear();
+        }
+
+        let user_uuid = match self.write_user_to_stdin(&prompt, &[]).await {
+            Ok(uuid) => uuid,
+            Err(e) => {
+                log::error!("[ralph] stdin write failed: {}", e);
+                // Compute action to avoid borrow conflict
+                let action = if let Some(ref mut ralph) = self.ralph_loop {
+                    ralph.consecutive_failures += 1;
+                    if ralph.consecutive_failures >= ralph.max_consecutive_failures {
+                        Some(RalphCompleteReason::FailStopped)
+                    } else {
+                        let backoff = Duration::from_secs(2 * ralph.consecutive_failures as u64);
+                        ralph.retry_after = Some(Instant::now() + backoff);
+                        ralph.phase = RalphPhase::WaitingRetry;
+                        None
+                    }
+                } else {
+                    None
+                };
+                if let Some(reason) = action {
+                    self.emit_ralph_complete(reason);
+                }
+                return;
+            }
+        };
+
+        self.persist_and_emit(&BusEvent::UserMessage {
+            run_id: self.run_id.clone(),
+            text: prompt,
+            uuid: Some(user_uuid),
+        });
+        self.emit_state("running", None, None, false);
+
+        let now = Instant::now();
+        self.active_turn = Some(ActiveTurn {
+            turn_seq: seq,
+            origin: TurnOrigin::Ralph,
+            phase: TurnPhase::Active,
+            started_at: now,
+            soft_deadline: now + USER_SOFT_TIMEOUT,
+            hard_deadline: now + USER_HARD_TIMEOUT,
+            turn_index,
+        });
+
+        log::debug!(
+            "[ralph] turn started: turn_index={}, seq={}, iteration={}",
+            turn_index,
+            seq,
+            self.ralph_loop.as_ref().map(|r| r.iteration).unwrap_or(0)
+        );
+    }
+
+    /// Emit RalphComplete and clean up ralph_loop. After this, self.ralph_loop == None.
+    fn emit_ralph_complete(&mut self, reason: RalphCompleteReason) {
+        let iteration = self.ralph_loop.as_ref().map(|r| r.iteration).unwrap_or(0);
+        self.ralph_loop = None;
+        self.persist_and_emit(&BusEvent::RalphComplete {
+            run_id: self.run_id.clone(),
+            reason,
+            iteration,
+        });
+        log::info!(
+            "[ralph] complete: reason={:?}, iteration={}",
+            reason,
+            iteration
+        );
+    }
+
+    /// Ralph state transition on turn end. Uses action-first pattern to avoid borrow conflicts.
+    fn ralph_on_turn_end(&mut self, turn: &ActiveTurn, state: &str) {
+        if self.ralph_loop.is_none() {
+            return;
+        }
+
+        // ── Step 1: compute action (borrows ralph_loop mutably, then drops) ──
+        enum RalphAction {
+            Complete(RalphCompleteReason),
+            EmitIteration { iteration: u32, max_iterations: u32 },
+            SetWaitingRetry { backoff: Duration },
+            ResumeFrom(RalphPhase),
+            Noop,
+        }
+
+        let action = {
+            let ralph = self.ralph_loop.as_mut().unwrap();
+
+            match turn.origin {
+                TurnOrigin::Ralph => {
+                    let is_cancel_pending = ralph.phase == RalphPhase::CancelPending;
+
+                    if state == "failed" {
+                        if is_cancel_pending {
+                            RalphAction::Complete(RalphCompleteReason::Cancelled)
+                        } else {
+                            ralph.consecutive_failures += 1;
+                            if ralph.consecutive_failures >= ralph.max_consecutive_failures {
+                                RalphAction::Complete(RalphCompleteReason::FailStopped)
+                            } else {
+                                let backoff =
+                                    Duration::from_secs(2 * ralph.consecutive_failures as u64);
+                                RalphAction::SetWaitingRetry { backoff }
+                            }
+                        }
+                    } else {
+                        // idle — process turn result normally
+                        ralph.consecutive_failures = 0;
+                        ralph.iteration += 1;
+
+                        // Check natural completion conditions first
+                        let natural_reason = if ralph.max_iterations > 0
+                            && ralph.iteration >= ralph.max_iterations
+                        {
+                            Some(RalphCompleteReason::MaxIterations)
+                        } else if let Some(ref promise) = ralph.completion_promise {
+                            let matched = ralph.turn_toplevel_texts.iter().any(|text| {
+                                extract_promise_tag(text)
+                                    .map(|found| found == promise.as_str())
+                                    .unwrap_or(false)
+                            });
+                            if matched {
+                                Some(RalphCompleteReason::CompletionPromise)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        if let Some(reason) = natural_reason {
+                            RalphAction::Complete(reason)
+                        } else if is_cancel_pending {
+                            RalphAction::Complete(RalphCompleteReason::Cancelled)
+                        } else {
+                            RalphAction::EmitIteration {
+                                iteration: ralph.iteration,
+                                max_iterations: ralph.max_iterations,
+                            }
+                        }
+                    }
+                }
+                TurnOrigin::User(_) => {
+                    if let RalphPhase::PausedByUser { ref was } = ralph.phase {
+                        RalphAction::ResumeFrom(*was.clone())
+                    } else {
+                        RalphAction::Noop
+                    }
+                }
+                _ => RalphAction::Noop,
+            }
+        };
+        // ← ralph_loop borrow ends here
+
+        // ── Step 2: execute action ──
+        match action {
+            RalphAction::Complete(reason) => {
+                self.emit_ralph_complete(reason);
+            }
+            RalphAction::EmitIteration {
+                iteration,
+                max_iterations,
+            } => {
+                self.persist_and_emit(&BusEvent::RalphIteration {
+                    run_id: self.run_id.clone(),
+                    iteration,
+                    max_iterations,
+                });
+            }
+            RalphAction::SetWaitingRetry { backoff } => {
+                if let Some(ref mut ralph) = self.ralph_loop {
+                    ralph.phase = RalphPhase::WaitingRetry;
+                    ralph.retry_after = Some(Instant::now() + backoff);
+                    log::warn!(
+                        "[ralph] turn failed ({}/{}), backing off {:?}",
+                        ralph.consecutive_failures,
+                        ralph.max_consecutive_failures,
+                        backoff
+                    );
+                }
+            }
+            RalphAction::ResumeFrom(phase) => {
+                if let Some(ref mut ralph) = self.ralph_loop {
+                    ralph.phase = phase;
+                    log::debug!("[ralph] resumed to {:?} after user turn", ralph.phase);
+                }
+            }
+            RalphAction::Noop => {}
+        }
+    }
+
     /// Independent timeout clock — checks soft/hard deadlines and quarantine. (HC #4)
     async fn on_tick_timeout(&mut self) {
         // Check quarantine deadline first
@@ -642,6 +1015,17 @@ impl SessionActor {
         }
 
         let Some(ref turn) = self.active_turn else {
+            // No active turn — check Ralph WaitingRetry backoff expiry
+            if let Some(ref ralph) = self.ralph_loop {
+                if ralph.phase == RalphPhase::WaitingRetry {
+                    if let Some(deadline) = ralph.retry_after {
+                        if Instant::now() >= deadline {
+                            log::debug!("[ralph] backoff expired, setting dispatch flag");
+                            self.ralph_needs_dispatch = true;
+                        }
+                    }
+                }
+            }
             return;
         };
         let now = Instant::now();
@@ -1086,9 +1470,31 @@ impl SessionActor {
                 match &event {
                     // Capture context data in both Active and Draining phases.
                     // Soft timeout only warns; data is still accepted until RunState ends the turn.
-                    BusEvent::CommandOutput { .. } | BusEvent::MessageComplete { .. } => {
+                    BusEvent::CommandOutput { .. } => {
                         if let Some(ref mut ext) = self.active_extractor {
                             ext.on_event(&event);
+                        }
+                    }
+                    BusEvent::MessageComplete {
+                        ref text,
+                        ref parent_tool_use_id,
+                        ..
+                    } => {
+                        if let Some(ref mut ext) = self.active_extractor {
+                            ext.on_event(&event);
+                        }
+                        // Ralph: accumulate top-level assistant text (only during ralph turns)
+                        if parent_tool_use_id.is_none() {
+                            let is_ralph_turn = self
+                                .active_turn
+                                .as_ref()
+                                .map(|t| matches!(t.origin, TurnOrigin::Ralph))
+                                .unwrap_or(false);
+                            if is_ralph_turn {
+                                if let Some(ref mut ralph) = self.ralph_loop {
+                                    ralph.turn_toplevel_texts.push(text.clone());
+                                }
+                            }
                         }
                     }
                     BusEvent::RunState { state, .. } => {
@@ -1152,16 +1558,19 @@ impl SessionActor {
                         }
                     }
 
-                    // Turn completion: idle or failed → on_user_turn_finished + end turn
+                    // Turn completion: idle or failed → on_user_turn_finished + ralph + end turn
                     if (emit_state == "idle" || emit_state == "failed")
                         && self.active_turn.is_some()
                     {
-                        // Take the active turn for on_user_turn_finished
                         let turn = self.active_turn.take().unwrap();
                         self.on_user_turn_finished(&turn);
                         self.active_turn = None;
                         self.active_extractor = None;
                         self.protocol.set_pending_slash_command(None);
+
+                        // Ralph loop: state transition on turn end
+                        self.ralph_on_turn_end(&turn, &emit_state);
+
                         self.try_dispatch().await;
                     }
 

--- a/src-tauri/src/agent/turn_engine.rs
+++ b/src-tauri/src/agent/turn_engine.rs
@@ -18,6 +18,8 @@ use super::session_actor::AttachmentData;
 pub enum TurnOrigin {
     User(UserTurnKind),
     Internal(InternalJobKind),
+    /// Ralph loop auto-resend turn. Does not trigger auto-context.
+    Ralph,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,6 +1,6 @@
 use crate::agent::adapter::{self, ActorSessionMap};
 use crate::agent::claude_stream;
-use crate::agent::session_actor::{self, ActorCommand, AttachmentData};
+use crate::agent::session_actor::{self, ActorCommand, AttachmentData, RalphCancelResult};
 use crate::agent::spawn_locks::SpawnLocks;
 use crate::models::{BusEvent, RemoteHost, RunMeta, RunStatus, SessionMode, UserSettings};
 use crate::process_ext::HideConsole;
@@ -1989,6 +1989,72 @@ pub async fn side_question(
 
     log::debug!("[btw] spawned side question stream, btw_id={}", btw_id);
     Ok(btw_id)
+}
+
+// ── Ralph Loop commands ──
+
+#[tauri::command]
+pub async fn start_ralph_loop(
+    sessions: State<'_, ActorSessionMap>,
+    run_id: String,
+    prompt: String,
+    max_iterations: u32,
+    completion_promise: Option<String>,
+) -> Result<(), String> {
+    log::debug!(
+        "[session] start_ralph_loop: run_id={}, prompt_len={}, max_iterations={}, promise={:?}",
+        run_id,
+        prompt.len(),
+        max_iterations,
+        completion_promise
+    );
+
+    let cmd_tx = {
+        let map = sessions.lock().await;
+        map.get(&run_id)
+            .map(|h| h.cmd_tx.clone())
+            .ok_or_else(|| format!("Session {} not found", run_id))?
+    };
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    cmd_tx
+        .send(ActorCommand::StartRalphLoop {
+            prompt,
+            max_iterations,
+            completion_promise,
+            reply: reply_tx,
+        })
+        .await
+        .map_err(|_| "Actor dead".to_string())?;
+
+    reply_rx
+        .await
+        .map_err(|_| "Actor dropped reply".to_string())?
+}
+
+#[tauri::command]
+pub async fn cancel_ralph_loop(
+    sessions: State<'_, ActorSessionMap>,
+    run_id: String,
+) -> Result<RalphCancelResult, String> {
+    log::debug!("[session] cancel_ralph_loop: run_id={}", run_id);
+
+    let cmd_tx = {
+        let map = sessions.lock().await;
+        map.get(&run_id)
+            .map(|h| h.cmd_tx.clone())
+            .ok_or_else(|| format!("Session {} not found", run_id))?
+    };
+
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    cmd_tx
+        .send(ActorCommand::CancelRalphLoop { reply: reply_tx })
+        .await
+        .map_err(|_| "Actor dead".to_string())?;
+
+    reply_rx
+        .await
+        .map_err(|_| "Actor dropped reply".to_string())?
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -202,6 +202,8 @@ pub fn run() {
             commands::session::get_bus_events,
             commands::session::fork_session,
             commands::session::side_question,
+            commands::session::start_ralph_loop,
+            commands::session::cancel_ralph_loop,
             commands::session::approve_session_tool,
             commands::session::cancel_control_request,
             commands::session::respond_permission,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -884,6 +884,18 @@ pub struct McpServerInfo {
     pub error: Option<String>,
 }
 
+// ── Ralph Loop types ──
+
+/// Reason a Ralph loop ended. Serializes to snake_case for frontend union matching.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RalphCompleteReason {
+    MaxIterations,
+    CompletionPromise,
+    Cancelled,
+    FailStopped,
+}
+
 // ── Event Bus types ──
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1177,6 +1189,27 @@ pub enum BusEvent {
         url: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         requested_schema: Option<Value>,
+    },
+    /// Ralph loop started — carries full config for replay.
+    RalphStarted {
+        run_id: String,
+        prompt: String,
+        max_iterations: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        completion_promise: Option<String>,
+        started_at: String,
+    },
+    /// Ralph loop iteration completed (not the final one).
+    RalphIteration {
+        run_id: String,
+        iteration: u32,
+        max_iterations: u32,
+    },
+    /// Ralph loop ended.
+    RalphComplete {
+        run_id: String,
+        reason: RalphCompleteReason,
+        iteration: u32,
     },
 }
 

--- a/src-tauri/src/web_server/broadcaster.rs
+++ b/src-tauri/src/web_server/broadcaster.rs
@@ -195,6 +195,9 @@ fn event_type_name(event: &BusEvent) -> &'static str {
         BusEvent::ControlCancelled { .. } => "control_cancelled",
         BusEvent::CommandOutput { .. } => "command_output",
         BusEvent::ElicitationPrompt { .. } => "elicitation_prompt",
+        BusEvent::RalphStarted { .. } => "ralph_started",
+        BusEvent::RalphIteration { .. } => "ralph_iteration",
+        BusEvent::RalphComplete { .. } => "ralph_complete",
         BusEvent::Raw { .. } => "raw",
     }
 }

--- a/src/app.css
+++ b/src/app.css
@@ -61,6 +61,48 @@
     --popover-foreground: 0 0% 93%;
     --sidebar-ring: 38 86% 64%;
   }
+
+  /* ── Neutral scheme: light ── */
+  .scheme-neutral {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 9%;
+    --secondary: 0 0% 96%;
+    --secondary-foreground: 0 0% 9%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 38%;
+    --accent: 0 0% 96%;
+    --accent-foreground: 0 0% 9%;
+    --border: 0 0% 88%;
+    --input: 0 0% 88%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 9%;
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 0 0% 9%;
+    --sidebar-accent: 0 0% 93%;
+    --sidebar-accent-foreground: 0 0% 9%;
+    --sidebar-border: 0 0% 90%;
+  }
+
+  /* ── Neutral scheme: dark ── */
+  .dark.scheme-neutral {
+    --background: 0 0% 8%;
+    --foreground: 0 0% 95%;
+    --secondary: 0 0% 16%;
+    --secondary-foreground: 0 0% 95%;
+    --muted: 0 0% 16%;
+    --muted-foreground: 0 0% 62%;
+    --accent: 0 0% 16%;
+    --accent-foreground: 0 0% 95%;
+    --border: 0 0% 22%;
+    --input: 0 0% 22%;
+    --popover: 0 0% 12%;
+    --popover-foreground: 0 0% 95%;
+    --sidebar-background: 0 0% 11%;
+    --sidebar-foreground: 0 0% 95%;
+    --sidebar-accent: 0 0% 18%;
+    --sidebar-accent-foreground: 0 0% 95%;
+    --sidebar-border: 0 0% 18%;
+  }
 }
 
 @layer base {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1116,3 +1116,27 @@ export async function deleteAgentFile(
     cwd: cwd ?? null,
   });
 }
+
+// ── Ralph Loop ──
+
+export async function startRalphLoop(
+  runId: string,
+  prompt: string,
+  maxIterations: number,
+  completionPromise: string | null,
+): Promise<void> {
+  dbg("api", "startRalphLoop", { runId, maxIterations, completionPromise });
+  return invoke<void>("start_ralph_loop", {
+    runId,
+    prompt,
+    maxIterations,
+    completionPromise,
+  });
+}
+
+export async function cancelRalphLoop(
+  runId: string,
+): Promise<{ iteration: number; immediate: boolean }> {
+  dbg("api", "cancelRalphLoop", { runId });
+  return invoke<{ iteration: number; immediate: boolean }>("cancel_ralph_loop", { runId });
+}

--- a/src/lib/stores/__fixtures__/ralph-loop.json
+++ b/src/lib/stores/__fixtures__/ralph-loop.json
@@ -1,0 +1,68 @@
+[
+  {
+    "type": "ralph_started",
+    "run_id": "run-ralph-1",
+    "prompt": "Build a REST API for todos",
+    "max_iterations": 3,
+    "completion_promise": "DONE",
+    "started_at": "2026-03-18T12:00:00Z"
+  },
+  {
+    "type": "user_message",
+    "run_id": "run-ralph-1",
+    "text": "Build a REST API for todos",
+    "uuid": "uuid-ralph-1"
+  },
+  {
+    "type": "run_state",
+    "run_id": "run-ralph-1",
+    "state": "running"
+  },
+  {
+    "type": "message_complete",
+    "run_id": "run-ralph-1",
+    "message_id": "msg-r1",
+    "text": "I'll start building the API.",
+    "model": "claude-opus-4-6"
+  },
+  {
+    "type": "run_state",
+    "run_id": "run-ralph-1",
+    "state": "idle"
+  },
+  {
+    "type": "ralph_iteration",
+    "run_id": "run-ralph-1",
+    "iteration": 1,
+    "max_iterations": 3
+  },
+  {
+    "type": "user_message",
+    "run_id": "run-ralph-1",
+    "text": "Build a REST API for todos",
+    "uuid": "uuid-ralph-2"
+  },
+  {
+    "type": "run_state",
+    "run_id": "run-ralph-1",
+    "state": "running"
+  },
+  {
+    "type": "message_complete",
+    "run_id": "run-ralph-1",
+    "message_id": "msg-r2",
+    "text": "API is complete. <promise>DONE</promise>",
+    "model": "claude-opus-4-6"
+  },
+  {
+    "type": "run_state",
+    "run_id": "run-ralph-1",
+    "state": "idle"
+  },
+  {
+    "type": "ralph_complete",
+    "run_id": "run-ralph-1",
+    "reason": "completion_promise",
+    "iteration": 2
+  }
+]

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -184,6 +184,18 @@ export class SessionStore {
   /** Pending MCP elicitation prompts keyed by request_id. */
   pendingElicitations = $state<Map<string, ElicitationState>>(new Map());
   persistedFiles = $state<unknown[]>([]);
+
+  /** Ralph loop state — null when no loop has been active. */
+  ralphLoop = $state<{
+    active: boolean;
+    prompt: string;
+    iteration: number;
+    maxIterations: number;
+    completionPromise: string | null;
+    startedAt: string;
+    reason: import("$lib/types").RalphCompleteReason | "interrupted" | null;
+  } | null>(null);
+
   /** CLI slash commands from session_init (session-specific, includes custom commands). */
   sessionCommands = $state<CliCommand[]>([]);
   /** MCP servers from session_init (per-session state). */
@@ -1019,6 +1031,14 @@ export class SessionStore {
         this.run = { ...this.run, ...updates };
       }
     }
+
+    // Ralph: mark interrupted loops after replay
+    // If ralphLoop.active is true but session is not live, the loop was interrupted
+    if (this.ralphLoop?.active && replayOnly) {
+      this.ralphLoop = { ...this.ralphLoop, active: false, reason: "interrupted" };
+      dbg("store", "ralph loop marked interrupted after replay");
+    }
+
     return performance.now() - t0;
   }
 
@@ -1099,6 +1119,7 @@ export class SessionStore {
     this.taskNotifications = new Map();
     this.pendingElicitations = new Map();
     this.persistedFiles = [];
+    this.ralphLoop = null;
     this.sessionCommands = [];
     this.mcpServers = [];
     this.cliVersion = "";
@@ -3334,6 +3355,74 @@ export class SessionStore {
           elicUpdated.delete(ev.request_id);
           this.pendingElicitations = elicUpdated;
         }
+        break;
+      }
+
+      // ── Ralph Loop events ──
+      case "ralph_started": {
+        this.ralphLoop = {
+          active: true,
+          prompt: ev.prompt,
+          iteration: 0,
+          maxIterations: ev.max_iterations,
+          completionPromise: ev.completion_promise,
+          startedAt: ev.started_at,
+          reason: null,
+        };
+        dbg("store", "ralph_started", {
+          maxIterations: ev.max_iterations,
+          promise: ev.completion_promise,
+        });
+        break;
+      }
+      case "ralph_iteration": {
+        if (this.ralphLoop) {
+          this.ralphLoop = {
+            ...this.ralphLoop,
+            iteration: ev.iteration,
+            maxIterations: ev.max_iterations,
+          };
+        }
+        // Insert iteration separator in timeline
+        const iterLabel =
+          ev.max_iterations > 0
+            ? `Ralph iteration ${ev.iteration}/${ev.max_iterations}`
+            : `Ralph iteration ${ev.iteration}`;
+        this._pushTimeline(ctx, {
+          kind: "separator",
+          id: uuid(),
+          content: `🔄 ${iterLabel}`,
+          ts: eventTs(ev),
+        });
+        dbg("store", "ralph_iteration", { iteration: ev.iteration });
+        break;
+      }
+      case "ralph_complete": {
+        // Insert completion separator in timeline
+        const reasonLabels: Record<string, string> = {
+          max_iterations: "max iterations reached",
+          completion_promise: "completion promise matched",
+          cancelled: "cancelled",
+          fail_stopped: "stopped after consecutive failures",
+        };
+        const reasonText = reasonLabels[ev.reason] ?? ev.reason;
+        const completeIcon =
+          ev.reason === "cancelled" || ev.reason === "fail_stopped" ? "❌" : "✅";
+        this._pushTimeline(ctx, {
+          kind: "separator",
+          id: uuid(),
+          content: `${completeIcon} Ralph Loop completed · ${ev.iteration} iterations · ${reasonText}`,
+          ts: eventTs(ev),
+        });
+        if (this.ralphLoop) {
+          this.ralphLoop = {
+            ...this.ralphLoop,
+            active: false,
+            iteration: ev.iteration,
+            reason: ev.reason,
+          };
+        }
+        dbg("store", "ralph_complete", { reason: ev.reason, iteration: ev.iteration });
         break;
       }
 

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -54,6 +54,7 @@ import compactBoundaryEvents from "./__fixtures__/compact-boundary.json";
 import subagentTaskEvents from "./__fixtures__/subagent-task.json";
 import protocolEvents from "./__fixtures__/protocol-events.json";
 import teamSessionEvents from "./__fixtures__/team-session.json";
+import ralphLoopEvents from "./__fixtures__/ralph-loop.json";
 import malformedEvents from "./__fixtures__/malformed-events.json";
 
 // Import store and mocked modules after mocks
@@ -2018,6 +2019,68 @@ describe("SessionStore reducer", () => {
     });
   });
 
+  describe("ralph_loop events", () => {
+    it("ralph_started initializes ralphLoop state", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEvent({
+        type: "ralph_started",
+        run_id: "run-1",
+        prompt: "Build an API",
+        max_iterations: 10,
+        completion_promise: "DONE",
+        started_at: "2026-03-18T12:00:00Z",
+      } as BusEvent);
+      expect(store.ralphLoop).not.toBeNull();
+      expect(store.ralphLoop!.active).toBe(true);
+      expect(store.ralphLoop!.iteration).toBe(0);
+      expect(store.ralphLoop!.maxIterations).toBe(10);
+      expect(store.ralphLoop!.completionPromise).toBe("DONE");
+    });
+
+    it("ralph_iteration updates iteration count", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEvent({
+        type: "ralph_started",
+        run_id: "run-1",
+        prompt: "Build an API",
+        max_iterations: 10,
+        completion_promise: null,
+        started_at: "2026-03-18T12:00:00Z",
+      } as BusEvent);
+      store.applyEvent({
+        type: "ralph_iteration",
+        run_id: "run-1",
+        iteration: 3,
+        max_iterations: 10,
+      } as BusEvent);
+      expect(store.ralphLoop!.iteration).toBe(3);
+    });
+
+    it("ralph_complete marks loop as inactive with reason", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEvent({
+        type: "ralph_started",
+        run_id: "run-1",
+        prompt: "Build an API",
+        max_iterations: 5,
+        completion_promise: null,
+        started_at: "2026-03-18T12:00:00Z",
+      } as BusEvent);
+      store.applyEvent({
+        type: "ralph_complete",
+        run_id: "run-1",
+        reason: "max_iterations",
+        iteration: 5,
+      } as BusEvent);
+      expect(store.ralphLoop!.active).toBe(false);
+      expect(store.ralphLoop!.reason).toBe("max_iterations");
+      expect(store.ralphLoop!.iteration).toBe(5);
+    });
+  });
+
   describe("elicitation_prompt", () => {
     it("adds to pendingElicitations map keyed by request_id", () => {
       store.run = makeRun("run-1");
@@ -3659,6 +3722,7 @@ describe("SessionStore reducer", () => {
       { name: "subagent-task", runId: "run-sub", events: subagentTaskEvents },
       { name: "team-session", runId: "run-1", events: teamSessionEvents },
       { name: "protocol-events", runId: "run-1", events: protocolEvents },
+      { name: "ralph-loop", runId: "run-ralph-1", events: ralphLoopEvents },
     ];
 
     for (const { name, runId, events } of strictFixtures) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -966,7 +966,28 @@ export type BusEvent =
       mode?: string;
       url?: string;
       requested_schema?: ElicitationSchema;
+    }
+  | {
+      type: "ralph_started";
+      run_id: string;
+      prompt: string;
+      max_iterations: number;
+      completion_promise: string | null;
+      started_at: string;
+    }
+  | { type: "ralph_iteration"; run_id: string; iteration: number; max_iterations: number }
+  | {
+      type: "ralph_complete";
+      run_id: string;
+      reason: RalphCompleteReason;
+      iteration: number;
     };
+
+export type RalphCompleteReason =
+  | "max_iterations"
+  | "completion_promise"
+  | "cancelled"
+  | "fail_stopped";
 
 // ── MCP Elicitation types ──
 

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -217,7 +217,59 @@ export const VIRTUAL_COMMANDS: CliCommand[] = [
     _virtual: true,
     _navigate: "/settings?tab=shortcuts",
   },
+  {
+    name: "ralph",
+    description: "Start a Ralph loop (auto-iterate same prompt until done)",
+    aliases: ["ralph-loop"],
+    _virtual: true,
+    _action: "start-ralph-loop",
+    argumentHint: "<prompt> [--max-iterations N] [--completion-promise TEXT]",
+  },
+  {
+    name: "cancel-ralph",
+    description: "Cancel active Ralph loop",
+    aliases: ["stop-ralph"],
+    _virtual: true,
+    _action: "cancel-ralph-loop",
+  },
 ];
+
+/**
+ * Parse /loop command arguments.
+ * Extracts: prompt, --max-iterations N, --completion-promise TEXT
+ */
+export function parseRalphArgs(args: string): {
+  prompt: string;
+  maxIterations: number;
+  completionPromise: string | null;
+} {
+  let maxIterations = 0;
+  let completionPromise: string | null = null;
+  const parts: string[] = [];
+
+  const tokens = args.split(/\s+/);
+  let i = 0;
+  while (i < tokens.length) {
+    if (tokens[i] === "--max-iterations" && i + 1 < tokens.length) {
+      maxIterations = parseInt(tokens[i + 1], 10) || 0;
+      i += 2;
+    } else if (tokens[i] === "--completion-promise" && i + 1 < tokens.length) {
+      // Collect until next flag or end
+      i += 1;
+      const promiseParts: string[] = [];
+      while (i < tokens.length && !tokens[i].startsWith("--")) {
+        promiseParts.push(tokens[i]);
+        i += 1;
+      }
+      completionPromise = promiseParts.join(" ") || null;
+    } else {
+      parts.push(tokens[i]);
+      i += 1;
+    }
+  }
+
+  return { prompt: parts.join(" "), maxIterations, completionPromise };
+}
 
 /**
  * Merge CLI commands with virtual commands and apply fallback descriptions.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -89,6 +89,7 @@
   let sidebarOpen = $state(true);
   let projectCwd = $state("");
   type ThemeMode = "light" | "dark" | "system";
+  type ColorScheme = "warm" | "neutral";
 
   function getInitialTheme(): ThemeMode {
     if (typeof window === "undefined") return "dark";
@@ -97,7 +98,14 @@
     return "dark";
   }
 
+  function getInitialScheme(): ColorScheme {
+    if (typeof window === "undefined") return "warm";
+    const saved = localStorage.getItem("ocv:colorScheme");
+    return saved === "neutral" ? "neutral" : "warm";
+  }
+
   let themeMode = $state<ThemeMode>(getInitialTheme());
+  let colorScheme = $state<ColorScheme>(getInitialScheme());
   let systemDark = $state(
     typeof window !== "undefined"
       ? window.matchMedia("(prefers-color-scheme: dark)").matches
@@ -1012,10 +1020,21 @@
     dbg("layout", "theme cycled", { themeMode, effectiveDark });
   }
 
+  function cycleScheme() {
+    colorScheme = colorScheme === "warm" ? "neutral" : "warm";
+    dbg("layout", "color scheme cycled", { colorScheme });
+  }
+
   // Persist theme + apply class
   $effect(() => {
     localStorage.setItem("ocv:theme", themeMode);
     document.documentElement.classList.toggle("dark", effectiveDark);
+  });
+
+  // Persist color scheme + apply class
+  $effect(() => {
+    localStorage.setItem("ocv:colorScheme", colorScheme);
+    document.documentElement.classList.toggle("scheme-neutral", colorScheme === "neutral");
   });
 
   // Auto-expand folder containing selected run (chats tab only)
@@ -1357,6 +1376,37 @@
                 /><line x1="12" x2="12" y1="17" y2="21" /></svg
               >
             {/if}
+          </button>
+          <button
+            class="flex h-9 w-9 items-center justify-center rounded-md text-sidebar-foreground hover:bg-sidebar-accent/50 transition-colors duration-150"
+            onclick={cycleScheme}
+            title={colorScheme === "warm"
+              ? t("layout_schemeTitle_warm")
+              : t("layout_schemeTitle_neutral")}
+          >
+            <!-- Palette icon -->
+            <svg
+              class="h-[18px] w-[18px]"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><circle cx="13.5" cy="6.5" r=".5" fill="currentColor" /><circle
+                cx="17.5"
+                cy="10.5"
+                r=".5"
+                fill="currentColor"
+              /><circle cx="8.5" cy="7.5" r=".5" fill="currentColor" /><circle
+                cx="6.5"
+                cy="12"
+                r=".5"
+                fill="currentColor"
+              /><path
+                d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 0 1 1.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.554C21.965 6.012 17.461 2 12 2z"
+              /></svg
+            >
           </button>
         </div>
       </div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -75,6 +75,7 @@
     mergeWithVirtual,
     buildHelpText,
     CONTEXT_CLEARED_MARKER,
+    parseRalphArgs,
   } from "$lib/utils/slash-commands";
   import { executeAddDir } from "$lib/utils/add-dir";
   import { buildDoctorReport } from "$lib/utils/doctor";
@@ -2370,6 +2371,58 @@
         window.open(url, "_blank");
       }
       appendCommandOutput("Opening sticker page in browser…");
+    } else if (action === "start-ralph-loop") {
+      const parsed = parseRalphArgs(args);
+      if (!parsed.prompt) {
+        appendCommandOutput(
+          "Usage: /ralph <prompt> [--max-iterations N] [--completion-promise TEXT]",
+        );
+        return;
+      }
+      try {
+        // If no active session, send the prompt as a normal message first to bootstrap
+        if (!store.run?.id || !store.sessionAlive) {
+          await sendMessage(parsed.prompt, []);
+          // Wait briefly for session to be alive (actor created)
+          let retries = 0;
+          while (!store.sessionAlive && retries < 20) {
+            await new Promise((r) => setTimeout(r, 100));
+            retries++;
+          }
+          if (!store.run?.id || !store.sessionAlive) {
+            appendCommandOutput("Failed to start session for ralph loop.");
+            return;
+          }
+        }
+        await api.startRalphLoop(
+          store.run.id,
+          parsed.prompt,
+          parsed.maxIterations,
+          parsed.completionPromise,
+        );
+        appendCommandOutput(
+          `Ralph loop started (max: ${parsed.maxIterations || "unlimited"}, promise: ${parsed.completionPromise ?? "none"})`,
+        );
+      } catch (err) {
+        appendCommandOutput(
+          `Failed to start loop: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    } else if (action === "cancel-ralph-loop") {
+      try {
+        const result = await api.cancelRalphLoop(store.run!.id);
+        if (result.immediate) {
+          appendCommandOutput(`Loop cancelled (iteration ${result.iteration})`);
+        } else {
+          appendCommandOutput(
+            `Loop will stop after current iteration (iteration ${result.iteration})`,
+          );
+        }
+      } catch (err) {
+        appendCommandOutput(
+          `Failed to cancel loop: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 
@@ -4073,6 +4126,49 @@
     {/if}
 
     <!-- Input bar -->
+    <!-- Ralph Loop status bar -->
+    {#if store.ralphLoop?.active}
+      <div class="mx-auto w-full max-w-3xl px-4 pb-2">
+        <div
+          class="flex items-center justify-between rounded-lg border border-blue-500/30 bg-blue-500/10 px-4 py-2 text-sm"
+        >
+          <div class="flex items-center gap-2 text-blue-400">
+            <span class="animate-pulse">🔄</span>
+            <span class="font-medium">Ralph Loop</span>
+            <span class="text-blue-400/70">
+              iteration {store.ralphLoop.iteration}/{store.ralphLoop.maxIterations || "∞"}
+            </span>
+            {#if store.ralphLoop.completionPromise}
+              <span class="text-blue-400/50">
+                · promise: "{store.ralphLoop.completionPromise}"
+              </span>
+            {/if}
+          </div>
+          <button
+            class="rounded px-2 py-0.5 text-xs text-red-400 hover:bg-red-500/20 transition-colors"
+            onclick={async () => {
+              try {
+                const result = await api.cancelRalphLoop(store.run!.id);
+                if (result.immediate) {
+                  appendCommandOutput(`Loop cancelled (iteration ${result.iteration})`);
+                } else {
+                  appendCommandOutput(
+                    `Loop will stop after current iteration (iteration ${result.iteration})`,
+                  );
+                }
+              } catch (err) {
+                appendCommandOutput(
+                  `Failed to cancel: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              }
+            }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    {/if}
+
     {#if !store.ptySpawned || store.sessionAlive}
       <PromptInput
         bind:this={promptRef}


### PR DESCRIPTION
## Summary

- **Ralph Loop**: Implements the Ralph Wiggum technique as a first-class feature — auto-resend the same prompt on turn completion with configurable max iterations and completion promise detection
- **Color Scheme**: Warm/neutral color scheme toggle for chat interface

### Ralph Loop Details

Backend (Rust):
- `RalphLoopState` with explicit state machine (`Running`, `WaitingRetry`, `PausedByUser`, `CancelPending`)
- `try_dispatch` ralph branch: user queue > ralph > internal (user messages always take priority)
- Turn-scoped top-level `MessageComplete` buffer for `<promise>` tag detection
- Backoff on consecutive failures (2×N seconds, max 3 before stopping)
- `CancelPending`: current turn finishes normally, then loop stops
- `emit_ralph_complete` cleans up state, allows re-use in same session
- IPC: `start_ralph_loop`, `cancel_ralph_loop`

Frontend (Svelte):
- `/ralph` and `/cancel-ralph` virtual commands with argument parsing
- Store reducer for `ralph_started` / `ralph_iteration` / `ralph_complete`
- Iteration separators and completion separators in message timeline
- Status bar above input with iteration count, promise info, and cancel button
- Interrupted loop detection on event replay
- Auto-starts session when used in a new chat

## Test plan

- [ ] `/ralph Say hi --max-iterations 2` — runs 2 iterations then stops
- [ ] `/ralph "Count to 3, output <promise>DONE</promise> at 3" --completion-promise DONE --max-iterations 10` — stops on promise match
- [ ] Cancel button during active loop — current turn finishes, then stops
- [ ] User message during loop — loop pauses, resumes after user turn
- [ ] Replay: refresh page after completed loop — separators render correctly
- [ ] Replay: force-close during loop — shows "interrupted", not "active"
- [ ] Same session re-use: `/ralph` again after loop completes
- [ ] `npm test` — 1101 tests pass (including 3 new ralph unit tests + strict fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)