### PR TITLE
feat: multi-fix batch (provider-model, folder-new-chat, search-scroll, cli-sync)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -281,6 +281,7 @@
   "sidebar_tasks": "{count} tasks",
   "sidebar_uncategorized": "Uncategorized",
   "sidebar_conversations": "{count} conversations",
+  "sidebar_newChatInFolder": "New chat",
   "sidebar_showMore": "Show {count} more...",
   "sidebar_deleteConfirm": "Delete conversation",
   "sidebar_deleteDesc": "This conversation will be removed from the sidebar. Data is kept on disk and can be restored later.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -281,6 +281,7 @@
   "sidebar_tasks": "{count} 个任务",
   "sidebar_uncategorized": "未分类",
   "sidebar_conversations": "{count} 个对话",
+  "sidebar_newChatInFolder": "新对话",
   "sidebar_showMore": "显示更多 ({count})...",
   "sidebar_deleteConfirm": "删除对话",
   "sidebar_deleteDesc": "对话将从侧边栏移除，数据保留在磁盘上，后续可恢复。",

--- a/src-tauri/src/agent/adapter.rs
+++ b/src-tauri/src/agent/adapter.rs
@@ -53,6 +53,30 @@ fn map_permission_mode(mode: &str) -> String {
     }
 }
 
+/// When a third-party provider supplies a default model (injected as `ANTHROPIC_MODEL` env var),
+/// clear `adapter.model` if it only came from the `user.default_model` fallback.
+/// This prevents the `--model` CLI flag from overriding the provider's env var.
+/// Explicit choices (UI model_override or agent config) are preserved.
+pub fn clear_model_if_provider_overrides(
+    adapter: &mut AdapterSettings,
+    model_override: &Option<String>,
+    agent_model: &Option<String>,
+    provider_default_model: &Option<String>,
+) {
+    if provider_default_model.is_none() {
+        return;
+    }
+    let has_explicit_ui = model_override.as_ref().is_some_and(|m| !m.is_empty());
+    let has_explicit_agent = agent_model.as_ref().is_some_and(|m| !m.is_empty());
+    if !has_explicit_ui && !has_explicit_agent {
+        log::debug!(
+            "[adapter] provider has default_model, clearing --model flag (was {:?}) to let ANTHROPIC_MODEL env var take effect",
+            adapter.model
+        );
+        adapter.model = None;
+    }
+}
+
 /// Build a unified `AdapterSettings` from agent + user settings.
 /// Agent-level settings take priority over user-level.
 /// `model_override` (from UI per-message) takes highest priority.

--- a/src-tauri/src/commands/runs.rs
+++ b/src-tauri/src/commands/runs.rs
@@ -230,6 +230,7 @@ pub async fn search_prompts(
                     matched_text: entry.text,
                     matched_seq: entry.seq,
                     matched_ts: entry.ts,
+                    matched_event_id: entry.event_id,
                     is_favorite: fav_set.contains(&(entry.run_id, entry.seq)),
                 })
             })

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -459,7 +459,7 @@ pub(crate) async fn start_session_impl(
     // 2. Read settings and build unified adapter settings
     let agent_settings = storage::settings::get_agent_settings(&meta.agent);
     let user_settings = storage::settings::get_user_settings();
-    let adapter_settings =
+    let mut adapter_settings =
         adapter::build_adapter_settings(&agent_settings, &user_settings, meta.model.clone());
 
     // 2b. Resolve remote host from RunMeta (audit #2: single truth source)
@@ -472,6 +472,12 @@ pub(crate) async fn start_session_impl(
         platform_id.as_deref().or(meta.platform_id.as_deref())
     };
     let resolved = resolve_auth_env_for_platform(&remote, &user_settings, effective_pid);
+    adapter::clear_model_if_provider_overrides(
+        &mut adapter_settings,
+        &meta.model,
+        &agent_settings.model,
+        &resolved.default_model,
+    );
     let resolved = augment_with_shell_auth(
         resolved,
         &user_settings.auth_mode,
@@ -901,7 +907,7 @@ pub(crate) async fn fork_session_impl(
     // 6. Build adapter settings + resolve remote (audit #3)
     let agent_settings = storage::settings::get_agent_settings(&source.agent);
     let user_settings = storage::settings::get_user_settings();
-    let adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
+    let mut adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
     let remote = resolve_remote_host(&source)?;
     // CLI Auth mode: ignore platform_id — CLI manages its own connection
     let effective_pid = if user_settings.auth_mode == "cli" {
@@ -910,6 +916,12 @@ pub(crate) async fn fork_session_impl(
         source.platform_id.as_deref()
     };
     let resolved = resolve_auth_env_for_platform(&remote, &user_settings, effective_pid);
+    adapter::clear_model_if_provider_overrides(
+        &mut adapter,
+        &None, // fork has no UI model override
+        &agent_settings.model,
+        &resolved.default_model,
+    );
     let resolved = augment_with_shell_auth(
         resolved,
         &user_settings.auth_mode,
@@ -1042,7 +1054,7 @@ pub(crate) async fn approve_session_tool_impl(
 
     let refreshed_agent = storage::settings::get_agent_settings(&meta.agent);
     let user = storage::settings::get_user_settings();
-    let adapter = adapter::build_adapter_settings(&refreshed_agent, &user, None);
+    let mut adapter = adapter::build_adapter_settings(&refreshed_agent, &user, None);
     // CLI Auth mode: ignore platform_id — CLI manages its own connection
     let effective_pid = if user.auth_mode == "cli" {
         None
@@ -1050,6 +1062,12 @@ pub(crate) async fn approve_session_tool_impl(
         meta.platform_id.as_deref()
     };
     let resolved = resolve_auth_env_for_platform(&remote, &user, effective_pid);
+    adapter::clear_model_if_provider_overrides(
+        &mut adapter,
+        &None,
+        &refreshed_agent.model,
+        &resolved.default_model,
+    );
     let resolved = augment_with_shell_auth(resolved, &user.auth_mode, remote.is_some(), &meta.cwd);
 
     // 4. Preflight — before killing old actor so session can recover on failure
@@ -1781,7 +1799,13 @@ pub async fn side_question(
 
     // Add adapter flags (model overrides, etc.)
     let agent_settings = storage::settings::get_agent_settings(&source.agent);
-    let adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
+    let mut adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
+    adapter::clear_model_if_provider_overrides(
+        &mut adapter,
+        &None,
+        &agent_settings.model,
+        &resolved.default_model,
+    );
     let flag_args = adapter::build_settings_args(&adapter, false);
     claude_args.extend(flag_args.iter().cloned());
 

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1630,6 +1630,9 @@ pub struct PromptSearchResult {
     pub matched_text: String,
     pub matched_seq: u64,
     pub matched_ts: String,
+    /// Stable event ID: uuid (user_message) or message_id (message_complete).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_event_id: Option<String>,
     pub is_favorite: bool,
 }
 

--- a/src-tauri/src/storage/prompt_index.rs
+++ b/src-tauri/src/storage/prompt_index.rs
@@ -23,6 +23,9 @@ pub struct PromptEntry {
     pub seq: u64,
     pub ts: String,
     pub text: String,
+    /// Stable event ID: uuid (user_message) or message_id (message_complete).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -129,6 +132,15 @@ fn scan_events_file(run_id: &str, events_path: &Path) -> Vec<PromptEntry> {
             if let Some(inner) = event.get("event") {
                 let inner_type = inner.get("type").and_then(|v| v.as_str()).unwrap_or("");
                 if inner_type == "user_message" || inner_type == "message_complete" {
+                    // Skip sub-messages (subagent output) — no top-level anchor
+                    if inner_type == "message_complete"
+                        && inner
+                            .get("parent_tool_use_id")
+                            .and_then(|v| v.as_str())
+                            .is_some()
+                    {
+                        continue;
+                    }
                     if let Some(text) = inner.get("text").and_then(|t| t.as_str()) {
                         if text.is_empty() {
                             continue;
@@ -144,11 +156,23 @@ fn scan_events_file(run_id: &str, events_path: &Path) -> Vec<PromptEntry> {
                         } else {
                             text.to_string()
                         };
+                        // Extract stable event ID
+                        let event_id = match inner_type {
+                            "user_message" => {
+                                inner.get("uuid").and_then(|v| v.as_str()).map(String::from)
+                            }
+                            "message_complete" => inner
+                                .get("message_id")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                            _ => None,
+                        };
                         entries.push(PromptEntry {
                             run_id: run_id.to_string(),
                             seq,
                             ts,
                             text: truncated,
+                            event_id,
                         });
                     }
                 }
@@ -180,6 +204,7 @@ fn scan_events_file(run_id: &str, events_path: &Path) -> Vec<PromptEntry> {
                     seq,
                     ts,
                     text: truncated,
+                    event_id: None, // legacy format has no stable ID
                 });
             }
         }
@@ -320,7 +345,7 @@ pub fn build_or_update_index() -> Result<Vec<PromptEntry>, String> {
 /// Current manifest version.  Bump this when the scanning logic changes
 /// so that existing on-disk manifests are treated as stale and all runs
 /// are re-scanned.
-const MANIFEST_VERSION: u32 = 2;
+const MANIFEST_VERSION: u32 = 3;
 
 fn load_manifest() -> Manifest {
     let path = manifest_path();

--- a/src/lib/components/ProjectFolderItem.svelte
+++ b/src/lib/components/ProjectFolderItem.svelte
@@ -22,6 +22,7 @@
     onSelectConversation: (runId: string) => void;
     onResume: (runId: string, mode: "resume") => void;
     onDelete?: (conversation: ConversationGroup) => void;
+    onNewChat?: () => void;
   };
 
   type CustomProps = BaseProps & {
@@ -44,6 +45,7 @@
     onSelectConversation,
     onResume,
     onDelete,
+    onNewChat,
   }: ChatProps | CustomProps = $props();
 
   let visibleCount = $state(PAGE_SIZE);
@@ -207,6 +209,26 @@
       {#if children}
         {@render children()}
       {:else}
+        {#if onNewChat}
+          <button
+            class="flex w-full items-center gap-1.5 px-3 py-1 text-xs text-muted-foreground hover:text-sidebar-foreground hover:bg-sidebar-accent/50 rounded-md transition-colors"
+            onclick={(e) => {
+              e.stopPropagation();
+              onNewChat?.();
+            }}
+          >
+            <svg
+              class="h-3 w-3 shrink-0"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"><path d="M12 5v14" /><path d="M5 12h14" /></svg
+            >
+            <span>{t("sidebar_newChatInFolder")}</span>
+          </button>
+        {/if}
         {#each visibleConversations as conv (conv.groupKey)}
           <ConversationItem
             conversation={conv}

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -67,6 +67,19 @@ function eventTs(ev: BusEvent): string {
   return (r.ts as string) ?? (r.timestamp as string) ?? new Date().toISOString();
 }
 
+/** Backfill anchorId for old snapshots/entries that predate the anchor system. Recursive for subTimelines. */
+function backfillAnchorId(entry: TimelineEntry): TimelineEntry {
+  const e = entry as Record<string, unknown>;
+  if (e.anchorId) return entry; // already has anchorId
+  const anchor = (e.cliUuid as string) || (e.id as string);
+  const patched = { ...entry, anchorId: anchor } as TimelineEntry;
+  if (patched.kind === "tool" && patched.subTimeline) {
+    (patched as { subTimeline: TimelineEntry[] }).subTimeline =
+      patched.subTimeline.map(backfillAnchorId);
+  }
+  return patched;
+}
+
 /** Parse event timestamp to epoch milliseconds (falls back to Date.now()). */
 function eventTsMs(ev: BusEvent): number {
   const iso = eventTs(ev);
@@ -807,10 +820,17 @@ export class SessionStore {
       // Create new synthetic entry
       const entry: TimelineEntry =
         field === "content"
-          ? { kind: "assistant", id: syntheticId, content: text, ts: new Date().toISOString() }
+          ? {
+              kind: "assistant",
+              id: syntheticId,
+              anchorId: syntheticId,
+              content: text,
+              ts: new Date().toISOString(),
+            }
           : {
               kind: "assistant",
               id: syntheticId,
+              anchorId: syntheticId,
               content: "",
               thinkingText: text,
               ts: new Date().toISOString(),
@@ -1257,7 +1277,8 @@ export class SessionStore {
       }
 
       // A group
-      this.timeline = obj.timeline as TimelineEntry[];
+      // Backfill anchorId for old snapshots that predate the anchor system
+      this.timeline = (obj.timeline as TimelineEntry[]).map(backfillAnchorId);
       this.tools = (obj.tools ?? []) as HookEvent[];
       this.hookEvents = (obj.hookEvents ?? []) as typeof this.hookEvents;
       this.streamingText = (obj.streamingText as string) ?? "";
@@ -1573,9 +1594,11 @@ export class SessionStore {
         // api.startSession(), but the middleware subscription isn't set up
         // until after goto() triggers the URL $effect.  Content-based dedup
         // in _reduce(user_message) prevents double display.
+        const optId1 = uuid();
         this._pushTimeline(null, {
           kind: "user",
-          id: uuid(),
+          id: optId1,
+          anchorId: optId1,
           content: prompt,
           ts: new Date().toISOString(),
           ...(attachments.length > 0 ? { attachments: timelineAttachments(attachments) } : {}),
@@ -1640,9 +1663,11 @@ export class SessionStore {
         // Optimistic user message — matches the pattern in startSession().
         // Content-based dedup in _reduce(user_message) prevents double display
         // when the backend's UserMessage bus event arrives.
+        const optId2 = uuid();
         this._pushTimeline(null, {
           kind: "user",
-          id: uuid(),
+          id: optId2,
+          anchorId: optId2,
           content: text,
           ts: new Date().toISOString(),
           ...(attachments.length > 0 ? { attachments: timelineAttachments(attachments) } : {}),
@@ -1875,9 +1900,11 @@ export class SessionStore {
       // Must be before startSession IPC so the user sees their message immediately.
       // Backend's UserMessage bus event will be deduped by content match in _reduce.
       if (initialMessage) {
+        const optId3 = uuid();
         this._pushTimeline(null, {
           kind: "user" as const,
-          id: uuid(),
+          id: optId3,
+          anchorId: optId3,
           content: initialMessage,
           ts: new Date().toISOString(),
           ...(attachments && attachments.length > 0
@@ -2475,6 +2502,7 @@ export class SessionStore {
           const entry: TimelineEntry = {
             kind: "assistant",
             id: ev.message_id,
+            anchorId: ev.message_id,
             content: ev.text,
             ts: eventTs(ev),
             ...(ev.model ? { model: ev.model } : {}),
@@ -2514,6 +2542,7 @@ export class SessionStore {
         const entry: TimelineEntry = {
           kind: "assistant",
           id: ev.message_id,
+          anchorId: ev.message_id,
           content: ev.text,
           ts: eventTs(ev),
           ...(ev.model ? { model: ev.model } : {}),
@@ -2545,10 +2574,10 @@ export class SessionStore {
             (e) => e.kind === "user" && e.content === ev.text && !e.cliUuid,
           );
           if (match && match.kind === "user") {
-            // Merge cliUuid from the confirmed backend event into the optimistic entry
+            // Merge cliUuid + anchorId from the confirmed backend event into the optimistic entry
             if (ev.uuid) {
               const idx = tl.indexOf(match);
-              const updated = { ...match, cliUuid: ev.uuid };
+              const updated = { ...match, cliUuid: ev.uuid, anchorId: ev.uuid };
               if (ctx) ctx.tl[idx] = updated;
               else {
                 const u = [...this.timeline];
@@ -2559,9 +2588,11 @@ export class SessionStore {
             break;
           }
         }
+        const newId = uuid();
         const entry: TimelineEntry = {
           kind: "user",
-          id: uuid(),
+          id: newId,
+          anchorId: ev.uuid || newId,
           content: ev.text,
           ts: eventTs(ev),
           ...(ev.uuid ? { cliUuid: ev.uuid } : {}),
@@ -2621,6 +2652,7 @@ export class SessionStore {
             const subEntry: TimelineEntry = {
               kind: "tool",
               id: ev.tool_use_id,
+              anchorId: ev.tool_use_id,
               tool: {
                 tool_use_id: ev.tool_use_id,
                 tool_name: ev.tool_name,
@@ -2641,6 +2673,7 @@ export class SessionStore {
         const tlEntry: TimelineEntry = {
           kind: "tool",
           id: ev.tool_use_id,
+          anchorId: ev.tool_use_id,
           tool: {
             tool_use_id: ev.tool_use_id,
             tool_name: ev.tool_name,
@@ -3066,6 +3099,7 @@ export class SessionStore {
             const tlEntry: TimelineEntry = {
               kind: "tool",
               id: ev.tool_use_id,
+              anchorId: ev.tool_use_id,
               tool: {
                 tool_use_id: ev.tool_use_id,
                 tool_name: ev.tool_name,
@@ -3097,9 +3131,11 @@ export class SessionStore {
           this.compactCount++;
           // Full compaction: insert timeline separator
           const tokensInfo = ev.pre_tokens ? ` (${Math.round(ev.pre_tokens / 1000)}k tokens)` : "";
+          const sepId = uuid();
           const entry: TimelineEntry = {
             kind: "separator",
-            id: uuid(),
+            id: sepId,
+            anchorId: sepId,
             content: `Context compacted${tokensInfo}`,
             ts: eventTs(ev),
           };
@@ -3128,9 +3164,11 @@ export class SessionStore {
           contentLen: ev.content.length,
           hasBatchCtx: !!ctx,
         });
+        const cmdId = uuid();
         const cmdEntry: TimelineEntry = {
           kind: "command_output",
-          id: uuid(),
+          id: cmdId,
+          anchorId: cmdId,
           content: ev.content,
           ts: eventTs(ev),
         };
@@ -3161,9 +3199,11 @@ export class SessionStore {
       case "raw": {
         const rawText = typeof ev.data === "string" ? ev.data : JSON.stringify(ev.data);
         if (rawText && (ev.source === "claude_stdout_text" || ev.source === "claude_stderr")) {
+          const rawId = uuid();
           const entry: TimelineEntry = {
             kind: "assistant",
-            id: uuid(),
+            id: rawId,
+            anchorId: rawId,
             content: `\`[${ev.source}]\` ${rawText}`,
             ts: new Date().toISOString(),
           };
@@ -3388,9 +3428,11 @@ export class SessionStore {
           ev.max_iterations > 0
             ? `Ralph iteration ${ev.iteration}/${ev.max_iterations}`
             : `Ralph iteration ${ev.iteration}`;
+        const iterSepId = uuid();
         this._pushTimeline(ctx, {
           kind: "separator",
-          id: uuid(),
+          id: iterSepId,
+          anchorId: iterSepId,
           content: `🔄 ${iterLabel}`,
           ts: eventTs(ev),
         });
@@ -3408,9 +3450,11 @@ export class SessionStore {
         const reasonText = reasonLabels[ev.reason] ?? ev.reason;
         const completeIcon =
           ev.reason === "cancelled" || ev.reason === "fail_stopped" ? "❌" : "✅";
+        const completeSepId = uuid();
         this._pushTimeline(ctx, {
           kind: "separator",
-          id: uuid(),
+          id: completeSepId,
+          anchorId: completeSepId,
           content: `${completeIcon} Ralph Loop completed · ${ev.iteration} iterations · ${reasonText}`,
           ts: eventTs(ev),
         });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1037,6 +1037,8 @@ export type TimelineEntry =
   | {
       kind: "user";
       id: string;
+      /** Stable anchor for DOM id and search scroll-to. */
+      anchorId: string;
       content: string;
       ts: string;
       attachments?: Attachment[];
@@ -1045,14 +1047,22 @@ export type TimelineEntry =
   | {
       kind: "assistant";
       id: string;
+      anchorId: string;
       content: string;
       ts: string;
       thinkingText?: string;
       model?: string;
     }
-  | { kind: "tool"; id: string; tool: BusToolItem; ts: string; subTimeline?: TimelineEntry[] }
-  | { kind: "separator"; id: string; content: string; ts: string }
-  | { kind: "command_output"; id: string; content: string; ts: string };
+  | {
+      kind: "tool";
+      id: string;
+      anchorId: string;
+      tool: BusToolItem;
+      ts: string;
+      subTimeline?: TimelineEntry[];
+    }
+  | { kind: "separator"; id: string; anchorId: string; content: string; ts: string }
+  | { kind: "command_output"; id: string; anchorId: string; content: string; ts: string };
 
 // ── App Updates ──
 
@@ -1093,7 +1103,8 @@ export type HookEventType =
   | "InstructionsLoaded"
   | "Elicitation"
   | "ElicitationResult"
-  | "PostCompact";
+  | "PostCompact"
+  | "StopFailure";
 
 export interface HookHandler {
   type: "command" | "prompt";
@@ -1180,6 +1191,8 @@ export interface PromptSearchResult {
   matchedText: string;
   matchedSeq: number;
   matchedTs: string;
+  /** Stable event ID for scroll-to anchor (uuid or message_id). */
+  matchedEventId?: string;
   isFavorite: boolean;
 }
 

--- a/src/lib/utils/agent-editor.ts
+++ b/src/lib/utils/agent-editor.ts
@@ -10,6 +10,7 @@ export interface AgentFormData {
   disallowedTools: string[];
   permissionMode: string; // "default" | "acceptEdits" | "dontAsk" | "bypassPermissions" | "plan"
   maxTurns: number | null;
+  effort: string; // "" | "low" | "medium" | "high"
   memory: string; // "" | memory file path/glob
   background: boolean;
   isolation: string; // "" | "worktree"
@@ -65,6 +66,9 @@ export function serializeAgentFile(data: AgentFormData): string {
   if (data.maxTurns != null && data.maxTurns > 0) {
     lines.push(`maxTurns: ${data.maxTurns}`);
   }
+  if (data.effort) {
+    lines.push(`effort: ${data.effort}`);
+  }
   if (data.memory) {
     lines.push(`memory: ${yamlString(data.memory)}`);
   }
@@ -111,6 +115,7 @@ export function parseAgentFile(content: string): AgentFormData {
     disallowedTools: [],
     permissionMode: "default",
     maxTurns: null,
+    effort: "",
     memory: "",
     background: false,
     isolation: "",
@@ -142,6 +147,7 @@ export function parseAgentFile(content: string): AgentFormData {
     disallowedTools: fm.disallowedTools ?? [],
     permissionMode: fm.permissionMode ?? "default",
     maxTurns: fm.maxTurns ?? null,
+    effort: fm.effort ?? "",
     memory: fm.memory ?? "",
     background: fm.background ?? false,
     isolation: fm.isolation ?? "",
@@ -157,6 +163,7 @@ interface SimpleFm {
   disallowedTools?: string[];
   permissionMode?: string;
   maxTurns?: number | null;
+  effort?: string;
   memory?: string;
   background?: boolean;
   isolation?: string;
@@ -205,6 +212,9 @@ function parseSimpleYaml(yaml: string): SimpleFm {
           break;
         case "maxTurns":
           result.maxTurns = parseInt(value, 10) || null;
+          break;
+        case "effort":
+          result.effort = value;
           break;
         case "memory":
           result.memory = value;
@@ -303,6 +313,13 @@ export function validateAgentForm(data: AgentFormData): ValidationError[] {
     }
   }
 
+  if (data.effort && !["low", "medium", "high"].includes(data.effort)) {
+    errors.push({
+      field: "effort",
+      message: "Must be low, medium, or high",
+    });
+  }
+
   for (const tool of data.tools) {
     if (!tool.trim()) {
       errors.push({ field: "tools", message: "Tool name cannot be empty" });
@@ -388,6 +405,7 @@ export function defaultFormData(): AgentFormData {
     disallowedTools: [],
     permissionMode: "default",
     maxTurns: null,
+    effort: "",
     memory: "",
     background: false,
     isolation: "",

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -23,6 +23,24 @@ export function truncate(text: string, maxLen: number): string {
   return text.slice(0, maxLen) + "\u2026";
 }
 
+/** Return a snippet of `text` centered on the first occurrence of `query`. */
+export function snippetAround(text: string, query: string, maxLen: number): string {
+  // Collapse whitespace (newlines, tabs) so the snippet is single-line
+  const flat = text.replace(/\s+/g, " ");
+  if (flat.length <= maxLen) return flat;
+  const lower = flat.toLowerCase();
+  const idx = lower.indexOf(query.toLowerCase());
+  if (idx < 0) return flat.slice(0, maxLen) + "\u2026";
+  const half = Math.floor((maxLen - query.length) / 2);
+  let start = Math.max(0, idx - half);
+  const end = Math.min(flat.length, start + maxLen);
+  if (end - start < maxLen) start = Math.max(0, end - maxLen);
+  let result = flat.slice(start, end);
+  if (start > 0) result = "\u2026" + result;
+  if (end < flat.length) result += "\u2026";
+  return result;
+}
+
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
     PromptSearchResult,
     MemoryFileCandidate,
   } from "$lib/types";
-  import { cwdDisplayLabel, truncate, relativeTime } from "$lib/utils/format";
+  import { cwdDisplayLabel, truncate, snippetAround, relativeTime } from "$lib/utils/format";
   import { filterVisibleCandidates } from "$lib/utils/memory-helpers";
   import {
     buildProjectFolders,
@@ -962,6 +962,11 @@
 
   function newChat() {
     goto("/chat");
+  }
+
+  function newChatInFolder(cwd: string) {
+    projectCwd = cwd;
+    goto(`/chat?folder=${encodeURIComponent(cwd)}`);
   }
 
   function toggleProject(folderKey: string) {
@@ -2033,13 +2038,16 @@
                         runSearchQuery = "";
                         searchResults = [];
                         goto(
-                          `/chat?run=${result.runId}&scrollTo=${encodeURIComponent(result.matchedTs)}`,
+                          `/chat?run=${result.runId}&scrollTo=${encodeURIComponent(result.matchedEventId || result.matchedTs)}`,
                         );
                       }}
                     >
-                      <p class="text-[12px] min-w-0 truncate">
+                      <p class="text-[12px] min-w-0 line-clamp-2 break-all">
                         <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                        {@html highlightMatch(truncate(result.matchedText, 60), runSearchQuery)}
+                        {@html highlightMatch(
+                          snippetAround(result.matchedText, runSearchQuery, 80),
+                          runSearchQuery,
+                        )}
                       </p>
                       <div class="flex items-center gap-1 text-xs text-muted-foreground min-w-0">
                         <span class="flex-1 min-w-0 truncate"
@@ -2069,6 +2077,9 @@
                     onRemove={folder.isUncategorized
                       ? undefined
                       : () => requestRemoveProject(folder.cwd)}
+                    onNewChat={folder.isUncategorized
+                      ? undefined
+                      : () => newChatInFolder(folder.cwd)}
                   />
                 {/each}
                 <!-- Open folder... -->

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -80,7 +80,7 @@
   import { executeAddDir } from "$lib/utils/add-dir";
   import { buildDoctorReport } from "$lib/utils/doctor";
   import type { RewindCandidate, RewindMarker } from "$lib/utils/rewind";
-  import { truncate } from "$lib/utils/format";
+  import { truncate, cwdDisplayLabel } from "$lib/utils/format";
   import { uuid } from "$lib/utils/uuid";
   import RewindModal from "$lib/components/RewindModal.svelte";
 
@@ -102,8 +102,12 @@
   let xtermReady = $state(false);
   let pendingMessage = $state<{ text: string; attachments: Attachment[] } | null>(null);
   let sidebarCollapsed = $state(false);
+  /** Reactive cwd override for new-chat-in-folder (cleared when a run is loaded) */
+  let folderCwdOverride = $state("");
   let chatAreaRef: HTMLDivElement | undefined = $state();
   let isChatAutoScroll = $state(true);
+  /** Non-reactive flag: suppresses auto-scroll reset during search scroll-to navigation. */
+  let _scrollToInFlight = false;
   let showChatScrollHint = $state(false);
   let agentSettings = $state<AgentSettings | null>(null);
   let resuming = $state(false);
@@ -592,20 +596,28 @@
     cancelProgressive();
     const gen = ++progressiveGen;
 
+    // Capture scrollTo BEFORE loadRun — URL may change during async load
+    const scrollTo = $page.url.searchParams.get("scrollTo");
+
+    // Flag suppresses auto-scroll reset during loadRun (non-reactive, won't trigger effects)
+    if (scrollTo) _scrollToInFlight = true;
+
     await store.loadRun(id, xtermRef);
+    if (id) folderCwdOverride = ""; // clear folder override when a real run loads
 
     if (gen !== progressiveGen) return;
     renderLimit = Infinity;
     dbg("chat", "loadRun complete", { timeline: filteredTimeline.length, gen });
 
-    // If ?scrollTo= is present, scroll to the matched message; otherwise scroll to bottom
-    const scrollTo = $page.url.searchParams.get("scrollTo");
     if (scrollTo) {
+      await tick();
+      scrollToMessage(scrollTo);
+      _scrollToInFlight = false;
+      // Clean scrollTo from URL — safe because $effect depends on
+      // runId and hasResumeParam (primitives), not the full $page.url.
       const clean = new URL($page.url);
       clean.searchParams.delete("scrollTo");
       replaceState(clean, {});
-      await tick();
-      scrollToMessage(scrollTo);
     } else {
       // Scroll to bottom after DOM update — ensures content-visibility triggers re-layout
       await tick();
@@ -617,7 +629,9 @@
 
   let isExpandingTimeline = $derived(false);
 
-  let welcomeVisible = $derived(store.timeline.length === 0 && !store.streamingText && !store.run);
+  let welcomeVisible = $derived(
+    store.timeline.length === 0 && !store.streamingText && !store.run && store.phase !== "loading",
+  );
 
   let inputBlockedByPermission = $derived(store.hasPendingPermission || store.hasElicitation);
   let pendingToolPermissions = $derived(store.pendingToolPermissions);
@@ -819,8 +833,26 @@
     return `${m}:${s.toString().padStart(2, "0")}`;
   }
 
-  // ── URL-derived ──
+  // ── URL-derived (primitive values only — avoids $effect re-trigger on unrelated URL changes) ──
   let runId = $derived($page.url.searchParams.get("run") ?? "");
+  let hasResumeParam = $derived($page.url.searchParams.has("resume"));
+  let folderParam = $derived($page.url.searchParams.get("folder"));
+
+  // Consume ?folder= param: switch to new chat in that folder, then clean URL
+  $effect(() => {
+    const folder = folderParam;
+    if (!folder) return;
+    untrack(() => {
+      dbg("chat", "new chat in folder", { folder });
+      localStorage.setItem("ocv:project-cwd", folder);
+      folderCwdOverride = folder;
+      store.loadRun("", xtermRef);
+      const clean = new URL($page.url);
+      clean.searchParams.delete("folder");
+      replaceState(clean, {});
+      requestAnimationFrame(() => promptRef?.focus());
+    });
+  });
 
   // ── Computed (thin wrappers for template convenience) ──
   let sending = $derived(store.phase === "spawning");
@@ -1101,7 +1133,7 @@
   $effect(() => {
     if (!middlewareReady) return;
     const id = runId;
-    const hasResume = $page.url.searchParams.has("resume");
+    const hasResume = hasResumeParam;
     untrack(() => {
       middleware.subscribeCurrent(id, store);
 
@@ -1129,12 +1161,36 @@
           const clean = new URL($page.url);
           clean.searchParams.delete("scrollTo");
           replaceState(clean, {});
-          scrollToMessage(scrollTo);
+          tick().then(() => scrollToMessage(scrollTo));
         }
         return;
       }
 
       loadRunProgressive(id, xtermRef);
+    });
+  });
+
+  // Handle scrollTo for already-loaded runs (e.g., clicking a second search result
+  // in the same run). The runId effect above won't re-fire when only scrollTo changes.
+  $effect(() => {
+    if (!middlewareReady) return;
+    const scrollTo = $page.url.searchParams.get("scrollTo");
+    if (!scrollTo) return;
+    untrack(() => {
+      // loadRunProgressive handles scrollTo during run loading — don't double-scroll
+      if (_scrollToInFlight) return;
+      if (store.phase === "loading") return;
+      if (store.run?.id !== runId) return;
+
+      dbg("effect", "same-run scrollTo", { scrollTo, runId });
+      _scrollToInFlight = true;
+      const clean = new URL($page.url);
+      clean.searchParams.delete("scrollTo");
+      replaceState(clean, {});
+      tick().then(() => {
+        scrollToMessage(scrollTo);
+        _scrollToInFlight = false;
+      });
     });
   });
 
@@ -1393,7 +1449,10 @@
   // Reset scroll state on run change
   $effect(() => {
     void store.run?.id;
-    isChatAutoScroll = true;
+    // _scrollToInFlight is non-reactive (plain let): reading it doesn't create a dependency.
+    // When a search scroll-to navigation is in progress, suppress auto-scroll so
+    // scrollToMessage isn't overridden by the auto-scroll $effect.
+    isChatAutoScroll = !_scrollToInFlight;
     showChatScrollHint = false;
     prevTl = 0;
     prevSt = 0;
@@ -1935,11 +1994,13 @@
   }
 
   function appendCommandOutput(text: string) {
+    const cmdId = uuid();
     store.timeline = [
       ...store.timeline,
       {
         kind: "command_output",
-        id: uuid(),
+        id: cmdId,
+        anchorId: cmdId,
         content: text,
         ts: new Date().toISOString(),
       },
@@ -2746,13 +2807,41 @@
       toolFilter = null;
       await tick();
     }
-    const el = document.getElementById("msg-" + ts);
+    // Primary: lookup by anchorId (stable event ID)
+    let el = document.getElementById("msg-" + ts);
+    // Fallback: search timeline by multiple fields (ts, anchorId, cliUuid, id)
+    if (!el) {
+      const match = store.timeline.find(
+        (e) =>
+          e.ts === ts ||
+          e.anchorId === ts ||
+          (e.kind === "user" && e.cliUuid === ts) ||
+          e.id === ts,
+      );
+      if (match) el = document.getElementById("msg-" + match.anchorId);
+    }
     if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      // Temporarily disable content-visibility on ALL entries so the browser
+      // knows real heights and scrollIntoView lands at the correct offset.
+      const container = chatAreaRef;
+      const cvEls = container
+        ? Array.from(container.querySelectorAll<HTMLElement>(".cv-auto"))
+        : [];
+      for (const c of cvEls) c.style.contentVisibility = "visible";
+
+      el.getBoundingClientRect(); // force reflow
+      el.scrollIntoView({ behavior: "instant", block: "center" });
       el.classList.add("ring-2", "ring-primary/50");
-      setTimeout(() => el.classList.remove("ring-2", "ring-primary/50"), 2000);
+
+      // Restore content-visibility after scroll settles
+      requestAnimationFrame(() => {
+        for (const c of cvEls) c.style.contentVisibility = "";
+      });
+      setTimeout(() => {
+        el!.classList.remove("ring-2", "ring-primary/50");
+      }, 2000);
     } else {
-      dbg("chat", "scrollToMessage: element not found", { ts });
+      dbg("chat", "scrollToMessage: element not found", { anchor: ts });
     }
   }
 
@@ -3310,7 +3399,26 @@
               <div class="flex flex-col items-center max-w-sm">
                 <div class="text-center animate-slide-up">
                   <img src="/logo.png?v=2" alt="OC" class="mx-auto mb-4 h-12 w-12 rounded-2xl" />
-                  <h2 class="text-lg font-semibold text-primary mb-4">{t("layout_appName")}</h2>
+                  <h2 class="text-lg font-semibold text-primary mb-1">{t("layout_appName")}</h2>
+                  {#if !store.run}
+                    {@const welcomeCwd =
+                      store.effectiveCwd ||
+                      folderCwdOverride ||
+                      localStorage.getItem("ocv:project-cwd") ||
+                      ""}
+                    {#if welcomeCwd}
+                      <p
+                        class="mb-3 text-xs text-muted-foreground/60 truncate max-w-[280px]"
+                        title={welcomeCwd}
+                      >
+                        {cwdDisplayLabel(welcomeCwd)}
+                      </p>
+                    {:else}
+                      <div class="mb-3"></div>
+                    {/if}
+                  {:else}
+                    <div class="mb-3"></div>
+                  {/if}
                   {#if lastContinuableRun}
                     <button
                       class="w-full flex items-center justify-center gap-2 rounded-lg border border-border bg-muted/50 px-4 py-3 text-sm text-foreground hover:bg-accent hover:border-ring/30 transition-all duration-150"
@@ -3357,6 +3465,13 @@
                   {@render heroMetaItems()}
                 </div>
               </div>
+            </div>
+          {:else if store.phase === "loading" && store.timeline.length === 0}
+            <!-- Loading state — avoids welcome page flash during loadRun -->
+            <div class="flex h-full items-center justify-center">
+              <div
+                class="h-5 w-5 rounded-full border-2 border-muted-foreground/30 border-t-primary animate-spin"
+              ></div>
             </div>
           {:else}
             <!-- Timeline: chat messages + inline tool cards -->
@@ -3439,7 +3554,7 @@
               {#each visibleTimeline as entry, i (entry.id)}
                 {#if !(burstHiddenIndices.has(i) && !toolBursts.has(i))}
                   <div
-                    id="msg-{entry.ts}"
+                    id="msg-{entry.anchorId}"
                     class:cv-auto={!IS_WEBKIT && entry.kind !== "tool"}
                     class="group/msg"
                     class:opacity-40={lastClearSepId !== null &&
@@ -4187,7 +4302,10 @@
         models={effectiveModels}
         currentModel={store.model}
         permissionMode={store.permissionMode}
-        cwd={store.effectiveCwd || localStorage.getItem("ocv:project-cwd") || ""}
+        cwd={store.effectiveCwd ||
+          folderCwdOverride ||
+          localStorage.getItem("ocv:project-cwd") ||
+          ""}
         authMode={store.authMode}
         platformId={store.platformId ?? "anthropic"}
         platformCredentials={settings?.platform_credentials ?? []}


### PR DESCRIPTION
## Summary

- **fix: provider model override** — When a third-party provider (e.g. MiniMax) supplies a default model via `ANTHROPIC_MODEL` env var, the adapter's `user.default_model` fallback was generating a `--model` CLI flag that took higher priority. Added `clear_model_if_provider_overrides()` to suppress the flag when no explicit model was chosen.
- **feat: per-folder "New chat"** — Each expanded project folder now shows a "+ New chat" entry. Navigates via `?folder=` param so the chat page resets with the correct cwd. Welcome page displays current project path for visual feedback.
- **fix: search scroll-to** — Stable event IDs, keyword snippet visibility, and scroll-to accuracy for search results.
- **chore: CLI upstream sync** — Added `StopFailure` hook event type, `effort` agent frontmatter field.

## Test plan

- [ ] Select a third-party provider (e.g. MiniMax), start a session — verify the provider's model is used (no fallback to Opus)
- [ ] Expand a project folder in sidebar, click "+ New chat" — verify new chat targets that folder (check git branch indicator + welcome page path)
- [ ] Search for a keyword in chat history, click a result — verify it scrolls to the correct message
- [ ] `npm test` — all 1101 tests pass
- [ ] `cargo clippy` — 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)