### PR TITLE
feat: session timeout observability + skill 404 error UX

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -486,6 +486,7 @@
   "plugin_failedDeleteSkill": "Failed to delete skill: {error}",
   "plugin_searchFailed": "Search failed: {error}",
   "plugin_failedLoadDetail": "Failed to load detail: {error}",
+  "plugin_skillUnavailable": "Skill Unavailable",
   "plugin_installedSkill": "Installed {name}",
   "plugin_errorGeneric": "Error: {error}",
   "plugin_uninstallTitle": "Uninstall Plugin",
@@ -1133,6 +1134,7 @@
   "error_category_budget_limit": "Budget Limit",
   "error_category_auth_issue": "Auth Issue",
   "error_category_server_issue": "Server Issue",
+  "error_category_session_timeout": "Session Timeout",
   "error_category_tool_issue": "Tool Issue",
   "error_category_unknown": "Error",
 
@@ -1140,6 +1142,7 @@
   "error_guidance_budget_limit": "Budget limit reached. Adjust max_budget_usd in settings to continue.",
   "error_guidance_auth_issue": "Authentication failed. Check your API key or login status in settings.",
   "error_guidance_server_issue": "Temporary server issue. Wait a moment and retry.",
+  "error_guidance_session_timeout": "The session timed out waiting for a response. This may be caused by a pending permission prompt, slow API, or unresponsive MCP server. Try resuming or starting a new chat.",
   "error_guidance_tool_issue": "A tool encountered an error. Check the tool output for details.",
   "error_guidance_unknown": "An unexpected error occurred. You can retry or dismiss.",
 

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -486,6 +486,7 @@
   "plugin_failedDeleteSkill": "删除技能失败：{error}",
   "plugin_searchFailed": "搜索失败：{error}",
   "plugin_failedLoadDetail": "加载详情失败：{error}",
+  "plugin_skillUnavailable": "技能不可用",
   "plugin_installedSkill": "已安装 {name}",
   "plugin_errorGeneric": "错误：{error}",
   "plugin_uninstallTitle": "卸载插件",
@@ -1133,6 +1134,7 @@
   "error_category_budget_limit": "预算超限",
   "error_category_auth_issue": "认证问题",
   "error_category_server_issue": "服务器问题",
+  "error_category_session_timeout": "会话超时",
   "error_category_tool_issue": "工具问题",
   "error_category_unknown": "错误",
 
@@ -1140,6 +1142,7 @@
   "error_guidance_budget_limit": "已达预算限制。在设置中调整 max_budget_usd 以继续。",
   "error_guidance_auth_issue": "认证失败。请在设置中检查 API 密钥或登录状态。",
   "error_guidance_server_issue": "服务器临时问题。稍等片刻后重试。",
+  "error_guidance_session_timeout": "会话等待响应超时。可能原因：未处理的权限请求、API 响应慢、MCP 服务器无响应。尝试恢复会话或新建对话。",
   "error_guidance_tool_issue": "工具遇到错误。查看工具输出了解详情。",
   "error_guidance_unknown": "发生意外错误。你可以重试或关闭。",
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.36"
+version = "0.1.40"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -84,6 +84,19 @@ pub struct RalphCancelResult {
     pub immediate: bool,
 }
 
+/// Tracks a pending interactive control request (permission, hook, elicitation)
+/// that was forwarded to the frontend and is waiting for user response.
+/// Used for diagnosing hard-timeout causes.
+#[derive(Debug)]
+struct PendingInteractiveRequest {
+    request_id: String,
+    /// "can_use_tool" | "hook_callback" | "elicitation"
+    subtype: String,
+    /// tool_name / hook event / server name
+    detail: String,
+    received_at: Instant,
+}
+
 // ── Public types ──
 
 /// Attachment data for multimodal messages (images, documents).
@@ -215,6 +228,12 @@ struct SessionActor {
     ralph_loop: Option<RalphLoopState>,
     /// Flag set by on_tick_timeout when WaitingRetry expires, consumed by main loop.
     ralph_needs_dispatch: bool,
+
+    // ── Observability: pending interactive request tracking ──
+    /// Tracks the most recent interactive control request awaiting user response.
+    /// Set when emitting PermissionPrompt / HookCallback(PreToolUse) / ElicitationPrompt.
+    /// Cleared when the response is received. Retained during quarantine for diagnostics.
+    pending_interactive_request: Option<PendingInteractiveRequest>,
 }
 
 // ── Spawn entry point ──
@@ -284,6 +303,7 @@ pub fn spawn_actor(
         json_parse_fail_count: 0,
         ralph_loop: None,
         ralph_needs_dispatch: false,
+        pending_interactive_request: None,
     };
 
     let join_handle = tokio::spawn(async move {
@@ -351,16 +371,19 @@ impl SessionActor {
                             let _ = reply.send(r);
                         }
                         Some(ActorCommand::CancelControlRequest { request_id, reply }) => {
+                            self.clear_pending_interactive_request(&request_id);
                             let r = self.handle_cancel_control_request(&request_id).await;
                             let _ = reply.send(r);
                         }
                         Some(ActorCommand::RespondHookCallback { request_id, response, reply }) => {
                             log::debug!("[actor] RespondHookCallback: run_id={}, req_id={}", self.run_id, request_id);
+                            self.clear_pending_interactive_request(&request_id);
                             let result = self.write_control_response(&request_id, response).await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::RespondElicitation { request_id, response, reply }) => {
                             log::debug!("[actor] RespondElicitation: run_id={}, req_id={}", self.run_id, request_id);
+                            self.clear_pending_interactive_request(&request_id);
                             let result = self.write_control_response(&request_id, response).await;
                             let _ = reply.send(result);
                         }
@@ -982,9 +1005,10 @@ impl SessionActor {
                 if Instant::now() >= deadline {
                     // Quarantine secondary timeout → hard-kill
                     log::warn!(
-                        "[turn] quarantine hard-timeout: killing process for run_id={} (from_internal={})",
+                        "[turn] quarantine hard-timeout: run_id={}, from_internal={}, pending_request={:?}",
                         self.run_id,
-                        self.quarantine_from_internal
+                        self.quarantine_from_internal,
+                        self.pending_interactive_request.as_ref().map(|r| (&r.subtype, &r.detail, r.received_at.elapsed().as_secs()))
                     );
                     self.protocol.set_pending_slash_command(None);
                     if let Some(ref mut child) = self.child {
@@ -992,8 +1016,15 @@ impl SessionActor {
                     }
                     let error_msg = if self.quarantine_from_internal {
                         "Auto-context hard timeout — process killed".to_string()
+                    } else if let Some(ref req) = self.pending_interactive_request {
+                        let wait_secs = req.received_at.elapsed().as_secs();
+                        format!(
+                            "Session timeout — waited {}s for {} response ({}). Process killed.",
+                            wait_secs, req.subtype, req.detail
+                        )
                     } else {
-                        "Session hard timeout — process killed".to_string()
+                        "Session timeout — no response from CLI for 10 minutes. Process killed."
+                            .to_string()
                     };
                     self.emit_state("failed", None, Some(error_msg), true);
                     self.fail_all_pending_replies("Session hard timeout");
@@ -1071,9 +1102,10 @@ impl SessionActor {
         // but hard_deadline provides a safety net
         else if now >= turn.hard_deadline {
             log::warn!(
-                "[turn] user hard timeout: entering quarantine for run_id={} (turn_seq={})",
+                "[turn] user hard timeout: entering quarantine for run_id={} (turn_seq={}), pending_request={:?}",
                 self.run_id,
-                turn.turn_seq
+                turn.turn_seq,
+                self.pending_interactive_request.as_ref().map(|r| (&r.subtype, &r.detail, r.received_at.elapsed().as_secs()))
             );
             self.protocol.set_pending_slash_command(None);
             self.active_turn = None;
@@ -1264,7 +1296,23 @@ impl SessionActor {
             self.run_id,
             request_id,
         );
+        self.clear_pending_interactive_request(request_id);
         self.write_control_response(request_id, response).await
+    }
+
+    /// Clear pending interactive request if it matches the given request_id.
+    fn clear_pending_interactive_request(&mut self, request_id: &str) {
+        if let Some(ref req) = self.pending_interactive_request {
+            if req.request_id == request_id {
+                log::debug!(
+                    "[actor] clearing pending_interactive_request: subtype={}, detail={}, waited={}s",
+                    req.subtype,
+                    req.detail,
+                    req.received_at.elapsed().as_secs()
+                );
+                self.pending_interactive_request = None;
+            }
+        }
     }
 
     /// Send a control_cancel_request to CLI stdin (top-level message type).
@@ -1712,6 +1760,12 @@ impl SessionActor {
                 }
             }
             if hook_event == "PreToolUse" {
+                self.pending_interactive_request = Some(PendingInteractiveRequest {
+                    request_id: request_id.clone(),
+                    subtype: "hook_callback".to_string(),
+                    detail: format!("PreToolUse:{}", hook_label),
+                    received_at: Instant::now(),
+                });
                 notify_if_background(
                     self.emitter.app(),
                     "Hook Review Required",
@@ -1784,6 +1838,12 @@ impl SessionActor {
                 url,
                 requested_schema,
             });
+            self.pending_interactive_request = Some(PendingInteractiveRequest {
+                request_id: request_id.clone(),
+                subtype: "elicitation".to_string(),
+                detail: mcp_server_name.clone(),
+                received_at: Instant::now(),
+            });
             notify_if_background(
                 self.emitter.app(),
                 "MCP Input Required",
@@ -1838,13 +1898,19 @@ impl SessionActor {
             let tool_label = tool_name.clone();
             self.persist_and_emit(&BusEvent::PermissionPrompt {
                 run_id: self.run_id.clone(),
-                request_id,
+                request_id: request_id.clone(),
                 tool_name,
                 tool_use_id,
                 tool_input,
                 decision_reason,
                 parent_tool_use_id,
                 suggestions,
+            });
+            self.pending_interactive_request = Some(PendingInteractiveRequest {
+                request_id,
+                subtype: "can_use_tool".to_string(),
+                detail: tool_label.clone(),
+                received_at: Instant::now(),
             });
             notify_if_background(
                 self.emitter.app(),

--- a/src-tauri/src/storage/community_skills.rs
+++ b/src-tauri/src/storage/community_skills.rs
@@ -405,10 +405,15 @@ async fn fallback_detail(source: &str, skill_id: &str) -> Result<CommunitySkillD
         .map_err(|e| format!("Failed to download SKILL.md: {e}"))?;
 
     if !resp.status().is_success() {
-        return Err(format!(
-            "Could not fetch skill detail (HTTP {})",
-            resp.status()
-        ));
+        let status = resp.status();
+        return Err(if status == reqwest::StatusCode::NOT_FOUND {
+            format!(
+                "Skill source unavailable — the repository {}/{} may have been removed or restructured (HTTP 404)",
+                source, skill_id
+            )
+        } else {
+            format!("Could not fetch skill detail (HTTP {})", status)
+        });
     }
 
     // Check content length

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -1360,6 +1360,26 @@ describe("SessionStore reducer", () => {
       );
       expect(classifyError(undefined, "Received 401 Unauthorized").category).toBe("auth_issue");
     });
+
+    it("classifies session_timeout by text matching", () => {
+      const c1 = classifyError(
+        undefined,
+        "Session timeout — waited 600s for can_use_tool response (Write). Process killed.",
+      );
+      expect(c1.category).toBe("session_timeout");
+      expect(c1.canRetry).toBe(true);
+
+      const c2 = classifyError(
+        undefined,
+        "Session timeout — no response from CLI for 10 minutes. Process killed.",
+      );
+      expect(c2.category).toBe("session_timeout");
+
+      // Legacy message format
+      expect(classifyError(undefined, "Session hard timeout — process killed").category).toBe(
+        "session_timeout",
+      );
+    });
   });
 
   // ── taskNotifications Map ──

--- a/src/lib/stores/types.ts
+++ b/src/lib/stores/types.ts
@@ -103,6 +103,7 @@ export type ErrorCategory =
   | "budget_limit"
   | "auth_issue"
   | "server_issue"
+  | "session_timeout"
   | "tool_issue"
   | "unknown";
 
@@ -177,6 +178,9 @@ export function classifyError(subtype?: string, errorMsg?: string): ClassifiedEr
   }
   if (/api.?key|auth|401|403/i.test(msg)) {
     return { category: "auth_issue", canRetry: false, canFork: false, settingsLink: "/settings" };
+  }
+  if (/session timeout|hard timeout|process killed/i.test(msg)) {
+    return { category: "session_timeout", canRetry: true, canFork: false, settingsLink: "" };
   }
   if (/rate.?limit|overloaded|timeout|network|connection|60s/i.test(msg)) {
     return { category: "server_issue", canRetry: true, canFork: false, settingsLink: "" };

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -4188,9 +4188,11 @@
                 ? "💰"
                 : classified.category === "server_issue"
                   ? "☁"
-                  : classified.category === "tool_issue"
-                    ? "🔧"
-                    : "❌"}
+                  : classified.category === "session_timeout"
+                    ? "⏱"
+                    : classified.category === "tool_issue"
+                      ? "🔧"
+                      : "❌"}
         <div class="absolute bottom-14 left-3 right-3 z-10">
           <div
             class="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm backdrop-blur-sm animate-fade-in"

--- a/src/routes/plugins/+page.svelte
+++ b/src/routes/plugins/+page.svelte
@@ -110,6 +110,7 @@
   let communityHealth = $state<ProviderHealth | null>(null);
   let communityDetail = $state<CommunitySkillDetail | null>(null);
   let communityDetailLoading = $state(false);
+  let communityDetailError = $state<string | null>(null);
   let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   let communityDisplayResults = $derived(
@@ -468,10 +469,11 @@
   async function handleCommunityDetail(skill: CommunitySkillResult) {
     communityDetailLoading = true;
     communityDetail = null;
+    communityDetailError = null;
     try {
       communityDetail = await getCommunitySkillDetail(skill.source, skill.name);
     } catch (e) {
-      showToast(t("plugin_failedLoadDetail", { error: String(e) }), "error");
+      communityDetailError = String(e);
     } finally {
       communityDetailLoading = false;
     }
@@ -1085,6 +1087,18 @@
                       <span class="ml-2 text-xs text-muted-foreground"
                         >{t("plugin_loadingPreview")}</span
                       >
+                    </div>
+                  {:else if communityDetailError}
+                    <div
+                      class="rounded-lg border border-destructive/30 bg-destructive/5 p-6 flex flex-col items-center justify-center h-full gap-2 text-center"
+                    >
+                      <span class="text-2xl">⚠</span>
+                      <p class="text-xs font-medium text-destructive">
+                        {t("plugin_skillUnavailable")}
+                      </p>
+                      <p class="text-[10px] text-muted-foreground max-w-[280px] leading-relaxed">
+                        {communityDetailError}
+                      </p>
                     </div>
                   {:else if communityDetail}
                     <div class="rounded-lg border border-border/50 bg-muted/20 p-4 space-y-3">


### PR DESCRIPTION
## Summary
- **Session timeout observability**: Track pending interactive requests (permission/hook/elicitation) in session actor. Hard-timeout error now shows what was being waited on and for how long, replacing the generic "Session hard timeout" message. New `session_timeout` error category with dedicated icon and i18n.
- **Skill 404 UX**: When a community skill's source repo is unavailable, show a persistent inline error in the preview panel instead of a 4-second toast. Backend returns descriptive message identifying the missing repo.

## Test plan
- [x] `cargo clippy` — 0 warnings
- [x] `npm test` — 1102 tests pass (includes new `session_timeout` classification tests)
- [x] `npm run build` — clean
- [ ] Manual: trigger permission prompt timeout → verify error card shows "Session Timeout" with wait details
- [ ] Manual: click unavailable skill in discovery → verify inline error panel appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)