### PR TITLE
fix: clear CLI apiKey when switching to CLI auth mode

### DIFF
--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1872,6 +1872,7 @@
                     active_platform_id: null,
                     auth_env_var: null,
                   });
+                  api.removeCliApiKey().catch(() => {});
                   api
                     .getAuthOverview()
                     .then((ov) => (authOverview = ov))


### PR DESCRIPTION
Bug Fix / 修复说明                                    

  Problem / 问题

  Switching to CLI auth mode did not clear the apiKey field in ~/.claude/settings.json. If a third-party
  platform key was previously set, it would persist and override the OAuth token, causing repeated 403
  errors.

  切换到 CLI 认证模式时，未清除 ~/.claude/settings.json 中的 apiKey
  字段。如果之前设置过第三方平台密钥，该密钥会残留并覆盖 OAuth token，导致反复出现 403 错误被踢出。

  Fix / 修复

  Added api.removeCliApiKey() call when switching to CLI mode.

  在切换到 CLI 模式时调用 api.removeCliApiKey() 清除残留密钥。

  File changed / 修改文件

  src/routes/settings/+page.svelte