### PR TITLE
feat: API Key connectivity test + Rust dedup + community skill fix

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -49,6 +49,14 @@
   "settings_local_setupHint_ccr": "Run \"ccr start\" to start the router only (do NOT use \"ccr code\"). Install: npm i -g @musistudio/claude-code-router",
   "settings_local_setupHint_ollama": "Run \"ollama serve\" to start the Ollama service",
 
+  "settings_apiTest": "Test",
+  "settings_apiTest_testing": "Testing...",
+  "settings_apiTest_success": "Connected ({latency}ms)",
+  "settings_apiTest_partial": "Auth OK ({latency}ms) — configure a model for full test",
+  "settings_apiTest_failed": "Connection failed",
+  "settings_apiTest_noKey": "Enter an API key first",
+  "settings_apiTest_noUrl": "Enter a base URL first",
+
   "settings_general_setupWizard": "Setup Wizard",
   "settings_general_setupWizardDesc": "Re-run the initial setup wizard to reconfigure CLI and authentication.",
   "settings_general_runWizard": "Run Wizard",
@@ -488,6 +496,7 @@
   "plugin_failedLoadDetail": "Failed to load detail: {error}",
   "plugin_skillUnavailable": "Skill Unavailable",
   "plugin_installedSkill": "Installed {name}",
+  "plugin_skillRestartHint": "Start a new session to use it.",
   "plugin_errorGeneric": "Error: {error}",
   "plugin_uninstallTitle": "Uninstall Plugin",
   "plugin_uninstallMsg": "Are you sure you want to uninstall \"{name}\"?",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -49,6 +49,14 @@
   "settings_local_setupHint_ccr": "运行 \"ccr start\" 仅启动路由服务（请勿使用 \"ccr code\"）。安装：npm i -g @musistudio/claude-code-router",
   "settings_local_setupHint_ollama": "运行 \"ollama serve\" 启动 Ollama 服务",
 
+  "settings_apiTest": "测试",
+  "settings_apiTest_testing": "测试中...",
+  "settings_apiTest_success": "已连通 ({latency}ms)",
+  "settings_apiTest_partial": "认证通过 ({latency}ms) — 配置模型后可完整测试",
+  "settings_apiTest_failed": "连接失败",
+  "settings_apiTest_noKey": "请先输入 API Key",
+  "settings_apiTest_noUrl": "请先填写 Base URL",
+
   "settings_general_setupWizard": "设置向导",
   "settings_general_setupWizardDesc": "重新运行初始设置向导以重新配置 CLI 和认证。",
   "settings_general_runWizard": "运行向导",
@@ -488,6 +496,7 @@
   "plugin_failedLoadDetail": "加载详情失败：{error}",
   "plugin_skillUnavailable": "技能不可用",
   "plugin_installedSkill": "已安装 {name}",
+  "plugin_skillRestartHint": "开始新会话即可使用。",
   "plugin_errorGeneric": "错误：{error}",
   "plugin_uninstallTitle": "卸载插件",
   "plugin_uninstallMsg": "确定要卸载 \"{name}\" 吗？",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.43"
+version = "0.1.45"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1,9 +1,9 @@
 use crate::agent::claude_stream::augmented_path;
 use crate::agent::ssh::{expand_local_tilde, shell_escape};
 use crate::models::{
-    AuthDiagnostics, ClaudeMdInfo, CliCheckResult, CliDiagnostics, CliDistTags, ConfigDiagnostics,
-    ConfigIssue, DiagnosticsReport, LocalProxyStatus, ProjectDiagnostics, ProjectInitStatus,
-    RemoteTestResult, ServicesDiagnostics, SshKeyInfo, SystemDiagnostics,
+    ApiTestResult, AuthDiagnostics, ClaudeMdInfo, CliCheckResult, CliDiagnostics, CliDistTags,
+    ConfigDiagnostics, ConfigIssue, DiagnosticsReport, LocalProxyStatus, ProjectDiagnostics,
+    ProjectInitStatus, RemoteTestResult, ServicesDiagnostics, SshKeyInfo, SystemDiagnostics,
 };
 use crate::process_ext::HideConsole;
 use std::path::Path;
@@ -131,6 +131,216 @@ pub async fn detect_local_proxy(
     base_url: String,
 ) -> Result<LocalProxyStatus, String> {
     Ok(detect_proxy_inner(&proxy_id, &base_url).await)
+}
+
+// ── API connectivity test ──
+
+/// Probe model used when the user hasn't configured one — just for connectivity testing.
+const PROBE_MODEL: &str = "claude-sonnet-4-6";
+
+async fn test_api_inner(
+    api_key: &str,
+    base_url: &str,
+    auth_env_var: &str,
+    model: &str,
+) -> ApiTestResult {
+    let is_probe = model.is_empty();
+    let effective_model = if is_probe { PROBE_MODEL } else { model };
+    let effective_base_url = if base_url.is_empty() {
+        "https://api.anthropic.com"
+    } else {
+        base_url
+    };
+    let url = format!("{}/v1/messages", effective_base_url.trim_end_matches('/'));
+
+    log::debug!(
+        "[diagnostics] test_api_connectivity: url={}, auth={}, model={}, probe={}",
+        url,
+        auth_env_var,
+        effective_model,
+        is_probe
+    );
+    log::debug!(
+        "[diagnostics] test_api_connectivity: key_len={}",
+        api_key.len()
+    );
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            log::debug!(
+                "[diagnostics] test_api_connectivity: client build failed: {}",
+                e
+            );
+            return ApiTestResult {
+                success: false,
+                latency_ms: 0,
+                reply: None,
+                error: Some(format!("HTTP client build failed: {}", e)),
+                partial: false,
+            };
+        }
+    };
+
+    let mut req = client
+        .post(&url)
+        .header("content-type", "application/json")
+        .header("anthropic-version", "2023-06-01");
+
+    req = match auth_env_var {
+        "ANTHROPIC_AUTH_TOKEN" => req.header("authorization", format!("Bearer {}", api_key)),
+        _ => req.header("x-api-key", api_key),
+    };
+
+    let body = serde_json::json!({
+        "model": effective_model,
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}]
+    });
+
+    let start = std::time::Instant::now();
+    let resp = match req.json(&body).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            let latency_ms = start.elapsed().as_millis() as u64;
+            let error = if e.is_timeout() {
+                "Connection timed out".to_string()
+            } else if e.is_connect() {
+                "Connection refused — is the service running?".to_string()
+            } else {
+                format!("Request failed: {}", e)
+            };
+            log::debug!(
+                "[diagnostics] test_api_connectivity: failed, error={}",
+                error
+            );
+            return ApiTestResult {
+                success: false,
+                latency_ms,
+                reply: None,
+                error: Some(error),
+                partial: false,
+            };
+        }
+    };
+
+    let latency_ms = start.elapsed().as_millis() as u64;
+    let status = resp.status().as_u16();
+
+    if status == 200 {
+        // Parse successful response — must contain content[0].text to count as valid
+        let body_text = resp.text().await.unwrap_or_default();
+        let reply = serde_json::from_str::<serde_json::Value>(&body_text)
+            .ok()
+            .and_then(|v| {
+                v.get("content")?
+                    .get(0)?
+                    .get("text")?
+                    .as_str()
+                    .map(String::from)
+            })
+            .map(|s| {
+                if s.len() > 50 {
+                    format!("{}…", &s[..50])
+                } else {
+                    s
+                }
+            });
+
+        if reply.is_some() {
+            log::debug!(
+                "[diagnostics] test_api_connectivity: success, latency={}ms",
+                latency_ms
+            );
+            ApiTestResult {
+                success: true,
+                latency_ms,
+                reply,
+                error: None,
+                partial: false,
+            }
+        } else {
+            log::debug!("[diagnostics] test_api_connectivity: 200 but invalid response body");
+            ApiTestResult {
+                success: false,
+                latency_ms,
+                reply: None,
+                error: Some(
+                    "Received 200 but response is not a valid Messages API reply".to_string(),
+                ),
+                partial: false,
+            }
+        }
+    } else {
+        // Parse error response
+        let body_text = resp.text().await.unwrap_or_default();
+        let api_error = serde_json::from_str::<serde_json::Value>(&body_text)
+            .ok()
+            .and_then(|v| v.get("error")?.get("message")?.as_str().map(String::from));
+
+        // Probe mode: 400 with model-related error means auth+connectivity OK, just wrong model
+        let is_model_error = status == 400
+            && api_error
+                .as_deref()
+                .map(|m| {
+                    let lower = m.to_lowercase();
+                    lower.contains("model") || lower.contains("not found")
+                })
+                .unwrap_or(false);
+
+        if is_probe && is_model_error {
+            log::debug!(
+                "[diagnostics] test_api_connectivity: partial success (probe model rejected), latency={}ms",
+                latency_ms
+            );
+            return ApiTestResult {
+                success: true,
+                latency_ms,
+                reply: None,
+                error: None,
+                partial: true,
+            };
+        }
+
+        let error = match status {
+            401 | 403 => "Authentication failed — check your API key".to_string(),
+            404 => "Endpoint not found — check your base URL".to_string(),
+            429 => "Rate limited — try again later".to_string(),
+            _ => {
+                if let Some(msg) = api_error {
+                    format!("HTTP {}: {}", status, msg)
+                } else {
+                    format!("HTTP {}", status)
+                }
+            }
+        };
+
+        log::debug!(
+            "[diagnostics] test_api_connectivity: failed, status={}, error={}",
+            status,
+            error
+        );
+        ApiTestResult {
+            success: false,
+            latency_ms,
+            reply: None,
+            error: Some(error),
+            partial: false,
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn test_api_connectivity(
+    api_key: String,
+    base_url: String,
+    auth_env_var: String,
+    model: String,
+) -> Result<ApiTestResult, String> {
+    Ok(test_api_inner(&api_key, &base_url, &auth_env_var, &model).await)
 }
 
 /// Platform-aware message for missing SSH binaries.
@@ -422,27 +632,15 @@ pub async fn run_diagnostics(cwd: String) -> Result<DiagnosticsReport, String> {
 
 async fn check_cli_inner() -> CliDiagnostics {
     let aug_path = augmented_path();
-    let (found, path) = match crate::agent::claude_stream::which_binary("claude") {
-        Some(p) => (true, Some(p)),
-        None => (false, None),
-    };
-
-    let version = if found {
-        match Command::new("claude")
-            .arg("--version")
-            .env("PATH", &aug_path)
-            .hide_console()
-            .output()
-        {
-            Ok(output) if output.status.success() => {
-                let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                Some(raw.find(" (").map(|i| raw[..i].to_string()).unwrap_or(raw))
-            }
-            _ => None,
-        }
-    } else {
-        None
-    };
+    // Reuse check_agent_cli for CLI detection + version
+    let cli = check_agent_cli("claude".into())
+        .await
+        .unwrap_or(CliCheckResult {
+            agent: "claude".into(),
+            found: false,
+            path: None,
+            version: None,
+        });
 
     let ripgrep_available = Command::new("rg")
         .arg("--version")
@@ -455,9 +653,9 @@ async fn check_cli_inner() -> CliDiagnostics {
         .unwrap_or(false);
 
     CliDiagnostics {
-        found,
-        version,
-        path,
+        found: cli.found,
+        version: cli.version,
+        path: cli.path,
         latest: None,              // filled by caller after dist tags fetch
         stable: None,              // filled by caller
         auto_update_channel: None, // filled by caller
@@ -1131,62 +1329,250 @@ mod tests {
         });
         timeout.await.expect("test timed out");
     }
+
+    // ── test_api_connectivity tests ──
+
+    #[tokio::test]
+    async fn test_api_connectivity_success_200() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = AsyncReadExt::read(&mut stream, &mut buf).await;
+                    let body = r#"{"content":[{"text":"Hello!"}]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            let result = test_api_inner("test-key", &url, "ANTHROPIC_API_KEY", "test-model").await;
+            assert!(result.success);
+            assert!(!result.partial);
+            assert!(result.latency_ms > 0);
+            assert_eq!(result.reply, Some("Hello!".to_string()));
+            assert!(result.error.is_none());
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_auth_failure_401() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = AsyncReadExt::read(&mut stream, &mut buf).await;
+                    let body = r#"{"error":{"message":"Invalid API key"}}"#;
+                    let resp = format!(
+                        "HTTP/1.1 401 Unauthorized\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            let result = test_api_inner("bad-key", &url, "ANTHROPIC_API_KEY", "test-model").await;
+            assert!(!result.success);
+            assert!(
+                result
+                    .error
+                    .as_deref()
+                    .unwrap()
+                    .contains("Authentication failed"),
+                "error was: {:?}",
+                result.error
+            );
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_not_found_404() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = AsyncReadExt::read(&mut stream, &mut buf).await;
+                    let resp = "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n";
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            let result = test_api_inner("test-key", &url, "ANTHROPIC_API_KEY", "test-model").await;
+            assert!(!result.success);
+            assert!(
+                result
+                    .error
+                    .as_deref()
+                    .unwrap()
+                    .contains("Endpoint not found"),
+                "error was: {:?}",
+                result.error
+            );
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_header_x_api_key() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let n = AsyncReadExt::read(&mut stream, &mut buf).await.unwrap();
+                    let req_str = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let _ = tx.send(req_str);
+                    let body = r#"{"content":[{"text":"ok"}]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            let result =
+                test_api_inner("test-key-123", &url, "ANTHROPIC_API_KEY", "test-model").await;
+            assert!(result.success);
+            let req_str = rx.await.unwrap();
+            let req_lower = req_str.to_lowercase();
+            assert!(
+                req_lower.contains("x-api-key: test-key-123"),
+                "expected x-api-key header, got: {}",
+                req_str
+            );
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_header_bearer() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let (tx, rx) = tokio::sync::oneshot::channel::<String>();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let n = AsyncReadExt::read(&mut stream, &mut buf).await.unwrap();
+                    let req_str = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let _ = tx.send(req_str);
+                    let body = r#"{"content":[{"text":"ok"}]}"#;
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            let result = test_api_inner(
+                "test-bearer-key",
+                &url,
+                "ANTHROPIC_AUTH_TOKEN",
+                "test-model",
+            )
+            .await;
+            assert!(result.success);
+            let req_str = rx.await.unwrap();
+            let req_lower = req_str.to_lowercase();
+            assert!(
+                req_lower.contains("authorization: bearer test-bearer-key"),
+                "expected Bearer header, got: {}",
+                req_str
+            );
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_probe_partial_success() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = AsyncReadExt::read(&mut stream, &mut buf).await;
+                    // Simulate a 400 "model not found" response
+                    let body = r#"{"error":{"message":"model: claude-sonnet-4-6 not found"}}"#;
+                    let resp = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            // model="" triggers probe mode
+            let result = test_api_inner("test-key", &url, "ANTHROPIC_API_KEY", "").await;
+            assert!(result.success, "expected partial success");
+            assert!(result.partial, "expected partial=true");
+            assert!(result.error.is_none());
+        });
+        timeout.await.expect("test timed out");
+    }
+
+    #[tokio::test]
+    async fn test_api_connectivity_non_probe_400_is_failure() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let timeout = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let port = listener.local_addr().unwrap().port();
+            tokio::spawn(async move {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let mut buf = [0u8; 4096];
+                    let _ = AsyncReadExt::read(&mut stream, &mut buf).await;
+                    let body = r#"{"error":{"message":"model: foo not found"}}"#;
+                    let resp = format!(
+                        "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+            });
+            let url = format!("http://127.0.0.1:{}", port);
+            // model="foo" — NOT probe mode, so 400 should be a real failure
+            let result = test_api_inner("test-key", &url, "ANTHROPIC_API_KEY", "foo").await;
+            assert!(!result.success, "expected failure for non-probe 400");
+            assert!(!result.partial);
+            assert!(result.error.is_some());
+        });
+        timeout.await.expect("test timed out");
+    }
 }
 
 /// Fetch npm dist-tags for @anthropic-ai/claude-code.
 /// Returns latest/stable version strings. Non-fatal: returns None on failure.
 #[tauri::command]
 pub async fn get_cli_dist_tags() -> Result<CliDistTags, String> {
-    log::debug!("[diagnostics] get_cli_dist_tags: fetching npm dist-tags");
-
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
-        .build()
-        .map_err(|e| format!("HTTP client error: {}", e))?;
-
-    let resp = client
-        .get("https://registry.npmjs.org/-/package/@anthropic-ai/claude-code/dist-tags")
-        .header("Accept", "application/json")
-        .send()
-        .await;
-
-    match resp {
-        Ok(r) if r.status().is_success() => {
-            let body: serde_json::Value = r
-                .json()
-                .await
-                .map_err(|e| format!("JSON parse error: {}", e))?;
-            let latest = body
-                .get("latest")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let stable = body
-                .get("stable")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            log::debug!(
-                "[diagnostics] get_cli_dist_tags: latest={:?}, stable={:?}",
-                latest,
-                stable
-            );
-            Ok(CliDistTags { latest, stable })
-        }
-        Ok(r) => {
-            let status = r.status();
-            log::debug!("[diagnostics] get_cli_dist_tags: HTTP {}", status);
-            Ok(CliDistTags {
-                latest: None,
-                stable: None,
-            })
-        }
-        Err(e) => {
-            log::debug!("[diagnostics] get_cli_dist_tags: request failed: {}", e);
-            Ok(CliDistTags {
-                latest: None,
-                stable: None,
-            })
-        }
-    }
+    log::debug!("[diagnostics] get_cli_dist_tags");
+    let (latest, stable, _channel) = fetch_dist_tags_inner().await;
+    Ok(CliDistTags { latest, stable })
 }
 
 /// Check for existing SSH key pairs. Returns info about the first usable pair found.

--- a/src-tauri/src/commands/runs.rs
+++ b/src-tauri/src/commands/runs.rs
@@ -1,5 +1,4 @@
 use crate::agent::adapter::ActorSessionMap;
-use crate::agent::session_actor::ActorCommand;
 use crate::models::{PromptFavorite, PromptSearchResult, RunStatus, TaskRun};
 use crate::storage;
 use std::collections::{HashMap, HashSet};
@@ -122,57 +121,22 @@ pub async fn stop_run(
     log::debug!("[runs] stop_run: id={}", id);
 
     // Try actor session first (primary mode)
-    let actor_stopped = {
-        let handle = {
-            let mut map = sessions.lock().await;
-            map.remove(&id)
-        };
-        if let Some(handle) = handle {
-            let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
-            if handle
-                .cmd_tx
-                .send(ActorCommand::Stop { reply: reply_tx })
-                .await
-                .is_ok()
-            {
-                let _ = reply_rx.await;
-            }
-            let _ =
-                tokio::time::timeout(std::time::Duration::from_secs(5), handle.join_handle).await;
-            true
-        } else {
-            false
-        }
-    };
+    let actor_stopped = super::session::stop_actor(&sessions, &id)
+        .await
+        .unwrap_or(false);
 
     if actor_stopped {
         log::debug!("[runs] stop_run: stopped actor session for id={}", id);
-        if let Err(e) = storage::runs::update_status(
-            &id,
-            RunStatus::Stopped,
-            None,
-            Some("Stopped by user".to_string()),
-        ) {
-            log::warn!("[runs] stop_run: failed to update status: {}", e);
+    } else {
+        // Fall through to PTY / pipe
+        let pty_killed = crate::agent::pty::close_pty(pty_map.inner(), &id).unwrap_or(false);
+        if !pty_killed {
+            crate::agent::stream::stop_process(&process_map, &id).await;
         }
-        return Ok(true);
     }
 
-    // Fall through to PTY / pipe
-    let pty_killed = crate::agent::pty::close_pty(pty_map.inner(), &id).unwrap_or(false);
-    if !pty_killed {
-        let killed = crate::agent::stream::stop_process(&process_map, &id).await;
-        if !killed {
-            if let Err(e) = storage::runs::update_status(
-                &id,
-                RunStatus::Stopped,
-                None,
-                Some("Stopped by user".to_string()),
-            ) {
-                log::warn!("[runs] stop_run: failed to update status: {}", e);
-            }
-        }
-    } else if let Err(e) = storage::runs::update_status(
+    // Update status regardless of which path stopped the process
+    if let Err(e) = storage::runs::update_status(
         &id,
         RunStatus::Stopped,
         None,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -22,9 +22,20 @@ fn truncate_str(s: &str, max: usize) -> &str {
     &s[..end]
 }
 
+/// Helper: get the actor command sender for a run_id.
+async fn get_cmd_tx(
+    sessions: &ActorSessionMap,
+    run_id: &str,
+) -> Result<tokio::sync::mpsc::Sender<ActorCommand>, String> {
+    let map = sessions.lock().await;
+    map.get(run_id)
+        .map(|h| h.cmd_tx.clone())
+        .ok_or_else(|| format!("Session {} not found", run_id))
+}
+
 /// Helper: stop an existing actor for a run_id, await its shutdown.
 /// Returns true if an actor was stopped.
-async fn stop_actor(sessions: &ActorSessionMap, run_id: &str) -> Result<bool, String> {
+pub(super) async fn stop_actor(sessions: &ActorSessionMap, run_id: &str) -> Result<bool, String> {
     let handle = {
         let mut map = sessions.lock().await;
         map.remove(run_id)
@@ -693,12 +704,7 @@ pub async fn send_session_message(
     );
 
     // Get channel sender
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     // Send message through actor channel
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
@@ -778,12 +784,7 @@ pub async fn send_session_control(
         subtype
     );
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     // Build control request
     let mut request = serde_json::json!({ "subtype": subtype });
@@ -1190,12 +1191,7 @@ pub(crate) async fn approve_session_tool_impl(
         "The tool {} is now allowed. Please retry your previous action using this tool.",
         tool_name
     );
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found after approve restart", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(sessions, &run_id).await?;
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx
         .send(ActorCommand::SendMessage {
@@ -1261,12 +1257,7 @@ pub async fn respond_permission(
         interrupt,
     );
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     // Build the response payload for Claude CLI.
     // CLI validates with Zod: allow requires `updatedInput` (record<string,unknown>),
@@ -1332,12 +1323,7 @@ pub async fn respond_hook_callback(
         decision
     );
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     let response = serde_json::json!({ "decision": decision });
 
@@ -1374,12 +1360,7 @@ pub async fn cancel_control_request(
         request_id
     );
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx
@@ -1428,12 +1409,7 @@ pub async fn respond_elicitation(
         other => serde_json::json!({"action": other}),
     };
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx
@@ -2079,12 +2055,7 @@ pub async fn start_ralph_loop(
         completion_promise
     );
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx
@@ -2109,12 +2080,7 @@ pub async fn cancel_ralph_loop(
 ) -> Result<RalphCancelResult, String> {
     log::debug!("[session] cancel_ralph_loop: run_id={}", run_id);
 
-    let cmd_tx = {
-        let map = sessions.lock().await;
-        map.get(&run_id)
-            .map(|h| h.cmd_tx.clone())
-            .ok_or_else(|| format!("Session {} not found", run_id))?
-    };
+    let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,6 +191,7 @@ pub fn run() {
             commands::diagnostics::generate_ssh_key,
             commands::diagnostics::run_diagnostics,
             commands::diagnostics::detect_local_proxy,
+            commands::diagnostics::test_api_connectivity,
             commands::pty::spawn_pty,
             commands::pty::write_pty,
             commands::pty::resize_pty,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -13,6 +13,17 @@ pub struct LocalProxyStatus {
 }
 
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApiTestResult {
+    pub success: bool,
+    pub latency_ms: u64,
+    pub reply: Option<String>,
+    pub error: Option<String>,
+    /// True when auth+connectivity OK but probe model was rejected (no user model configured).
+    pub partial: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct MemoryFileCandidate {
     pub path: String,
     pub label: String,
@@ -1426,6 +1437,7 @@ pub struct PluginOperationResult {
 pub struct CommunitySkillResult {
     pub id: String,
     pub name: String,
+    pub skill_id: String,
     pub installs: u64,
     pub source: String,
 }

--- a/src-tauri/src/storage/community_skills.rs
+++ b/src-tauri/src/storage/community_skills.rs
@@ -297,14 +297,21 @@ pub async fn search(query: &str, limit: u32) -> Result<Vec<CommunitySkillResult>
         .skills
         .into_iter()
         .map(|item| {
+            // Compute reliable skill_id: prefer explicit skillId, fall back to last segment of id
+            let effective_skill_id = if !item.skill_id.is_empty() {
+                item.skill_id.clone()
+            } else {
+                item.id.rsplit('/').next().unwrap_or(&item.id).to_string()
+            };
             let display_name = if item.name.is_empty() {
-                item.skill_id
+                effective_skill_id.clone()
             } else {
                 item.name
             };
             CommunitySkillResult {
                 id: item.id,
                 name: display_name,
+                skill_id: effective_skill_id,
                 installs: item.installs,
                 source: item.source,
             }
@@ -795,6 +802,59 @@ mod tests {
             path.to_str().unwrap(),
             "/project/.claude/skills/react-components/SKILL.md"
         );
+    }
+
+    #[test]
+    fn test_search_mapping_skill_id_fallback() {
+        // Simulate the mapping logic inline (mirrors the search() mapping)
+        let items = vec![
+            // First item: no skillId → extract from id's last segment
+            SkillsShItem {
+                id: "vercel-labs/agent-skills/vercel-react-best-practices".into(),
+                name: "vercel-react-best-practices".into(),
+                skill_id: String::new(), // empty
+                installs: 100,
+                source: "vercel-labs/agent-skills".into(),
+            },
+            // Second item: has skillId → use directly
+            SkillsShItem {
+                id: "google-labs/stitch-skills/react:components".into(),
+                name: "react-components".into(),
+                skill_id: "react-components".into(),
+                installs: 50,
+                source: "google-labs/stitch-skills".into(),
+            },
+        ];
+
+        let results: Vec<CommunitySkillResult> = items
+            .into_iter()
+            .map(|item| {
+                let effective_skill_id = if !item.skill_id.is_empty() {
+                    item.skill_id.clone()
+                } else {
+                    item.id.rsplit('/').next().unwrap_or(&item.id).to_string()
+                };
+                let display_name = if item.name.is_empty() {
+                    effective_skill_id.clone()
+                } else {
+                    item.name
+                };
+                CommunitySkillResult {
+                    id: item.id,
+                    name: display_name,
+                    skill_id: effective_skill_id,
+                    installs: item.installs,
+                    source: item.source,
+                }
+            })
+            .collect();
+
+        // First: no skillId → fallback to last segment of id
+        assert_eq!(results[0].skill_id, "vercel-react-best-practices");
+        assert_eq!(results[0].name, "vercel-react-best-practices");
+        // Second: has skillId → used directly
+        assert_eq!(results[1].skill_id, "react-components");
+        assert_eq!(results[1].name, "react-components");
     }
 
     #[test]

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -591,6 +591,20 @@ pub async fn dispatch_command(
                 crate::commands::diagnostics::detect_local_proxy(proxy_id, base_url).await?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
+        "test_api_connectivity" => {
+            let api_key = extract_str(&params, "api_key")?;
+            let base_url = extract_str(&params, "base_url")?;
+            let auth_env_var = extract_str(&params, "auth_env_var")?;
+            let model = extract_str(&params, "model")?;
+            let result = crate::commands::diagnostics::test_api_connectivity(
+                api_key,
+                base_url,
+                auth_env_var,
+                model,
+            )
+            .await?;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
         "test_remote_host" => {
             let host = extract_str(&params, "host")?;
             let user = extract_str(&params, "user")?;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -349,6 +349,21 @@ export async function detectLocalProxy(
   return invoke<import("./types").LocalProxyStatus>("detect_local_proxy", { proxyId, baseUrl });
 }
 
+export async function testApiConnectivity(
+  apiKey: string,
+  baseUrl: string,
+  authEnvVar: string,
+  model: string,
+): Promise<import("./types").ApiTestResult> {
+  dbg("api", "testApiConnectivity", { baseUrl, authEnvVar, model });
+  return invoke<import("./types").ApiTestResult>("test_api_connectivity", {
+    apiKey,
+    baseUrl,
+    authEnvVar,
+    model,
+  });
+}
+
 export async function runDiagnostics(cwd: string): Promise<DiagnosticsReport> {
   dbg("api", "runDiagnostics", { cwd });
   return invoke<DiagnosticsReport>("run_diagnostics", { cwd });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -285,6 +285,15 @@ export interface LocalProxyStatus {
   error?: string;
 }
 
+export interface ApiTestResult {
+  success: boolean;
+  latencyMs: number;
+  reply?: string;
+  error?: string;
+  /** True when auth+connectivity OK but probe model was rejected (no user model configured). */
+  partial: boolean;
+}
+
 export interface ModelUsageSummary {
   inputTokens: number;
   outputTokens: number;
@@ -656,6 +665,7 @@ export interface PluginOperationResult {
 export interface CommunitySkillResult {
   id: string;
   name: string;
+  skill_id: string;
   installs: number;
   source: string;
 }

--- a/src/routes/plugins/+page.svelte
+++ b/src/routes/plugins/+page.svelte
@@ -185,8 +185,29 @@
     }),
   );
 
-  // Installed skill names (for community install status check)
-  let installedSkillNames = $derived(new Set(skills.map((s) => s.name.toLowerCase())));
+  // Installed skill slugs (for community install status check)
+  // Extract parent directory name from skill.path as the installed slug
+  // path format: "~/.claude/skills/react-components/SKILL.md"
+  function installedSlug(skillPath: string): string {
+    const parts = skillPath.replace(/\\/g, "/").split("/");
+    return parts.length >= 2 ? parts[parts.length - 2].toLowerCase() : "";
+  }
+  // Match backend to_local_slug: rsplit('/') → colon→hyphen → keep alphanumeric/-/_
+  function toLocalSlug(s: string): string {
+    const base = s.split("/").pop() ?? s;
+    return base
+      .replace(/:/g, "-")
+      .replace(/[^a-zA-Z0-9_-]/g, "")
+      .toLowerCase();
+  }
+  let installedSlugsByScope = $derived.by(() => {
+    const map: Record<string, Set<string>> = { user: new Set(), project: new Set() };
+    for (const s of skills) {
+      const slug = installedSlug(s.path);
+      if (slug && s.scope && map[s.scope]) map[s.scope].add(slug);
+    }
+    return map;
+  });
 
   // MCP: installed plugins that declare mcp_servers
 
@@ -491,7 +512,7 @@
     communityDetail = null;
     communityDetailError = null;
     try {
-      communityDetail = await getCommunitySkillDetail(skill.source, skill.name);
+      communityDetail = await getCommunitySkillDetail(skill.source, skill.skill_id);
     } catch (e) {
       communityDetailError = String(e);
     } finally {
@@ -504,12 +525,14 @@
     try {
       const result = await installCommunitySkill(
         skill.source,
-        skill.name,
+        skill.skill_id,
         communityScope,
         projectCwd || undefined,
       );
       showToast(
-        result.success ? t("plugin_installedSkill", { name: skill.name }) : result.message,
+        result.success
+          ? t("plugin_installedSkill", { name: skill.name }) + " " + t("plugin_skillRestartHint")
+          : result.message,
         result.success ? "success" : "error",
       );
       if (result.success) {
@@ -1065,7 +1088,9 @@
                 <!-- Left: scrollable skill list -->
                 <div class="w-[280px] shrink-0 overflow-y-auto space-y-1.5 pr-1">
                   {#each communityDisplayResults as skill}
-                    {@const isInstalled = installedSkillNames.has(skill.name.toLowerCase())}
+                    {@const isInstalled = (
+                      installedSlugsByScope[communityScope] ?? new Set<string>()
+                    ).has(toLocalSlug(skill.skill_id))}
                     <div
                       class="w-full text-left rounded-lg border px-3 py-2 transition-colors cursor-pointer {communityDetail?.id ===
                       skill.id

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -120,6 +120,29 @@
   let localAdvancedOpen = $state(false);
   let localProxyStatuses = $state<Record<string, { running: boolean; needsAuth: boolean }>>({});
 
+  // ── API connectivity test state ──
+  let apiTestLoading = $state(false);
+  let apiTestResult = $state<import("$lib/types").ApiTestResult | null>(null);
+  let apiTestRequestId = $state(0);
+  // Derive effective auth env var (tracks platformCredentials + selectedPlatformId)
+  let effectiveAuthEnvVar = $derived(
+    findCredential(platformCredentials, selectedPlatformId ?? "")?.auth_env_var ||
+      selectedPlatform?.auth_env_var ||
+      "ANTHROPIC_API_KEY",
+  );
+  // Clear stale test result AND invalidate in-flight requests when any relevant input changes
+  $effect(() => {
+    void anthropicApiKey;
+    void anthropicBaseUrl;
+    void platformModels;
+    void effectiveAuthEnvVar;
+    return () => {
+      apiTestResult = null;
+      apiTestRequestId++; // invalidate in-flight request
+      apiTestLoading = false;
+    };
+  });
+
   // ── Web Server state (desktop-only) ──
   let webToken = $state<string | null>(null);
   let webStatus = $state<{
@@ -786,6 +809,7 @@
 
   /** Load display fields (key + URL) from credential store for a given platform. */
   function loadFieldsFromCredential(platformId: string | null) {
+    apiTestResult = null;
     if (!platformId) {
       anthropicApiKey = "";
       anthropicBaseUrl = "";
@@ -2279,8 +2303,112 @@
                     >
                       {showApiKey ? t("settings_general_hide") : t("settings_general_show")}
                     </button>
+                    {#if selectedPlatform?.category !== "local"}
+                      {@const cred = findCredential(platformCredentials, selectedPlatformId ?? "")}
+                      {@const authEnvVar =
+                        cred?.auth_env_var || selectedPlatform?.auth_env_var || "ANTHROPIC_API_KEY"}
+                      {@const parsedModels = platformModels
+                        .split(",")
+                        .map((s) => s.trim())
+                        .filter(Boolean)}
+                      {@const testModel = parsedModels[0] || selectedPlatform?.models?.[0] || ""}
+                      {@const isCustom = isCustomPlatform(selectedPlatformId ?? "")}
+                      {@const noKey = !anthropicApiKey}
+                      {@const noUrl = isCustom && !anthropicBaseUrl.trim()}
+                      {@const disableReason = noKey
+                        ? t("settings_apiTest_noKey")
+                        : noUrl
+                          ? t("settings_apiTest_noUrl")
+                          : ""}
+                      <button
+                        class="rounded-md border px-3 py-2 text-xs transition-colors {disableReason ||
+                        apiTestLoading
+                          ? 'text-muted-foreground/50 cursor-not-allowed'
+                          : 'text-muted-foreground hover:bg-accent hover:text-foreground'}"
+                        disabled={!!disableReason || apiTestLoading}
+                        title={disableReason || ""}
+                        onclick={async () => {
+                          const myRequestId = ++apiTestRequestId;
+                          const myPlatformId = selectedPlatformId;
+                          apiTestLoading = true;
+                          apiTestResult = null;
+                          dbg("settings", "testApi start", {
+                            platform: myPlatformId,
+                            model: testModel,
+                            authEnvVar,
+                            reqId: myRequestId,
+                          });
+                          try {
+                            const result = await api.testApiConnectivity(
+                              anthropicApiKey,
+                              anthropicBaseUrl,
+                              authEnvVar,
+                              testModel,
+                            );
+                            if (myRequestId !== apiTestRequestId) return;
+                            if (myPlatformId !== selectedPlatformId) return;
+                            apiTestResult = result;
+                            if (result.success) {
+                              dbg("settings", "testApi success", { latencyMs: result.latencyMs });
+                            } else {
+                              dbgWarn("settings", "testApi error", result.error);
+                            }
+                          } catch (e) {
+                            if (
+                              myRequestId !== apiTestRequestId ||
+                              myPlatformId !== selectedPlatformId
+                            )
+                              return;
+                            apiTestResult = {
+                              success: false,
+                              latencyMs: 0,
+                              error: String(e),
+                              partial: false,
+                            };
+                            dbgWarn("settings", "testApi error", e);
+                          } finally {
+                            if (myRequestId === apiTestRequestId) apiTestLoading = false;
+                          }
+                        }}
+                      >
+                        {t("settings_apiTest")}
+                      </button>
+                    {/if}
                   </div>
-                  {#if selectedPlatform?.id === "ollama"}
+                  <!-- API test result -->
+                  {#if apiTestLoading}
+                    <div class="mt-1.5 flex items-center gap-1.5">
+                      <span class="h-2 w-2 rounded-full bg-amber-400 animate-pulse"></span>
+                      <span class="text-xs text-muted-foreground"
+                        >{t("settings_apiTest_testing")}</span
+                      >
+                    </div>
+                  {:else if apiTestResult?.success && apiTestResult.partial}
+                    <div class="mt-1.5 flex items-center gap-1.5">
+                      <span class="h-2 w-2 rounded-full bg-green-500"></span>
+                      <span class="text-xs text-green-600 dark:text-green-400"
+                        >{t("settings_apiTest_partial", {
+                          latency: String(apiTestResult.latencyMs),
+                        })}</span
+                      >
+                    </div>
+                  {:else if apiTestResult?.success}
+                    <div class="mt-1.5 flex items-center gap-1.5">
+                      <span class="h-2 w-2 rounded-full bg-green-500"></span>
+                      <span class="text-xs text-green-600 dark:text-green-400"
+                        >{t("settings_apiTest_success", {
+                          latency: String(apiTestResult.latencyMs),
+                        })}</span
+                      >
+                    </div>
+                  {:else if apiTestResult && !apiTestResult.success}
+                    <div class="mt-1.5 flex items-center gap-1.5">
+                      <span class="h-2 w-2 rounded-full bg-red-500"></span>
+                      <span class="text-xs text-red-600 dark:text-red-400"
+                        >{apiTestResult.error ?? t("settings_apiTest_failed")}</span
+                      >
+                    </div>
+                  {:else if selectedPlatform?.id === "ollama"}
                     <p class="mt-1 text-xs text-muted-foreground">{t("setup_noKeyNeeded")}</p>
                   {:else}
                     <p class="mt-1 text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- **API Key connectivity test**: Add "Test" button next to API Key input in settings. Sends a `max_tokens=1` request to verify connectivity and authentication
  - Probe model fallback (`claude-sonnet-4-6`) when no model configured, with partial success detection (auth OK, model mismatch)
  - Race-guard protection (request-id + platform snapshot), stale result auto-clear on input/auth-type changes
  - 7 Rust tests covering success, auth failure, 404, header verification (x-api-key/Bearer), probe partial success
- **Rust dedup**: Deduplicate get_cmd_tx, diagnostics, stop_run
- **Fix**: Community skill id mismatch + post-install session hint

## Test plan
- [ ] Select Anthropic → enter key + model → Test → green dot + latency
- [ ] Wrong key → red dot "Authentication failed"
- [ ] Custom endpoint without model → Test → green dot "Auth OK — configure a model for full test"
- [ ] Switch platform / edit key / URL / model → stale result auto-clears
- [ ] Local platform (Ollama) → Test button not shown
- [ ] `cargo test` + `npm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)