### PR TITLE
fix: migrate Bailian to the current DashScope Anthropic endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You can re-run the wizard anytime from **Settings > General > Setup Wizard**.
 | Kimi For Coding | `api.kimi.com/coding/` | Bearer |
 | Zhipu (智谱) | `open.bigmodel.cn/api/anthropic` | Bearer |
 | Zhipu (智谱 Intl) | `api.z.ai/api/anthropic` | Bearer |
-| Bailian (百炼) | `coding.dashscope.aliyuncs.com/apps/anthropic` | Bearer |
+| Bailian (百炼) | `dashscope.aliyuncs.com/apps/anthropic` | Bearer |
 | DouBao (豆包) | `ark.cn-beijing.volces.com/api/coding` | Bearer |
 | MiniMax | `api.minimax.io/anthropic` | Bearer |
 | MiniMax (China) | `api.minimaxi.com/anthropic` | Bearer |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,7 +157,7 @@ npm run tauri dev
 | Kimi For Coding | `api.kimi.com/coding/` | Bearer |
 | 智谱 | `open.bigmodel.cn/api/anthropic` | Bearer |
 | 智谱（国际） | `api.z.ai/api/anthropic` | Bearer |
-| 百炼（阿里云） | `coding.dashscope.aliyuncs.com/apps/anthropic` | Bearer |
+| 百炼（阿里云） | `dashscope.aliyuncs.com/apps/anthropic` | Bearer |
 | 豆包（字节跳动） | `ark.cn-beijing.volces.com/api/coding` | Bearer |
 | MiniMax | `api.minimax.io/anthropic` | Bearer |
 | MiniMax（中国） | `api.minimaxi.com/anthropic` | Bearer |

--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -2,8 +2,15 @@ use crate::models::{AgentSettings, AllSettings, UserSettings};
 use std::fs;
 use std::path::PathBuf;
 
+const BAILIAN_COMPAT_BASE_URL: &str = "https://dashscope.aliyuncs.com/apps/anthropic";
+const BAILIAN_LEGACY_COMPAT_BASE_URL: &str = "https://coding.dashscope.aliyuncs.com/apps/anthropic";
+
 fn settings_path() -> PathBuf {
     super::data_dir().join("settings.json")
+}
+
+fn url_eq_ignore_trailing_slash(a: &str, b: &str) -> bool {
+    a.trim_end_matches('/') == b.trim_end_matches('/')
 }
 
 pub fn load() -> AllSettings {
@@ -118,7 +125,7 @@ fn known_provider_defaults(pid: &str) -> Option<ProviderDefaults> {
             auth_env_var: None,
         }),
         "bailian" => Some(ProviderDefaults {
-            base_url: Some("https://coding.dashscope.aliyuncs.com/apps/anthropic"),
+            base_url: Some(BAILIAN_COMPAT_BASE_URL),
             models: Some(vec![
                 "qwen3-max".to_string(),
                 "qwen3.5-plus".to_string(),
@@ -272,6 +279,21 @@ fn migrate_platform_credentials(settings: &mut AllSettings) -> bool {
         // base_url is CRITICAL — without it, ANTHROPIC_BASE_URL is not set and
         // requests go to Anthropic's default endpoint instead of the third-party provider.
         if let Some(defaults) = known_provider_defaults(&cred.platform_id) {
+            // Migrate legacy Bailian compat endpoint to the current official endpoint.
+            if cred.platform_id == "bailian" {
+                if let Some(ref url) = cred.base_url {
+                    if url_eq_ignore_trailing_slash(url, BAILIAN_LEGACY_COMPAT_BASE_URL) {
+                        log::info!(
+                            "[storage/settings] migrating bailian base_url: {} -> {}",
+                            BAILIAN_LEGACY_COMPAT_BASE_URL,
+                            BAILIAN_COMPAT_BASE_URL
+                        );
+                        cred.base_url = Some(BAILIAN_COMPAT_BASE_URL.to_string());
+                        changed = true;
+                    }
+                }
+            }
+
             if cred.base_url.as_ref().is_none_or(|s| s.is_empty()) {
                 if let Some(url) = defaults.base_url {
                     log::info!(
@@ -343,6 +365,21 @@ fn migrate_platform_credentials(settings: &mut AllSettings) -> bool {
                 );
                 settings.user.auth_env_var = Some(correct.to_string());
                 changed = true;
+            }
+        }
+
+        // Keep global anthropic_base_url in sync for migrated Bailian endpoint.
+        if pid == "bailian" {
+            if let Some(ref url) = settings.user.anthropic_base_url {
+                if url_eq_ignore_trailing_slash(url, BAILIAN_LEGACY_COMPAT_BASE_URL) {
+                    log::info!(
+                        "[storage/settings] migrating global anthropic_base_url for bailian: {} -> {}",
+                        BAILIAN_LEGACY_COMPAT_BASE_URL,
+                        BAILIAN_COMPAT_BASE_URL
+                    );
+                    settings.user.anthropic_base_url = Some(BAILIAN_COMPAT_BASE_URL.to_string());
+                    changed = true;
+                }
             }
         }
     }

--- a/src/lib/utils/platform-presets.ts
+++ b/src/lib/utils/platform-presets.ts
@@ -66,7 +66,7 @@ export const PLATFORM_PRESETS: PlatformPreset[] = [
   {
     id: "bailian",
     name: "Bailian (\u767e\u70bc)",
-    base_url: "https://coding.dashscope.aliyuncs.com/apps/anthropic",
+    base_url: "https://dashscope.aliyuncs.com/apps/anthropic",
     auth_env_var: "ANTHROPIC_AUTH_TOKEN",
     description: "Alibaba DashScope",
     key_placeholder: "your-bailian-key",


### PR DESCRIPTION
This updates the Bailian preset from the legacy compatibility endpoint to the current DashScope Anthropic endpoint:

  `https://dashscope.aliyuncs.com/apps/anthropic`

  Why this change:
  - new Bailian setups should default to the current endpoint
  - existing users should not stay stuck on the legacy URL after upgrading
  - saved settings should migrate automatically instead of requiring manual cleanup

  What this patch does:
  - updates the Bailian preset base URL
  - migrates saved Bailian credential `base_url` from the legacy endpoint
  - migrates global `anthropic_base_url` when the active platform is Bailian
  - updates the English and Chinese README entries to match the new URL

  Files:
  - `src-tauri/src/storage/settings.rs`
  - `src/lib/utils/platform-presets.ts`
  - `README.md`
  - `README.zh-CN.md`

  This is intended to be a narrow migration-only fix.