### PR TITLE
fix: surface API retry failures in the session timeline

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -1780,7 +1780,7 @@ export class SessionStore {
         // Session may already be dead
       }
       this._setPhase("stopped");
-  
+
       this.run = { ...this.run, status: "stopped" };
     }
   }
@@ -1821,7 +1821,7 @@ export class SessionStore {
       // Always clean up frontend state, even if backend calls failed.
       // If the process is already dead, the UI must not stay stuck in "running".
       this._setPhase("stopped");
-  
+
       this.run = { ...this.run!, status: "stopped" };
       this._stopping = false;
     }
@@ -2207,7 +2207,6 @@ export class SessionStore {
   resolvePermissionAllow(requestId: string): void {
     this._resolvePermission("allow", requestId);
   }
-
 
   /** Handle chat-done event (pipe mode). */
   handleChatDone(_done: { ok: boolean; code: number; error?: string }): void {
@@ -3179,6 +3178,40 @@ export class SessionStore {
 
       case "raw": {
         const rawText = typeof ev.data === "string" ? ev.data : JSON.stringify(ev.data);
+        if (ev.source === "claude_system_api_retry" && ev.data && typeof ev.data === "object") {
+          const payload = ev.data as Record<string, unknown>;
+          const attempt = typeof payload.attempt === "number" ? payload.attempt : undefined;
+          const maxRetries =
+            typeof payload.max_retries === "number" ? payload.max_retries : undefined;
+          const errorStatus =
+            typeof payload.error_status === "number" ? payload.error_status : undefined;
+          const errorCode = typeof payload.error === "string" ? payload.error : "api_retry";
+          const retryDelayMs =
+            typeof payload.retry_delay_ms === "number" ? payload.retry_delay_ms : undefined;
+
+          // Surface the first and final retry attempts so auth failures are visible
+          // immediately, without flooding the timeline on every backoff step.
+          const isFirstAttempt = attempt === 1;
+          const isFinalAttempt = !!(attempt && maxRetries && attempt >= maxRetries);
+          if (isFirstAttempt || isFinalAttempt) {
+            const statusPart = errorStatus ? `HTTP ${errorStatus}` : "HTTP unknown";
+            const attemptPart =
+              attempt && maxRetries ? `attempt ${attempt}/${maxRetries}` : "retrying";
+            const delayPart = retryDelayMs ? `next retry in ~${Math.round(retryDelayMs)}ms` : "";
+            const msg = [statusPart, errorCode, attemptPart, delayPart]
+              .filter((s) => s.length > 0)
+              .join(" · ");
+            const retryId = uuid();
+            this._pushTimeline(ctx, {
+              kind: "assistant",
+              id: retryId,
+              anchorId: retryId,
+              content: `\`[api_retry]\` ${msg}`,
+              ts: eventTs(ev),
+            });
+          }
+          break;
+        }
         if (rawText && (ev.source === "claude_stdout_text" || ev.source === "claude_stderr")) {
           const rawId = uuid();
           const entry: TimelineEntry = {

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -514,6 +514,44 @@ describe("SessionStore reducer", () => {
       });
       expect(store.timeline).toHaveLength(0);
     });
+
+    it("surfaces first api_retry auth error in timeline", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEvent({
+        type: "raw",
+        run_id: "run-1",
+        source: "claude_system_api_retry",
+        data: {
+          attempt: 1,
+          max_retries: 10,
+          error_status: 401,
+          error: "authentication_failed",
+          retry_delay_ms: 512.7,
+        } as unknown as Record<string, unknown>,
+      });
+      expect(store.timeline).toHaveLength(1);
+      expect(store.timeline[0].content).toContain("[api_retry]");
+      expect(store.timeline[0].content).toContain("HTTP 401");
+    });
+
+    it("suppresses intermediate api_retry spam", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEvent({
+        type: "raw",
+        run_id: "run-1",
+        source: "claude_system_api_retry",
+        data: {
+          attempt: 2,
+          max_retries: 10,
+          error_status: 401,
+          error: "authentication_failed",
+          retry_delay_ms: 1024,
+        } as unknown as Record<string, unknown>,
+      });
+      expect(store.timeline).toHaveLength(0);
+    });
   });
 
   // ── Reset ──

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1600,7 +1600,6 @@
     // Codex pipe mode doesn't need resize — terminal is output-only
   }
 
-
   // ── Chat scroll ──
 
   /** Threshold (px) for "near bottom" detection. Shared concept with TerminalPane. */
@@ -1715,7 +1714,6 @@
         window.dispatchEvent(new Event("ocv:runs-changed"));
         // Re-detect CLI version on new session (picks up external updates)
         loadCliVersionInfo();
-
       } else if (store.useStreamSession && !store.sessionAlive && store.run.session_id) {
         // Stopped stream session: atomic resume + send (message written to CLI stdin at spawn)
         dbg("chat", "auto-resume on send", {


### PR DESCRIPTION
Right now `claude_system_api_retry` events can be effectively invisible from the main session timeline.

  That makes auth and connectivity failures look like a hang, especially for cases like HTTP 401, even though the CLI is already retrying in the background.

  What this patch does:
  - surfaces the first retry event in the timeline
  - surfaces the final retry event in the timeline
  - suppresses intermediate retry events to avoid transcript spam
  - adds regression coverage for both the visible and suppressed cases

  Files:
  - `src/lib/stores/session-store.svelte.ts`
  - `src/lib/stores/session-store.test.ts`

  Note:
  - this branch also includes a small whitespace-only cleanup in `src/routes/chat/+page.svelte` so the frontend Prettier check passes on the current branch
  state
  - there is no intended behavioral change in `src/routes/chat/+page.svelte`

  Validation:
  - `npx vitest run src/lib/stores/session-store.test.ts`
  - `npm run format:check`