### PR TITLE
feat: sidebar idle/done status — distinguish running from waiting-for-input

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -679,6 +679,7 @@
   "history_statusFailed": "Failed",
   "history_statusStopped": "Stopped",
   "history_statusRunning": "Running",
+  "history_statusDone": "Done",
   "history_project": "Project",
   "history_tools": "Tools",
   "history_dateFrom": "From",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -679,6 +679,7 @@
   "history_statusFailed": "失败",
   "history_statusStopped": "已停止",
   "history_statusRunning": "运行中",
+  "history_statusDone": "已完成",
   "history_project": "项目",
   "history_tools": "工具",
   "history_dateFrom": "从",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.47"
+version = "0.1.50"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -679,6 +679,7 @@ impl SessionActor {
             uuid: Some(user_uuid),
         });
         self.emit_state("running", None, None, false);
+        self.persist_idle_running(RunStatus::Running);
 
         // Reply success to caller
         let _ = ticket.reply.send(Ok(()));
@@ -840,6 +841,7 @@ impl SessionActor {
             uuid: Some(user_uuid),
         });
         self.emit_state("running", None, None, false);
+        self.persist_idle_running(RunStatus::Running);
 
         let now = Instant::now();
         self.active_turn = Some(ActiveTurn {
@@ -1557,6 +1559,11 @@ impl SessionActor {
                         };
 
                     self.emit_state(&emit_state, *exit_code, emit_error.clone(), false);
+
+                    // Persist idle status to meta (uses normalized emit_state, not raw state)
+                    if emit_state == "idle" {
+                        self.persist_idle_running(RunStatus::Idle);
+                    }
 
                     // Persist result error on failed
                     if emit_state == "failed" {
@@ -2278,13 +2285,52 @@ impl SessionActor {
 
 // ── Helpers ──
 
+impl SessionActor {
+    /// Persist idle↔running status transition to meta + notify all windows.
+    /// Only allows Running→Idle and Idle→Running; other transitions are skipped.
+    fn persist_idle_running(&self, target: RunStatus) {
+        let meta = match storage::runs::get_run(&self.run_id) {
+            Some(m) => m,
+            None => return,
+        };
+        let allowed = matches!(
+            (&meta.status, &target),
+            (RunStatus::Running, RunStatus::Idle) | (RunStatus::Idle, RunStatus::Running)
+        );
+        if !allowed {
+            log::debug!(
+                "[actor] persist_idle_running skip: run={} from={:?} to={:?}",
+                self.run_id,
+                meta.status,
+                target
+            );
+            return;
+        }
+        let status_str = target.to_string();
+        if let Err(e) = storage::runs::update_status(&self.run_id, target, None, None) {
+            log::warn!(
+                "[actor] idle/running meta update failed: run={} target={} err={}",
+                self.run_id,
+                status_str,
+                e
+            );
+        } else {
+            self.emitter.emit_realtime(
+                "ocv:status-changed",
+                &serde_json::json!({"run_id": self.run_id.as_str(), "status": status_str}),
+                Some(&self.run_id),
+            );
+        }
+    }
+}
+
 fn map_state_to_run_status(state: &str) -> Option<RunStatus> {
     match state {
         "spawning" | "running" => Some(RunStatus::Running),
         "completed" => Some(RunStatus::Completed),
         "failed" => Some(RunStatus::Failed),
         "stopped" => Some(RunStatus::Stopped),
-        "idle" => None,
+        "idle" => Some(RunStatus::Idle),
         _ => None,
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -703,6 +703,21 @@ pub(crate) async fn start_session_impl(
             error: None,
         };
         emitter.persist_and_emit(&run_id, &idle_event);
+        // Persist idle status (allows Pending→Idle, not just Running→Idle)
+        let should_update = storage::runs::get_run(&run_id)
+            .map(|m| m.status != RunStatus::Idle)
+            .unwrap_or(false);
+        if should_update {
+            if let Err(e) = storage::runs::update_status(&run_id, RunStatus::Idle, None, None) {
+                log::warn!("[session] synthetic idle meta update failed: {}", e);
+            } else {
+                emitter.emit_realtime(
+                    "ocv:status-changed",
+                    &serde_json::json!({"run_id": run_id.as_str(), "status": "idle"}),
+                    Some(&run_id),
+                );
+            }
+        }
         log::debug!(
             "[session] resume/continue: emitted synthetic RunState(idle) for run_id={}",
             run_id

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -36,6 +36,8 @@ pub struct MemoryFileCandidate {
 pub enum RunStatus {
     Pending,
     Running,
+    /// Turn complete, waiting for user input. Session is still alive.
+    Idle,
     Completed,
     Failed,
     Stopped,
@@ -46,6 +48,7 @@ impl std::fmt::Display for RunStatus {
         match self {
             RunStatus::Pending => write!(f, "pending"),
             RunStatus::Running => write!(f, "running"),
+            RunStatus::Idle => write!(f, "idle"),
             RunStatus::Completed => write!(f, "completed"),
             RunStatus::Failed => write!(f, "failed"),
             RunStatus::Stopped => write!(f, "stopped"),

--- a/src-tauri/src/storage/runs.rs
+++ b/src-tauri/src/storage/runs.rs
@@ -297,9 +297,12 @@ pub fn list_runs() -> Vec<TaskRun> {
                     let events_path = entry.path().join("events.jsonl");
                     let (last_activity, msg_count, last_preview) = summarize_events(&events_path);
 
-                    // Skip runs with no events that aren't running/pending
+                    // Skip runs with no events that aren't active (running/pending/idle)
                     if msg_count == 0
-                        && !matches!(meta.status, RunStatus::Running | RunStatus::Pending)
+                        && !matches!(
+                            meta.status,
+                            RunStatus::Running | RunStatus::Pending | RunStatus::Idle
+                        )
                     {
                         // Still include if recent (within last hour)
                         if let Ok(started) = chrono::DateTime::parse_from_rfc3339(&meta.started_at)
@@ -454,7 +457,7 @@ pub fn reconcile_orphaned_runs() {
                 if let Ok(mut meta) = serde_json::from_str::<RunMeta>(&content) {
                     let mut dirty = false;
 
-                    if meta.status == RunStatus::Running {
+                    if matches!(meta.status, RunStatus::Running | RunStatus::Idle) {
                         meta.status = RunStatus::Stopped;
                         meta.ended_at = Some(now_iso());
                         meta.error_message = Some("Recovered after app restart".to_string());
@@ -499,7 +502,10 @@ pub fn soft_delete_runs(ids: &[String]) -> Result<u32, String> {
         if meta.deleted_at.is_some() {
             continue; // already deleted, skip
         }
-        if matches!(meta.status, RunStatus::Running | RunStatus::Pending) {
+        if matches!(
+            meta.status,
+            RunStatus::Running | RunStatus::Pending | RunStatus::Idle
+        ) {
             return Err(format!("Cannot delete: run {} is still active", id));
         }
         metas.push(meta);

--- a/src/lib/components/StatusBadge.svelte
+++ b/src/lib/components/StatusBadge.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { RunStatus } from "$lib/types";
 
-  type DisplayStatus = RunStatus | "waiting";
+  type DisplayStatus = Exclude<RunStatus, "idle"> | "waiting" | "done";
 
   let {
     status,
@@ -14,12 +14,17 @@
   } = $props();
 
   const displayStatus: DisplayStatus = $derived(
-    status === "running" && attention ? "waiting" : status,
+    (status === "running" || status === "idle") && attention
+      ? "waiting"
+      : status === "idle"
+        ? "done"
+        : status,
   );
 
   const colors: Record<DisplayStatus, string> = {
     pending: "bg-amber-500/20 text-amber-600 dark:text-amber-400",
     running: "bg-blue-500/20 text-blue-600 dark:text-blue-400",
+    done: "bg-cyan-500/20 text-cyan-600 dark:text-cyan-400",
     waiting: "bg-amber-500/20 text-amber-600 dark:text-amber-400",
     completed: "bg-emerald-500/20 text-emerald-600 dark:text-emerald-400",
     failed: "bg-red-500/20 text-red-600 dark:text-red-400",
@@ -29,6 +34,7 @@
   const dots: Record<DisplayStatus, string> = {
     pending: "bg-amber-500",
     running: "bg-blue-500 animate-pulse",
+    done: "bg-cyan-500",
     waiting: "bg-amber-500 animate-pulse",
     completed: "bg-emerald-500",
     failed: "bg-red-500",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,7 @@ export interface MemoryFileCandidate {
   exists: boolean;
 }
 
-export type RunStatus = "pending" | "running" | "completed" | "failed" | "stopped";
+export type RunStatus = "pending" | "running" | "idle" | "completed" | "failed" | "stopped";
 
 export type RunEventType = "system" | "stdout" | "stderr" | "command" | "user" | "assistant";
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -767,8 +767,24 @@
     }
     window.addEventListener("ocv:explorer-file-selected", onExplorerFileSelected);
 
+    // Listen for run status changes (idle↔running) from backend
+    let unlistenStatus: (() => void) | undefined;
+    transport
+      .listen("ocv:status-changed", (payload: unknown) => {
+        dbg("layout", "status-changed", payload);
+        loadRuns();
+      })
+      .then((fn) => {
+        if (destroyed) {
+          fn();
+          return;
+        }
+        unlistenStatus = fn;
+      });
+
     return () => {
       resizeCleanup?.(); // Clean up resize drag if component unmounts mid-drag
+      unlistenStatus?.();
       clearInterval(interval);
       clearInterval(teamPollInterval);
       if (debounceTimer) clearTimeout(debounceTimer);

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -997,7 +997,12 @@
     // Find most recent run with session_id for "Continue last session"
     try {
       const runs = await api.listRuns();
-      lastContinuableRun = runs.find((r) => r.session_id && r.status !== "running") ?? null;
+      lastContinuableRun =
+        runs.find(
+          (r) =>
+            r.session_id &&
+            (r.status === "completed" || r.status === "stopped" || r.status === "failed"),
+        ) ?? null;
     } catch (e) {
       dbgWarn("chat", "failed to load runs for continue:", e);
     }

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -60,6 +60,8 @@
         return "bg-yellow-500";
       case "running":
         return "bg-blue-500";
+      case "idle":
+        return "bg-emerald-500";
       default:
         return "bg-gray-400";
     }
@@ -79,7 +81,15 @@
         // Explicitly set or clear statuses based on pill selection
         statuses:
           activeStatusFilter !== "all"
-            ? [activeStatusFilter as "completed" | "failed" | "stopped" | "running" | "pending"]
+            ? [
+                activeStatusFilter as
+                  | "completed"
+                  | "failed"
+                  | "stopped"
+                  | "running"
+                  | "pending"
+                  | "idle",
+              ]
             : undefined,
       };
 
@@ -254,7 +264,7 @@
 
     <!-- Status pills -->
     <div class="mb-4 flex flex-wrap gap-2">
-      {#each [{ key: "all", label: t("history_allStatuses") }, { key: "completed", label: t("history_statusCompleted") }, { key: "failed", label: t("history_statusFailed") }, { key: "stopped", label: t("history_statusStopped") }, { key: "running", label: t("history_statusRunning") }] as pill}
+      {#each [{ key: "all", label: t("history_allStatuses") }, { key: "completed", label: t("history_statusCompleted") }, { key: "failed", label: t("history_statusFailed") }, { key: "stopped", label: t("history_statusStopped") }, { key: "running", label: t("history_statusRunning") }, { key: "idle", label: t("history_statusDone") }] as pill}
         <button
           onclick={() => onStatusFilter(pill.key)}
           class="rounded-full px-3 py-1 text-xs font-medium transition-colors {activeStatusFilter ===


### PR DESCRIPTION
## Summary

Users with multiple sessions can't tell which ones are done vs still running. This adds `RunStatus::Idle` to distinguish "AI finished, waiting for input" from "AI actively processing".

## Status Display

| Status | Color | Dot | Meaning |
|--------|-------|-----|---------|
| 🔵 running | blue | pulse | AI is processing |
| 🩵 done | cyan | static | AI finished, waiting for your input |
| 🟠 waiting | amber | pulse | Needs your action (permission/ask) |
| 🟢 completed | green | static | Session ended normally |
| 🔴 failed | red | static | Session errored |
| ⚪ stopped | gray | static | User stopped |

## Backend Changes

- `RunStatus::Idle` enum variant + Display impl
- `persist_idle_running()` helper — only allows Running↔Idle transitions, skips others
- 3 call sites: turn completion→Idle, user turn start→Running, ralph turn→Running
- Synthetic idle (resume without message) also persists Idle with guard
- `map_state_to_run_status("idle")` consistency patch
- 3 active-run guards updated (list_runs, reconcile_orphans, soft_delete)
- Emits `ocv:status-changed` Tauri event for multi-window sync

## Frontend Changes

- StatusBadge: `done` (cyan) with attention priority (`waiting > done`)
- Layout listens `ocv:status-changed` → refreshes sidebar (all windows)
- Chat: "Continue last session" excludes idle (still alive)
- History: idle color + Done filter pill
- i18n: `history_statusDone` (en + zh-CN)

## Test plan
- [x] `cargo test` — 408 tests pass
- [x] `cargo clippy` — 0 warnings
- [x] `npm test` — 1134 tests pass
- [x] `npm run build` — clean
- [ ] Manual: send message → AI replies → sidebar shows 🩵 done
- [ ] Manual: send again → sidebar shows 🔵 running → then 🩵 done
- [ ] Manual: permission prompt → sidebar shows 🟠 waiting
- [ ] Manual: multi-window — done status syncs across windows
- [ ] Manual: History page → Done filter pill works
- [ ] Manual: idle session not in "Continue last session"

🤖 Generated with [Claude Code](https://claude.com/claude-code)