### PR TITLE
feat: sync /team-onboarding command + fix effort selector

### DIFF
--- a/src/lib/components/SessionStatusBar.svelte
+++ b/src/lib/components/SessionStatusBar.svelte
@@ -341,9 +341,21 @@
           : "bg-emerald-500",
   );
 
-  let currentModelInfo = $derived(models.find((m) => m.value === model));
-  let effortLevels = $derived(currentModelInfo?.supportedEffortLevels ?? []);
-  let showEffort = $derived(currentModelInfo?.supportsEffort === true && effortLevels.length > 0);
+  // Find model info: exact match first, then fuzzy (model ID contains alias)
+  let currentModelInfo = $derived.by(() => {
+    const exact = models.find((m) => m.value === model);
+    if (exact) return exact;
+    return models.find((m) => model.includes(m.value) && m.value !== "default");
+  });
+  // Effort: always collect levels from any model that supports them (for always-visible UI)
+  let anyModelEffortLevels = $derived.by(() => {
+    const supporting = models.find(
+      (m) => m.supportsEffort === true && m.supportedEffortLevels?.length,
+    );
+    return supporting?.supportedEffortLevels ?? [];
+  });
+  let effortLevels = $derived(currentModelInfo?.supportedEffortLevels ?? anyModelEffortLevels);
+  let effortDisabled = $derived(currentModelInfo?.supportsEffort !== true);
 
   let modelLabel = $derived.by(() => {
     // Check platform models first, then CLI models
@@ -455,7 +467,7 @@
             onclick={toggleModelDropdown}
           >
             {modelLabel}
-            {#if showEffort && effort}
+            {#if !effortDisabled && effort}
               <span class="text-foreground/60 text-[10px]">{effort}</span>
             {/if}
             <svg
@@ -851,7 +863,7 @@
         </button>
       {/each}
     </div>
-    {#if showEffort && onEffortChange}
+    {#if effortLevels.length > 0 && onEffortChange}
       <!-- svelte-ignore a11y_no_static_element_interactions -->
       <div
         onkeydown={(e) => {
@@ -862,14 +874,21 @@
       >
         <div class="border-t mx-1 my-1"></div>
         <div class="px-3 py-2">
-          <div class="text-[10px] text-muted-foreground mb-1.5">{t("effort_label")}</div>
+          <div class="text-[10px] text-muted-foreground mb-1.5">
+            {t("effort_label")}{#if effortDisabled}<span class="ml-1 opacity-50"
+                >— {currentModelInfo?.displayName ?? model} not supported</span
+              >{/if}
+          </div>
           <div class="flex gap-1">
             {#each effortLevels as level}
               <button
                 class="flex-1 rounded px-2 py-1 text-xs transition-colors
-                  {effort === level
-                  ? 'bg-primary text-primary-foreground font-medium'
-                  : 'bg-muted/50 text-muted-foreground hover:bg-accent'}"
+                  {effortDisabled
+                  ? 'bg-muted/30 text-muted-foreground/40 cursor-not-allowed'
+                  : effort === level
+                    ? 'bg-primary text-primary-foreground font-medium'
+                    : 'bg-muted/50 text-muted-foreground hover:bg-accent'}"
+                disabled={effortDisabled}
                 onclick={() => onEffortChange(level)}>{level}</button
               >
             {/each}

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -48,6 +48,7 @@ const KNOWN_COMMAND_DESCRIPTIONS: Record<string, string> = {
   "add-dir": "Add a directory to the workspace",
   btw: "Ask a side question without interrupting the current task",
   loop: "Run a prompt or slash command on a recurring interval",
+  "team-onboarding": "Help teammates ramp on Claude Code with a guide from your usage",
 };
 
 // ── Fallback argumentHints for known CLI commands ──
@@ -502,6 +503,8 @@ const COMMAND_CATEGORY_MAP: Record<string, SlashCategory> = {
   plugin: "config",
   ide: "config",
   "add-dir": "config",
+  // Coding (continued)
+  "team-onboarding": "coding",
   // Help
   help: "help",
   doctor: "help",


### PR DESCRIPTION
## Summary
- Add `/team-onboarding` (CLI v2.1.101) to `KNOWN_COMMAND_DESCRIPTIONS` and `COMMAND_CATEGORY_MAP`
- Fix effort selector disappearing: `currentModelInfo` used strict match (`m.value === model`) but `store.model` holds full model ID (e.g. `claude-sonnet-4-6`) while models list uses aliases (`sonnet`). Now uses fuzzy match consistent with `modelLabel` logic.
- Effort section always visible in model dropdown: shows disabled state for models that don't support effort (e.g. Haiku) instead of hiding entirely, so users always know the feature exists.

## Test plan
- [ ] Open model dropdown on a session using Opus/Sonnet — effort buttons should be active
- [ ] Switch to Haiku — effort buttons should appear grayed out with "not supported" hint
- [ ] Type `/team-onboarding` in slash menu — should appear under Coding category with description