### PR TITLE
feat: sync CLI 2.1.98–2.1.112

### DIFF
--- a/src-tauri/src/agent/claude_protocol.rs
+++ b/src-tauri/src/agent/claude_protocol.rs
@@ -367,6 +367,12 @@ impl ProtocolState {
                         skills.len()
                     );
 
+                    let plugin_errors: Vec<Value> = raw
+                        .get("plugin_errors")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+
                     events.push(BusEvent::SessionInit {
                         run_id: run_id.to_string(),
                         session_id,
@@ -382,6 +388,7 @@ impl ProtocolState {
                         agents,
                         skills,
                         plugins,
+                        plugin_errors,
                         fast_mode_state,
                     });
                     // Only emit RunState on the FIRST system/init:

--- a/src-tauri/src/agent/control.rs
+++ b/src-tauri/src/agent/control.rs
@@ -297,12 +297,13 @@ pub fn fallback_cli_info() -> CliInfo {
             CliModelInfo {
                 value: "opus".to_string(),
                 display_name: "Opus".to_string(),
-                description: "Opus 4.6".to_string(),
+                description: "Opus 4.7".to_string(),
                 supports_effort: Some(true),
                 supported_effort_levels: Some(vec![
                     "low".into(),
                     "medium".into(),
                     "high".into(),
+                    "xhigh".into(),
                     "max".into(),
                 ]),
                 supports_adaptive_thinking: Some(true),
@@ -340,6 +341,11 @@ mod tests {
             .unwrap()
             .contains(&"medium".to_string()));
         assert_eq!(find("opus").supports_effort, Some(true));
+        assert!(find("opus")
+            .supported_effort_levels
+            .as_ref()
+            .unwrap()
+            .contains(&"xhigh".to_string()));
         assert_eq!(find("haiku").supports_effort, Some(false));
         assert!(find("haiku").supported_effort_levels.is_none());
     }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1002,6 +1002,8 @@ pub enum BusEvent {
         skills: Vec<String>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         plugins: Vec<Value>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        plugin_errors: Vec<Value>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         fast_mode_state: Option<String>,
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -839,6 +839,7 @@ export type BusEvent =
       agents?: string[];
       skills?: string[];
       plugins?: unknown[];
+      plugin_errors?: unknown[];
       fast_mode_state?: string;
     }
   | {
@@ -1148,6 +1149,7 @@ export type HookEventType =
   | "InstructionsLoaded"
   | "Elicitation"
   | "ElicitationResult"
+  | "PreCompact"
   | "PostCompact"
   | "StopFailure"
   | "TaskCreated"

--- a/src/lib/utils/hook-helpers.ts
+++ b/src/lib/utils/hook-helpers.ts
@@ -29,6 +29,7 @@ export const HOOK_EVENT_TYPES: readonly HookEventType[] = [
   "InstructionsLoaded",
   "Elicitation",
   "ElicitationResult",
+  "PreCompact",
   "PostCompact",
   "StopFailure",
   "TaskCreated",

--- a/src/lib/utils/tool-colors.ts
+++ b/src/lib/utils/tool-colors.ts
@@ -186,6 +186,12 @@ const toolColors: Record<string, ToolColor> = {
     icon: "M5 3l7 9-7 9M14 21h7",
     border: "border-blue-500/30",
   },
+  Monitor: {
+    bg: "bg-cyan-500/10",
+    text: "text-cyan-600 dark:text-cyan-400",
+    icon: "M12 20v-6M6 20V10M18 20V4",
+    border: "border-cyan-500/30",
+  },
 };
 
 const defaultToolColor: ToolColor = {

--- a/src/lib/utils/tool-rendering.ts
+++ b/src/lib/utils/tool-rendering.ts
@@ -147,6 +147,8 @@ const FRIENDLY_TOOL_NAMES: Record<string, string> = {
   WebSearch: "Search web",
   Task: "Run sub-agent",
   NotebookEdit: "Edit notebook",
+  PowerShell: "Run PowerShell",
+  Monitor: "Monitor events",
 };
 
 /** Map a tool name to a human-readable description. Falls back to the original name. */


### PR DESCRIPTION
## Summary
- **config**: Add `xhigh` effort level for Opus 4.7 (sits between `high` and `max`) — fallback model list + test
- **hook**: Add `PreCompact` hook event type (v2.1.105) — `types.ts` HookEventType + `hook-helpers.ts` ALL_HOOK_EVENTS
- **sdk**: Add `plugin_errors` field to `session_init` event (v2.1.112) — `types.ts` + `models.rs` serde pair + protocol parser
- **tool**: Add `Monitor` tool (v2.1.98) — `tool-colors.ts` + `friendlyToolName`
- **tool**: Add `PowerShell` friendly name — already had `tool-colors.ts`, added "Run PowerShell" to `FRIENDLY_TOOL_NAMES`

## Test plan
- [ ] `npm test` — 1134 tests pass (including keybindings)
- [ ] `cargo clippy -- -D warnings` — 0 errors
- [ ] `scripts/check-serde-sync.sh` — serde renames synced
- [ ] Opus model shows `xhigh` in effort selector dropdown