### PR TITLE
fix: deduplicate MCP servers across all entry points

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -34,6 +34,7 @@ import { updateInstalledVersion, getCliCommands } from "./cli-info.svelte";
 import * as snapshotCache from "$lib/utils/snapshot-cache";
 import { getTransport } from "$lib/transport";
 import { getAgentFeatures, type AgentFeatures } from "$lib/utils/agent-features";
+import { dedupeMcpServersByName } from "$lib/utils/mcp";
 
 // ── CLI permission mode normalization ──
 // CLI may return different names for the same mode across versions.
@@ -1365,7 +1366,7 @@ export class SessionStore {
       this.fastModeState = (obj.fastModeState as string) ?? "";
       this.apiKeySource = (obj.apiKeySource as string) ?? "";
       this.sessionCommands = (obj.sessionCommands ?? []) as CliCommand[];
-      this.mcpServers = (obj.mcpServers ?? []) as McpServerInfo[];
+      this.mcpServers = dedupeMcpServersByName((obj.mcpServers ?? []) as McpServerInfo[]);
       this.sessionTools = (obj.sessionTools ?? []) as string[];
       this.availableAgents = (obj.availableAgents ?? []) as string[];
       this.availableSkills = (obj.availableSkills ?? []) as string[];
@@ -2132,12 +2133,7 @@ export class SessionStore {
 
   /** Update MCP servers (e.g. after getMcpStatus refresh). Deduplicates by name. */
   updateMcpServers(servers: McpServerInfo[]): void {
-    const seen = new Set<string>();
-    this.mcpServers = servers.filter((s) => {
-      if (seen.has(s.name)) return false;
-      seen.add(s.name);
-      return true;
-    });
+    this.mcpServers = dedupeMcpServersByName(servers);
   }
 
   /** Resolve an AskUserQuestion tool: transition from ask_pending → success. */
@@ -2362,12 +2358,7 @@ export class SessionStore {
         }
         // Store MCP servers (per-session state, deduplicate by name)
         if (ev.mcp_servers && ev.mcp_servers.length > 0) {
-          const seen = new Set<string>();
-          this.mcpServers = ev.mcp_servers.filter((s) => {
-            if (seen.has(s.name)) return false;
-            seen.add(s.name);
-            return true;
-          });
+          this.mcpServers = dedupeMcpServersByName(ev.mcp_servers);
         }
         // Store CLI verbose fields
         if (ev.claude_code_version) {

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -2130,9 +2130,14 @@ export class SessionStore {
     this._clearSpawnTimeout();
   }
 
-  /** Update MCP servers (e.g. after getMcpStatus refresh). */
+  /** Update MCP servers (e.g. after getMcpStatus refresh). Deduplicates by name. */
   updateMcpServers(servers: McpServerInfo[]): void {
-    this.mcpServers = servers;
+    const seen = new Set<string>();
+    this.mcpServers = servers.filter((s) => {
+      if (seen.has(s.name)) return false;
+      seen.add(s.name);
+      return true;
+    });
   }
 
   /** Resolve an AskUserQuestion tool: transition from ask_pending → success. */
@@ -2355,9 +2360,14 @@ export class SessionStore {
             typeof c === "string" ? { name: c, description: "", aliases: [] } : (c as CliCommand),
           );
         }
-        // Store MCP servers (per-session state)
+        // Store MCP servers (per-session state, deduplicate by name)
         if (ev.mcp_servers && ev.mcp_servers.length > 0) {
-          this.mcpServers = ev.mcp_servers;
+          const seen = new Set<string>();
+          this.mcpServers = ev.mcp_servers.filter((s) => {
+            if (seen.has(s.name)) return false;
+            seen.add(s.name);
+            return true;
+          });
         }
         // Store CLI verbose fields
         if (ev.claude_code_version) {

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -3143,6 +3143,48 @@ describe("SessionStore reducer", () => {
       expect(store.mcpServers[0].name).toBe("new1");
       expect(store.mcpServers[1].name).toBe("new2");
     });
+
+    // CLI may return the same server from user/project/local scopes as
+    // separate entries — UI collapses them to one row, first occurrence wins.
+    it("deduplicates mcp_servers from session_init by name", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      const events: BusEvent[] = [
+        {
+          type: "session_init",
+          run_id: "run-1",
+          session_id: "sess-1",
+          model: "claude-opus-4-6",
+          tools: ["Bash"],
+          cwd: "/",
+          mcp_servers: [
+            { name: "context7", status: "connected", scope: "user" },
+            { name: "context7", status: "connected", scope: "project" },
+            { name: "postgres", status: "connected" },
+            { name: "context7", status: "failed", scope: "local" },
+          ],
+        },
+      ];
+      store.applyEventBatch(events as BusEvent[]);
+
+      expect(store.mcpServers).toHaveLength(2);
+      expect(store.mcpServers[0].name).toBe("context7");
+      expect(store.mcpServers[0].scope).toBe("user");
+      expect(store.mcpServers[1].name).toBe("postgres");
+    });
+
+    it("updateMcpServers deduplicates by name", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.updateMcpServers([
+        { name: "context7", status: "connected" },
+        { name: "context7", status: "connected" },
+        { name: "github", status: "connected" },
+      ]);
+      expect(store.mcpServers).toHaveLength(2);
+      expect(store.mcpServers[0].name).toBe("context7");
+      expect(store.mcpServers[1].name).toBe("github");
+    });
   });
 
   // ── canResumeRun ──
@@ -3900,6 +3942,33 @@ describe("SessionStore reducer", () => {
         expect(ok).toBe(true);
         expect(store2.cliVersion).toBe("1.2.3-sentinel");
         expect(store2.sessionCwd).toBe("/sentinel/path");
+      });
+    });
+
+    describe("_tryApplySnapshot mcp dedup", () => {
+      // Snapshots written before commit 550c8f4 may contain duplicate
+      // mcpServers entries. Restoring must dedupe so old snapshots don't
+      // continue to show 10 rows when CLI returned 3 distinct names.
+      it("deduplicates mcpServers when restoring legacy snapshot", () => {
+        const store1 = new SessionStore();
+        const body = JSON.stringify({
+          timeline: [],
+          usage: { inputTokens: 0 },
+          mcpServers: [
+            { name: "context7", status: "connected", scope: "user" },
+            { name: "context7", status: "connected", scope: "project" },
+            { name: "github", status: "connected" },
+            { name: "context7", status: "connected", scope: "local" },
+          ],
+        });
+        const ok = (
+          store1 as unknown as { _tryApplySnapshot(b: string): boolean }
+        )._tryApplySnapshot(body);
+        expect(ok).toBe(true);
+        expect(store1.mcpServers).toHaveLength(2);
+        expect(store1.mcpServers[0].name).toBe("context7");
+        expect(store1.mcpServers[0].scope).toBe("user");
+        expect(store1.mcpServers[1].name).toBe("github");
       });
     });
 

--- a/src/lib/utils/__tests__/mcp.test.ts
+++ b/src/lib/utils/__tests__/mcp.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { dedupeMcpServersByName, parseServersFromResponse } from "../mcp";
+
+describe("dedupeMcpServersByName", () => {
+  it("removes duplicates while preserving first occurrence", () => {
+    const result = dedupeMcpServersByName([
+      { name: "context7", status: "connected", scope: "user" },
+      { name: "context7", status: "failed", scope: "project" },
+      { name: "github", status: "connected" },
+      { name: "context7", status: "connected", scope: "local" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ name: "context7", status: "connected", scope: "user" });
+    expect(result[1]).toEqual({ name: "github", status: "connected" });
+  });
+
+  it("returns empty array unchanged", () => {
+    expect(dedupeMcpServersByName([])).toEqual([]);
+  });
+
+  it("returns single-item list unchanged", () => {
+    const input = [{ name: "postgres", status: "connected" }];
+    expect(dedupeMcpServersByName(input)).toEqual(input);
+  });
+});
+
+describe("parseServersFromResponse", () => {
+  it("dedupes parsed servers by name", () => {
+    const result = parseServersFromResponse({
+      servers: [
+        { name: "context7", status: "connected", scope: "user" },
+        { name: "context7", status: "connected", scope: "project" },
+        { name: "github", status: "failed" },
+      ],
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe("context7");
+    expect(result[1].name).toBe("github");
+  });
+
+  it("returns empty array for missing arr", () => {
+    expect(parseServersFromResponse({})).toEqual([]);
+  });
+});

--- a/src/lib/utils/mcp.ts
+++ b/src/lib/utils/mcp.ts
@@ -33,18 +33,31 @@ export function statusLabel(status: string): string {
   }
 }
 
+/** Deduplicate MCP servers by name. CLI may report the same server from
+ *  multiple scopes (user/project/local) as separate entries; UI treats them
+ *  as a single logical server. First occurrence wins. */
+export function dedupeMcpServersByName(servers: McpServerInfo[]): McpServerInfo[] {
+  const seen = new Set<string>();
+  return servers.filter((s) => {
+    if (seen.has(s.name)) return false;
+    seen.add(s.name);
+    return true;
+  });
+}
+
 export function parseServersFromResponse(response: Record<string, unknown>): McpServerInfo[] {
   // The response shape from get_mcp_status is not fully documented.
   // Try common field names defensively.
   const arr = (response.servers ?? response.mcp_servers ?? response.data) as unknown;
   if (Array.isArray(arr)) {
-    return arr.map((s: Record<string, unknown>) => ({
+    const parsed = arr.map((s: Record<string, unknown>) => ({
       name: String(s.name ?? "unknown"),
       status: String(s.status ?? "pending"),
       server_type: (s.type as string | undefined) ?? (s.server_type as string | undefined),
       scope: s.scope as string | undefined,
       error: s.error as string | undefined,
     }));
+    return dedupeMcpServersByName(parsed);
   }
   return [];
 }

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -654,7 +654,7 @@
             disabledSet.has(s.name) && s.status !== "disabled" ? { ...s, status: "disabled" } : s,
           );
           if (patched.some((s, i) => s !== store.mcpServers[i])) {
-            store.mcpServers = patched;
+            store.updateMcpServers(patched);
             dbg("chat", "patched MCP disabled state", { disabledNames });
           }
         }
@@ -3631,7 +3631,7 @@
           sessionAlive={store.sessionAlive}
           onClose={() => (mcpPanelOpen = false)}
           onServersUpdate={(servers) => {
-            store.mcpServers = servers;
+            store.updateMcpServers(servers);
           }}
         />
       </div>


### PR DESCRIPTION
## Summary

CLI's `system/init.mcp_servers` may include the same MCP server from user/project/local scopes as separate entries. The UI (status bar count, MCP panel) was treating them as distinct, so a single registered `context7` could render as 10 rows.

This PR consolidates dedupe into a single `dedupeMcpServersByName()` helper routed through all five ingestion paths:

- `session_init` reducer
- `updateMcpServers()` (post-refresh)
- snapshot restore (closes legacy snapshots that persisted duplicates)
- `parseServersFromResponse()` (source-side for MCP status refresh)
- chat/+page.svelte: MCP panel `onServersUpdate` callback + disabled-state patch both route through `store.updateMcpServers()`

## Commits

1. `6ccd578` fix: deduplicate MCP servers by name (#93) — initial fix at 2 ingestion points
2. `da56e7f` fix: centralize MCP server dedupe across all entry points — extends to remaining 3 paths + adds tests

## Test plan

- [x] `npm test` — 1142 tests pass, new tests cover: `dedupeMcpServersByName` helper, `parseServersFromResponse` dedup, `session_init` duplicates, `updateMcpServers` duplicates, snapshot restore with legacy duplicate state
- [x] `npm run lint:fix` / `format:check`
- [x] `npm run build`
- [ ] Manual: open a session with MCP server configured in both user + project scope → status bar shows 1 count, MCP panel shows 1 row
- [ ] Manual: click MCP refresh → still 1 row
- [ ] Manual: load a legacy session with persisted duplicate snapshot → 1 row