### PR TITLE
fix: ExitPlanMode 'clear context + auto-accept' unusable after approval (#90)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -491,6 +491,7 @@ pub(crate) async fn start_session_impl(
     initial_message: Option<String>,
     attachments: Option<Vec<AttachmentData>>,
     platform_id: Option<String>,
+    permission_mode_override: Option<String>,
 ) -> Result<(), String> {
     let _guard = spawn_locks.acquire(&run_id).await;
     let session_mode = mode.unwrap_or_default();
@@ -527,6 +528,18 @@ pub(crate) async fn start_session_impl(
     let user_settings = storage::settings::get_user_settings();
     let mut adapter_settings =
         adapter::build_adapter_settings(&agent_settings, &user_settings, meta.model.clone());
+
+    // 2a. Apply per-session permission_mode override (e.g. ExitPlanMode → acceptEdits).
+    //     Session-scoped: does not touch persisted user settings. Must run BEFORE spawn
+    //     so the CLI's --permission-mode arg reflects the override for the first turn.
+    if let Some(ref override_mode) = permission_mode_override {
+        log::debug!(
+            "[session] permission_mode override: {:?} → {:?}",
+            adapter_settings.permission_mode,
+            override_mode
+        );
+        adapter_settings.permission_mode = Some(override_mode.clone());
+    }
 
     // 2b. Resolve remote host from RunMeta (audit #2: single truth source)
     let remote = resolve_remote_host(&meta)?;
@@ -741,6 +754,7 @@ pub async fn start_session(
     initial_message: Option<String>,
     attachments: Option<Vec<AttachmentData>>,
     platform_id: Option<String>,
+    permission_mode_override: Option<String>,
 ) -> Result<(), String> {
     start_session_impl(
         emitter.inner(),
@@ -753,6 +767,7 @@ pub async fn start_session(
         initial_message,
         attachments,
         platform_id,
+        permission_mode_override,
     )
     .await
 }

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -792,6 +792,10 @@ pub async fn dispatch_command(
                 .get("platform_id")
                 .and_then(|v| v.as_str())
                 .map(String::from);
+            let permission_mode_override = params
+                .get("permission_mode_override")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             crate::commands::session::start_session_impl(
                 &state.emitter,
                 &state.sessions,
@@ -803,6 +807,7 @@ pub async fn dispatch_command(
                 initial_message,
                 attachments,
                 platform_id,
+                permission_mode_override,
             )
             .await?;
             Ok(json!(true))

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -424,6 +424,7 @@ export async function startSession(
   initialMessage?: string,
   attachments?: Array<{ content_base64: string; media_type: string; filename: string }>,
   platformId?: string,
+  permissionModeOverride?: string,
 ): Promise<void> {
   dbg("api", "startSession", {
     runId,
@@ -432,6 +433,7 @@ export async function startSession(
     hasMessage: !!initialMessage,
     attachments: attachments?.length ?? 0,
     platformId,
+    permissionModeOverride,
   });
   return invoke("start_session", {
     runId,
@@ -440,6 +442,7 @@ export async function startSession(
     initialMessage,
     attachments: attachments ?? null,
     platformId: platformId ?? null,
+    permissionModeOverride: permissionModeOverride ?? null,
   });
 }
 

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -1646,8 +1646,16 @@ export class SessionStore {
     }
   }
 
-  /** Create a new run and start the session. Returns the run ID. */
-  async startSession(prompt: string, cwd: string, attachments: Attachment[]): Promise<string> {
+  /** Create a new run and start the session. Returns the run ID.
+   *  permissionModeOverride: session-scoped permission mode (CLI name, e.g. "acceptEdits").
+   *  When set, takes priority over persisted user settings for this spawn only —
+   *  used by ExitPlanMode "clear context + auto-accept" flow. */
+  async startSession(
+    prompt: string,
+    cwd: string,
+    attachments: Attachment[],
+    permissionModeOverride?: string,
+  ): Promise<string> {
     this.error = "";
     this._setPhase("spawning");
 
@@ -1677,7 +1685,13 @@ export class SessionStore {
           auto: "auto",
           dont_ask: "dontAsk",
         };
-        if (freshSettings.permission_mode) {
+        if (permissionModeOverride) {
+          // Session-scoped override wins — sync UI state to match what backend will spawn with.
+          if (permissionModeOverride !== this.permissionMode) {
+            this.permissionMode = permissionModeOverride;
+            this.permissionModeSetByUser = true;
+          }
+        } else if (freshSettings.permission_mode) {
           const freshPerm =
             APP_TO_CLI[freshSettings.permission_mode] ?? freshSettings.permission_mode;
           if (freshPerm !== this.permissionMode) {
@@ -1726,6 +1740,7 @@ export class SessionStore {
           undefined,
           backendAtt,
           this.platformId || undefined,
+          permissionModeOverride,
         );
         dbg("store", "startSession resolved");
         // phase will be set by run_state bus event

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -3285,11 +3285,13 @@
       // 5. Navigate to fresh chat URL, then start a new session inline.
       //    Using sessionStorage + onMount doesn't work: /chat?run=X → /chat
       //    is the same route component and onMount won't re-fire.
+      //    permissionModeOverride threads through api.startSession → backend
+      //    adapter_settings, so the CLI spawns with --permission-mode acceptEdits
+      //    and the first "Implement..." turn runs in auto-accept (not plan).
       const planPrompt = `Implement the following plan:\n\n${planContent}`;
       await goto("/chat", { replaceState: true });
       await tick(); // let runId effect run loadRun("") → store.reset()
-      store.permissionMode = "acceptEdits"; // applied at spawn time for the new run
-      const newRunId = await store.startSession(planPrompt, cwd, []);
+      const newRunId = await store.startSession(planPrompt, cwd, [], "acceptEdits");
       await goto(`/chat?run=${newRunId}`, { replaceState: true });
       dbg("chat", "ExitPlanMode: new session started", { newRunId });
     } catch (e) {

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1099,36 +1099,6 @@
     return () => window.removeEventListener("ocv:runs-changed", onRunsChanged);
   });
 
-  // Check for pending plan from ExitPlanMode "clear context"
-  onMount(() => {
-    const pendingPlan = sessionStorage.getItem("ocv:pending-plan-prompt");
-    const pendingCwd = sessionStorage.getItem("ocv:pending-plan-cwd");
-    if (pendingPlan && !store.run) {
-      sessionStorage.removeItem("ocv:pending-plan-prompt");
-      sessionStorage.removeItem("ocv:pending-plan-cwd");
-      const cwd = pendingCwd || localStorage.getItem("ocv:project-cwd") || "";
-      dbg("chat", "auto-sending pending plan from ExitPlanMode clear context");
-      // Use tick to ensure mount is complete
-      tick().then(async () => {
-        try {
-          const newRunId = await store.startSession(pendingPlan, cwd, []);
-          goto(`/chat?run=${newRunId}`);
-          // Set permission mode to acceptEdits in new session
-          // Wait for session to initialize first
-          setTimeout(async () => {
-            if (store.run) {
-              await api.setPermissionMode(store.run.id, "acceptEdits");
-              store.permissionMode = "acceptEdits";
-              dbg("chat", "new session permission mode set to acceptEdits");
-            }
-          }, 2000);
-        } catch (e) {
-          dbgWarn("chat", "auto-send pending plan failed:", e);
-        }
-      });
-    }
-  });
-
   // Start middleware + register handlers
   onMount(() => {
     let destroyed = false;
@@ -3312,12 +3282,16 @@
       await api.stopSession(runId);
       dbg("chat", "ExitPlanMode: session stopped");
 
-      // 5. Navigate to fresh chat and schedule plan sending
+      // 5. Navigate to fresh chat URL, then start a new session inline.
+      //    Using sessionStorage + onMount doesn't work: /chat?run=X → /chat
+      //    is the same route component and onMount won't re-fire.
       const planPrompt = `Implement the following plan:\n\n${planContent}`;
-      sessionStorage.setItem("ocv:pending-plan-prompt", planPrompt);
-      sessionStorage.setItem("ocv:pending-plan-cwd", cwd);
-      goto("/chat");
-      // The fresh chat page mount will detect sessionStorage items and auto-send
+      await goto("/chat", { replaceState: true });
+      await tick(); // let runId effect run loadRun("") → store.reset()
+      store.permissionMode = "acceptEdits"; // applied at spawn time for the new run
+      const newRunId = await store.startSession(planPrompt, cwd, []);
+      await goto(`/chat?run=${newRunId}`, { replaceState: true });
+      dbg("chat", "ExitPlanMode: new session started", { newRunId });
     } catch (e) {
       dbgWarn("chat", "ExitPlanMode clear context failed:", e);
       store.pendingClearContextPlan = null;


### PR DESCRIPTION
## Summary

Closes #90 — After user clicks "清除上下文并自动接受编辑" on the ExitPlanMode approval card, the old session ended but the new session never started: conversation showed as "done" and input was unusable.

Two independent bugs were stacking:

1. **Cross-lifecycle handoff didn't fire** — the plan prompt was written to `sessionStorage`, then `goto("/chat")` was expected to trigger an `onMount` handler that reads it and calls `startSession`. But `/chat?run=X` → `/chat` is the same route component; SvelteKit reuses the instance and `onMount` never re-fires. Plan prompt stayed orphaned.

2. **Permission mode override was frontend-only** — setting `store.permissionMode = "acceptEdits"` never reached the backend. Backend reads `user_settings.permission_mode` directly in `start_session_impl` and builds `--permission-mode <persisted>`; whatever the user had persisted (likely `plan`) won the spawn. The CLI would then re-plan instead of executing on the first turn.

## Fix

1. Inline the handoff inside `handleExitPlanClearContext`: stop old → `goto("/chat")` → `tick()` (lets `loadRun("")` run via runId effect → reset) → `startSession(planPrompt, cwd, [], "acceptEdits")` → goto new run URL.
2. Add session-scoped `permission_mode_override: Option<String>` through `api.startSession` → `start_session_impl` → `adapter_settings.permission_mode`. Applied after `build_adapter_settings` and before spawn, so `--permission-mode acceptEdits` is on the CLI args for the first turn. User settings are never touched.

## Commits

1. `af30745` fix: do ExitPlanMode clear-context handoff inline (#90)
2. `87c9da1` fix: thread session-scoped permission_mode override through start_session

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo fmt`
- [x] `npm test` — all passing
- [x] `npm run lint:fix` / `format:check`
- [x] `npm run build`
- [ ] Manual: plan a task → approve "Clear context + auto-accept" → verify new session starts, first turn executes (not re-plans), acceptEdits mode visible in status bar
- [ ] Manual: user setting persisted as `ask` → same flow → new session still spawns in acceptEdits; persisted setting unchanged after flow completes