### PR TITLE
fix: add CJK font fallback for Chinese display on Linux/WSL2

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,8 @@
           "xclip | xsel"
         ],
         "recommends": [
-          "wl-clipboard"
+          "wl-clipboard",
+          "fonts-noto-cjk | fonts-wqy-microhei"
         ]
       }
     },

--- a/src/app.css
+++ b/src/app.css
@@ -111,7 +111,9 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-family:
+      -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB",
+      "Microsoft YaHei", "Noto Sans CJK SC", "Source Han Sans SC", "WenQuanYi Micro Hei", sans-serif;
   }
 }
 

--- a/src/app.html
+++ b/src/app.html
@@ -38,7 +38,9 @@
         border-top-color: hsl(38 86% 64%);
       }
       #app-splash .hint {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Microsoft YaHei",
+          "Noto Sans CJK SC", "WenQuanYi Micro Hei", sans-serif;
         font-size: 13px;
         color: hsl(0 0% 54.5%);
       }


### PR DESCRIPTION
## Summary

- WSL2 / Linux 用户报告聊天输入框无法显示中文、导入的历史中文渲染为空白。根因是 `body` / splash 字体栈只有拉丁字体（`-apple-system`、`Segoe UI`、`Roboto`），WebKitGTK 在缺少 CJK fallback 的情况下找不到中文字形就直接放弃渲染。
- 在 `src/app.css` body 和 `src/app.html` splash hint 字体栈里追加 macOS / Windows / Linux 三平台的 native CJK 字体（PingFang SC、Hiragino Sans GB、Microsoft YaHei、Noto Sans CJK SC、Source Han Sans SC、WenQuanYi Micro Hei）。WebKit per-character fallback 让拉丁字符仍走 Latin 字体、CJK 字符落到对应平台的中文字体。
- 在 `src-tauri/tauri.conf.json` 的 deb `recommends` 加入 `fonts-noto-cjk | fonts-wqy-microhei`，让新装 Linux 用户通过 apt 自动安装中文字体。

## Out of Scope

- WSLg IME 转发问题（输入法本身不工作）属于系统层 / WebKitGTK 自身缺陷，应通过引导用户优先使用 Windows 原生构建解决，本 PR 不处理。
- `cli_sessions.rs` 导入 user message 只识别字符串 content、忽略 array text block 的 bug 单独分支处理。

## Test plan

- [x] `npm run lint:fix` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm test` — 1142 tests passed
- [x] `npm run build` — frontend build OK
- [ ] 手测：在缺 CJK 字体的 Linux/WSL2 环境装 deb，验证 recommends 自动安装 fonts-noto-cjk 后中文正常显示
- [ ] 手测：在已装 PingFang/YaHei 的 macOS/Windows 环境验证拉丁字符仍走原 Latin 字体（无回归）