### PR TITLE
feat: support updatedInput on hook callback response (CLI v2.1.85)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1406,17 +1406,26 @@ pub async fn respond_hook_callback(
     run_id: String,
     request_id: String,
     decision: String, // "allow", "deny", or "defer" (defer pauses tool call in headless sessions)
+    // PreToolUse hooks can rewrite tool input alongside `decision: "allow"` (CLI v2.1.85+).
+    // Only honored when decision == "allow"; CLI ignores it for deny/defer.
+    updated_input: Option<serde_json::Value>,
 ) -> Result<(), String> {
     log::debug!(
-        "[session] respond_hook_callback: run_id={}, req_id={}, decision={}",
+        "[session] respond_hook_callback: run_id={}, req_id={}, decision={}, has_updated_input={}",
         run_id,
         request_id,
-        decision
+        decision,
+        updated_input.is_some(),
     );
 
     let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
 
-    let response = serde_json::json!({ "decision": decision });
+    let mut response = serde_json::json!({ "decision": decision });
+    if decision == "allow" {
+        if let Some(input) = updated_input {
+            response["updatedInput"] = input;
+        }
+    }
 
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     cmd_tx

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -992,11 +992,13 @@ pub async fn dispatch_command(
             let run_id = extract_str(&params, "run_id")?;
             let request_id = extract_str(&params, "request_id")?;
             let decision = extract_str(&params, "decision")?;
+            let updated_input = params.get("updated_input").cloned();
             log::debug!(
-                "[dispatch] respond_hook_callback: run_id={}, req_id={}, decision={}",
+                "[dispatch] respond_hook_callback: run_id={}, req_id={}, decision={}, has_updated_input={}",
                 run_id,
                 request_id,
-                decision
+                decision,
+                updated_input.is_some(),
             );
             let cmd_tx = {
                 let map = state.sessions.lock().await;
@@ -1004,7 +1006,12 @@ pub async fn dispatch_command(
                     .map(|h| h.cmd_tx.clone())
                     .ok_or_else(|| format!("Session {} not found", run_id))?
             };
-            let response = json!({ "decision": decision });
+            let mut response = json!({ "decision": decision });
+            if decision == "allow" {
+                if let Some(input) = updated_input {
+                    response["updatedInput"] = input;
+                }
+            }
             let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
             cmd_tx
                 .send(ActorCommand::RespondHookCallback {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -559,9 +559,22 @@ export async function respondHookCallback(
   runId: string,
   requestId: string,
   decision: "allow" | "deny" | "defer",
+  // PreToolUse hooks can rewrite tool input alongside `allow` (CLI v2.1.85+).
+  // Only honored by the CLI when decision == "allow".
+  updatedInput?: Record<string, unknown>,
 ): Promise<void> {
-  dbg("api", "respondHookCallback", { runId, requestId, decision });
-  return invoke("respond_hook_callback", { runId, requestId, decision });
+  dbg("api", "respondHookCallback", {
+    runId,
+    requestId,
+    decision,
+    hasUpdatedInput: updatedInput != null,
+  });
+  return invoke("respond_hook_callback", {
+    runId,
+    requestId,
+    decision,
+    updatedInput: updatedInput ?? null,
+  });
 }
 
 // ── Typed control request wrappers ──


### PR DESCRIPTION
## Summary

Sync to Claude Code CLI v2.1.85 protocol addition: PreToolUse hooks can return \`updatedInput\` alongside \`decision: \"allow\"\` to rewrite tool input (headless equivalent of the permission flow's existing \`updatedInput\` support).

The permission path (\`respond_permission\`) already supports this; \`respond_hook_callback\` did not, so headless integrations forwarding hook decisions could not transform tool input alongside \`allow\`.

## Changes

- **\`src-tauri/src/commands/session.rs\`** — \`respond_hook_callback\` Tauri command accepts optional \`updated_input: Option<Value>\`. When \`decision == \"allow\"\` and \`updated_input.is_some()\`, includes \`updatedInput\` field in the control_response JSON.
- **\`src-tauri/src/web_server/dispatch.rs\`** — same handling for the web-server dispatch path (Remote Control / web sessions).
- **\`src/lib/api.ts\`** — \`respondHookCallback\` accepts optional \`updatedInput?: Record<string, unknown>\` and forwards to backend.

CLI ignores the field for \`deny\`/\`defer\` decisions; we guard accordingly to keep the wire format clean.

## Out of Scope

UI caller (\`chat/+page.svelte\` \`handleHookCallbackRespond\`) is unchanged — it still passes only \`(requestId, decision)\`, so this PR is purely API plumbing. A future PR can add UI that lets users rewrite tool input alongside an allow decision (mirroring the existing permission \"editTool\" flow).

## Test plan

- [x] \`npm run lint:fix\` — 0 errors
- [x] \`npm run format:check\` — clean
- [x] \`cargo fmt\` — applied
- [x] \`cargo check\` — builds clean
- [x] \`cargo clippy\` — 0 warnings
- [x] \`npm test\` — 1142 tests pass
- [x] \`npm run build\` — frontend builds
- [ ] Manual: write a hook that returns \`{decision: \"allow\", updatedInput: {...}}\` via the app's headless callback path; verify CLI applies the modified input