### PR TITLE
feat: extend syntax highlighting for framework/DSL files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.52"
+version = "0.1.55"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src/lib/components/CodeEditor.svelte
+++ b/src/lib/components/CodeEditor.svelte
@@ -22,7 +22,11 @@
   import { dbg, dbgWarn } from "$lib/utils/debug";
   import { perfMark, perfMarkAsync } from "$lib/utils/perf";
   import { fileName } from "$lib/utils/format";
-  import { resolveStaticLanguage, resolveByFirstLine } from "$lib/utils/codemirror-languages";
+  import {
+    resolveStaticExtensionInfo,
+    resolveStaticFilenameInfo,
+    resolveByFirstLine,
+  } from "$lib/utils/codemirror-languages";
 
   let {
     content = $bindable(""),
@@ -51,18 +55,40 @@
   /**
    * Resolve language extensions for a file path.
    *
-   * 1. Static mapping (sync) — covers ~20 common languages
-   * 2. Dynamic fallback via @codemirror/language-data (async, with try/catch)
-   * 3. Returns [] on failure (plain text, never throws)
+   * 1a. Filename match (Containerfile, Makefile, Cargo.lock, .gitignore,
+   *     Dockerfile.dev, ...) — must run BEFORE extension match because
+   *     Dockerfile.dev would otherwise miss EXT_MAP for "dev" and fall
+   *     through pointlessly. Note: exact "Dockerfile" / "Component.vue" /
+   *     "snippet.liquid" are intentionally NOT in static maps so the
+   *     dynamic loader can supply their real parsers.
+   * 1b. Extension static mapping (sync) — covers ~30 common languages
+   * 2.  Dynamic fallback via @codemirror/language-data (async, with try/catch)
+   * 3.  First-line detection (shebang, XML declaration, JSON brace)
+   * 4.  Returns [] on failure (plain text, never throws)
    */
   async function resolveLanguage(path: string): Promise<Extension[]> {
     const name = fileName(path);
 
-    // 1. Static mapping (sync — no dynamic chunk loading)
-    const staticResult = resolveStaticLanguage(name);
-    if (staticResult) {
-      dbg("code-editor", "static-hit", { name });
-      return staticResult;
+    // 1a. Filename match
+    const filenameInfo = resolveStaticFilenameInfo(name);
+    if (filenameInfo) {
+      dbg("code-editor", "filename-hit", {
+        name,
+        kind: filenameInfo.kind,
+        approx: filenameInfo.approx,
+      });
+      return filenameInfo.extensions;
+    }
+
+    // 1b. Extension static mapping (sync — no dynamic chunk loading)
+    const extInfo = resolveStaticExtensionInfo(name);
+    if (extInfo) {
+      dbg("code-editor", "static-hit", {
+        name,
+        kind: extInfo.kind,
+        approx: extInfo.approx,
+      });
+      return extInfo.extensions;
     }
 
     // 2. Dynamic fallback: language-data auto-detection

--- a/src/lib/utils/__tests__/codemirror-languages.test.ts
+++ b/src/lib/utils/__tests__/codemirror-languages.test.ts
@@ -1,95 +1,229 @@
 import { describe, it, expect } from "vitest";
-import { resolveStaticLanguage, resolveByFirstLine } from "../codemirror-languages";
+import {
+  resolveStaticLanguage,
+  resolveStaticExtensionInfo,
+  resolveStaticFilename,
+  resolveStaticFilenameInfo,
+  resolveByFirstLine,
+  __getStaticExtensionKeysForTest,
+} from "../codemirror-languages";
 
-describe("resolveStaticLanguage", () => {
-  // ── Common extensions ──
+// ──────────────────────────────────────────────────────────────────────
+// Extension-based resolution
+// ──────────────────────────────────────────────────────────────────────
 
-  it("resolves common code extensions", () => {
-    const shouldMatch = [
-      "app.ts",
-      "openai.d.ts", // .d.ts → extension "ts" → TypeScript
-      "global.d.mts", // .d.mts → extension "mts" → TypeScript
-      "app.tsx",
-      "index.js",
-      "index.jsx",
-      "main.mjs",
-      "main.cjs",
-      "styles.css",
-      "README.md",
-      "config.json",
-      "main.py",
-      "lib.rs",
-      "main.go",
-      "App.java",
-      "main.cpp",
-      "main.c",
-      "util.h",
-      "util.hpp",
-      "index.html",
-      "page.htm",
-      "schema.sql",
-      "config.yaml",
-      "config.yml",
-      "data.xml",
-      "icon.svg",
-      "Cargo.toml",
-      "script.sh",
-      "script.bash",
-      "changes.diff",
-      "fix.patch",
-    ];
-    for (const filename of shouldMatch) {
-      expect(resolveStaticLanguage(filename), `expected match for ${filename}`).not.toBeNull();
+describe("resolveStaticExtensionInfo — new framework approximations", () => {
+  it.each([
+    ["App.svelte", "html"],
+    ["page.astro", "html"],
+    ["comp.marko", "html"],
+  ])("%s → html (approx)", (name, kind) => {
+    const info = resolveStaticExtensionInfo(name);
+    expect(info).not.toBeNull();
+    expect(info!.kind).toBe(kind);
+    expect(info!.approx).toBe(true);
+    expect(info!.extensions.length).toBeGreaterThan(0);
+    // Bridge: thin wrapper returns same-shape extensions array.
+    // Can't deep-compare because StreamLanguage.define() returns fresh
+    // instances per call; length + non-null is enough to catch divergence.
+    expect(resolveStaticLanguage(name)?.length).toBe(info!.extensions.length);
+  });
+
+  it.each([["README.mdx"], ["paper.qmd"], ["notebook.rmd"]])(
+    "%s → markdown (approx — embedded JSX/R/Python not parsed)",
+    (name) => {
+      const info = resolveStaticExtensionInfo(name);
+      expect(info).not.toBeNull();
+      expect(info!.kind).toBe("markdown");
+      expect(info!.approx).toBe(true);
+      // Bridge: thin wrapper returns same-shape extensions array.
+      // Can't deep-compare because StreamLanguage.define() returns fresh
+      // instances per call; length + non-null is enough to catch divergence.
+      expect(resolveStaticLanguage(name)?.length).toBe(info!.extensions.length);
+    },
+  );
+});
+
+describe("resolveStaticExtensionInfo — existing parsers (regression + canonical kind)", () => {
+  // Table-driven smoke test — confirms (a) no existing ext was broken and
+  // (b) `kind` uses canonical language names, not extension strings.
+  it.each([
+    ["app.ts", "typescript", false],
+    ["openai.d.ts", "typescript", false],
+    ["global.d.mts", "typescript", false],
+    ["app.tsx", "typescript", false],
+    ["index.js", "javascript", false],
+    ["index.jsx", "javascript", false],
+    ["main.mjs", "javascript", false],
+    ["main.cjs", "javascript", false],
+    ["lib.rs", "rust", false],
+    ["script.py", "python", false],
+    ["main.go", "go", false],
+    ["App.java", "java", false],
+    ["foo.c", "c", true], // .c uses cpp() parser as approximation
+    ["main.cpp", "cpp", false],
+    ["util.h", "cpp", false],
+    ["util.hpp", "cpp", false],
+    ["index.html", "html", false],
+    ["page.htm", "html", false],
+    ["styles.css", "css", false],
+    ["data.json", "json", false],
+    ["config.yaml", "yaml", false],
+    ["config.yml", "yaml", false],
+    ["Cargo.toml", "toml", false],
+    ["README.md", "markdown", false],
+    ["data.xml", "xml", false],
+    ["icon.svg", "xml", false],
+    ["schema.sql", "sql", false],
+    ["script.sh", "shell", false],
+    ["script.bash", "shell", false],
+    ["changes.diff", "diff", false],
+    ["fix.patch", "diff", false],
+    ["my.conf", "shell", true],
+    ["settings.ini", "shell", true],
+  ])("%s resolves with kind=%s approx=%s", (name, kind, approx) => {
+    const info = resolveStaticExtensionInfo(name);
+    expect(info, name).not.toBeNull();
+    expect(info!.kind, name).toBe(kind);
+    expect(info!.approx, name).toBe(approx);
+    expect(resolveStaticLanguage(name)?.length, name).toBe(info!.extensions.length);
+  });
+
+  it("does NOT map .nix (intentional — shellMode too misleading)", () => {
+    expect(resolveStaticExtensionInfo("default.nix")).toBeNull();
+    expect(resolveStaticLanguage("default.nix")).toBeNull();
+  });
+
+  it("does NOT statically map vue/liquid (let dynamic loader use real parsers)", () => {
+    // language-data has lang-vue and lang-liquid; static html() approx would pre-empt them.
+    expect(resolveStaticExtensionInfo("Component.vue")).toBeNull();
+    expect(resolveStaticExtensionInfo("snippet.liquid")).toBeNull();
+  });
+
+  it("returns null for unknown extensions", () => {
+    expect(resolveStaticExtensionInfo("unknown.xyz")).toBeNull();
+    expect(resolveStaticExtensionInfo("data.parquet")).toBeNull();
+  });
+
+  it("returns null for files without an extension (extension-only function)", () => {
+    // Bare-filename matches (Dockerfile, README) belong to resolveStaticFilenameInfo.
+    expect(resolveStaticExtensionInfo("README")).toBeNull();
+  });
+
+  // Exhaustive guardrail — iterates ALL EXT_MAP keys, asserts each has both
+  // a working factory AND an EXT_META entry. Catches "added EXT_MAP, forgot
+  // EXT_META" at PR time instead of at user-facing static-hit miss.
+  it("every EXT_MAP key has working factory + EXT_META entry", () => {
+    for (const key of __getStaticExtensionKeysForTest()) {
+      const synthetic = `dummy.${key}`;
+      const info = resolveStaticExtensionInfo(synthetic);
+      expect(info, `missing META or factory for .${key}`).not.toBeNull();
+      // kind allows lowercase + digits + dashes (future: vue-html, objective-c).
+      expect(info!.kind, `kind for .${key}`).toMatch(/^[a-z][a-z0-9-]*$/);
+      expect(info!.extensions.length, `extensions for .${key}`).toBeGreaterThan(0);
     }
-  });
-
-  // ── Dotfiles ──
-
-  it("resolves shell-like dotfiles", () => {
-    expect(resolveStaticLanguage(".gitignore")).not.toBeNull();
-    expect(resolveStaticLanguage(".dockerignore")).not.toBeNull();
-    expect(resolveStaticLanguage(".npmignore")).not.toBeNull();
-    expect(resolveStaticLanguage(".env")).not.toBeNull();
-  });
-
-  it("resolves .env.* variants", () => {
-    expect(resolveStaticLanguage(".env.local")).not.toBeNull();
-    expect(resolveStaticLanguage(".env.production")).not.toBeNull();
-    expect(resolveStaticLanguage(".env.development.local")).not.toBeNull();
-  });
-
-  it("resolves JSON-like dotfiles", () => {
-    expect(resolveStaticLanguage(".prettierrc")).not.toBeNull();
-    expect(resolveStaticLanguage(".eslintrc")).not.toBeNull();
-    expect(resolveStaticLanguage(".babelrc")).not.toBeNull();
-  });
-
-  it("resolves Makefile", () => {
-    expect(resolveStaticLanguage("Makefile")).not.toBeNull();
-    expect(resolveStaticLanguage("GNUmakefile")).not.toBeNull();
-  });
-
-  // ── Config extensions ──
-
-  it("resolves config file extensions", () => {
-    expect(resolveStaticLanguage("my.conf")).not.toBeNull();
-    expect(resolveStaticLanguage("settings.ini")).not.toBeNull();
-    expect(resolveStaticLanguage("Cargo.lock")).not.toBeNull();
-  });
-
-  // ── Dynamic fallback (returns null) ──
-
-  it("returns null for files that should use dynamic fallback", () => {
-    // Dockerfile — language-data handles it natively, should NOT be forced to Shell
-    expect(resolveStaticLanguage("Dockerfile")).toBeNull();
-    // Unknown extensions
-    expect(resolveStaticLanguage("unknown.xyz")).toBeNull();
-    expect(resolveStaticLanguage("README")).toBeNull();
-    expect(resolveStaticLanguage("data.parquet")).toBeNull();
   });
 });
 
-describe("resolveByFirstLine", () => {
+// ──────────────────────────────────────────────────────────────────────
+// Filename-based resolution (Dockerfile, .gitignore, Cargo.lock, ...)
+// ──────────────────────────────────────────────────────────────────────
+
+describe("resolveStaticFilenameInfo — exact + prefix", () => {
+  it.each([
+    "Containerfile",
+    "Makefile",
+    "GNUmakefile",
+    "makefile",
+    "Justfile",
+    "justfile",
+    "Earthfile",
+    "Procfile",
+    ".gitignore",
+    ".dockerignore",
+    ".npmignore",
+    ".prettierignore",
+    ".eslintignore",
+    ".env",
+    ".editorconfig",
+  ])("exact shell: %s → shell approx", (name) => {
+    const info = resolveStaticFilenameInfo(name);
+    expect(info, name).not.toBeNull();
+    expect(info!.kind).toBe("shell");
+    expect(info!.approx).toBe(true);
+    expect(resolveStaticFilename(name)?.length, name).toBe(info!.extensions.length);
+  });
+
+  it.each([".prettierrc", ".eslintrc", ".babelrc", ".swcrc"])("exact json: %s → json", (name) => {
+    const info = resolveStaticFilenameInfo(name);
+    expect(info, name).not.toBeNull();
+    expect(info!.kind).toBe("json");
+    expect(info!.approx).toBe(false);
+    expect(resolveStaticFilename(name)?.length, name).toBe(info!.extensions.length);
+  });
+
+  it("Cargo.lock → toml (specific lock file, not blanket .lock)", () => {
+    const info = resolveStaticFilenameInfo("Cargo.lock");
+    expect(info).not.toBeNull();
+    expect(info!.kind).toBe("toml");
+    expect(info!.approx).toBe(false);
+  });
+
+  it("package-lock.json resolves via .json extension (not filename)", () => {
+    // Deliberate: filename has no entry; ext path handles it identically.
+    expect(resolveStaticFilenameInfo("package-lock.json")).toBeNull();
+    const info = resolveStaticExtensionInfo("package-lock.json");
+    expect(info).not.toBeNull();
+    expect(info!.kind).toBe("json");
+  });
+
+  it("yarn.lock has no static handler (no good parser → plain text)", () => {
+    expect(resolveStaticFilenameInfo("yarn.lock")).toBeNull();
+    expect(resolveStaticExtensionInfo("yarn.lock")).toBeNull();
+  });
+
+  it("Dockerfile (exact) is NOT statically mapped — dynamic loader has real parser", () => {
+    // language-data matches /^Dockerfile$/ to legacy-modes/mode/dockerfile.
+    // Static shellMode approx would pre-empt the better parser.
+    expect(resolveStaticFilenameInfo("Dockerfile")).toBeNull();
+    // But variants (Dockerfile.dev) ARE captured — dynamic doesn't cover them.
+    expect(resolveStaticFilenameInfo("Dockerfile.dev")).not.toBeNull();
+  });
+
+  it.each([
+    "Dockerfile.dev",
+    "Dockerfile.prod",
+    "Containerfile.alpine",
+    "Makefile.linux",
+    "Justfile.local",
+    "justfile.local",
+    ".env.local",
+    ".env.production",
+    ".env.development.local",
+  ])("prefix: %s → shell approx", (name) => {
+    const info = resolveStaticFilenameInfo(name);
+    expect(info, name).not.toBeNull();
+    expect(info!.kind).toBe("shell");
+    expect(info!.approx).toBe(true);
+    expect(resolveStaticFilename(name)?.length, name).toBe(info!.extensions.length);
+  });
+
+  it.each([
+    "foo.svelte", // would match EXT, not filename
+    "DockerfileXYZ", // no dot separator
+    "dockerfile", // lowercase 'd' not in exact list
+    "myDockerfile", // doesn't start with Dockerfile
+  ])("does NOT match: %s", (name) => {
+    expect(resolveStaticFilenameInfo(name), name).toBeNull();
+    expect(resolveStaticFilename(name), name).toBeNull();
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// First-line detection
+// ──────────────────────────────────────────────────────────────────────
+
+describe("resolveByFirstLine — shebangs, XML, HTML, JSON", () => {
   it("detects shell shebang", () => {
     expect(resolveByFirstLine("#!/bin/bash")).not.toBeNull();
     expect(resolveByFirstLine("#!/usr/bin/env sh")).not.toBeNull();
@@ -124,5 +258,42 @@ describe("resolveByFirstLine", () => {
     expect(resolveByFirstLine("hello world")).toBeNull();
     expect(resolveByFirstLine("")).toBeNull();
     expect(resolveByFirstLine("some random text")).toBeNull();
+  });
+});
+
+describe("resolveByFirstLine — HTML-like (split, strict)", () => {
+  it.each([
+    '<script lang="ts">',
+    "<template>",
+    "<style>",
+    "<astro>",
+    "  <script>", // leading whitespace OK
+  ])("matches plain HTML-like: %s", (line) => {
+    expect(resolveByFirstLine(line)).not.toBeNull();
+  });
+
+  it.each([
+    "<svelte:options>",
+    "<svelte:options runes={true}>",
+    // ⚠️ Open tag with no closing > yet (streaming first line). REGRESSION GUARD:
+    //    if someone tightens (\s|>|$) → [\s>] this case will fail and prevent
+    //    silently dropping streaming-tag detection.
+    "<svelte:options",
+  ])("matches svelte:options: %s", (line) => {
+    expect(resolveByFirstLine(line)).not.toBeNull();
+  });
+
+  it.each([
+    "<scripty>", // tag boundary required
+    "<scriptaculous",
+    "<svelte:component>", // explicitly only svelte:options is whitelisted
+    "<svelte:foo>",
+  ])("does NOT match: %s", (line) => {
+    expect(resolveByFirstLine(line)).toBeNull();
+  });
+
+  it("does NOT match `---` (intentional — would mis-classify YAML configs)", () => {
+    expect(resolveByFirstLine("---")).toBeNull();
+    expect(resolveByFirstLine("--- # yaml comment")).toBeNull();
   });
 });

--- a/src/lib/utils/codemirror-languages.ts
+++ b/src/lib/utils/codemirror-languages.ts
@@ -2,12 +2,13 @@
  * Static CodeMirror language resolution.
  *
  * Pre-imports common languages so the editor never depends on dynamic chunk
- * loading for the ~20 most-used file types. Unknown extensions fall through
+ * loading for the ~30 most-used file types. Unknown extensions fall through
  * to @codemirror/language-data (async, handled by the caller).
  */
 
 import type { Extension } from "@codemirror/state";
 import { StreamLanguage } from "@codemirror/language";
+import { dbgWarn } from "$lib/utils/debug";
 
 // ── Modern language packages (tree-shaken, sync) ──
 import { javascript } from "@codemirror/lang-javascript";
@@ -46,15 +47,29 @@ const EXT_MAP: Record<string, () => Extension[]> = {
   json: () => [json()],
   jsonc: () => [json()],
   toml: () => [StreamLanguage.define(tomlMode)],
-  lock: () => [StreamLanguage.define(tomlMode)], // Cargo.lock
   // Markup
   md: () => [markdown()],
   markdown: () => [markdown()],
   html: () => [html()],
   htm: () => [html()],
+  // Svelte / Astro / Marko: HTML-shaped with embedded <script>/<style>;
+  // html() does mixed-mode parsing for these blocks. Not perfect (doesn't
+  // know Svelte directives like {#if}, Astro frontmatter) but better than
+  // plain text. NOTE: vue and liquid intentionally OMITTED — they have
+  // real parsers in @codemirror/language-data (lang-vue, lang-liquid)
+  // which the dynamic fallback path will load. Adding them here would
+  // pre-empt the better parser with our HTML approximation.
+  svelte: () => [html()],
+  astro: () => [html()],
+  marko: () => [html()],
   xml: () => [xml()],
   svg: () => [xml()],
   xsl: () => [xml()],
+  // Markdown variants. mdx has embedded JSX (not parsed), qmd/rmd have
+  // executable code chunks (not parsed) — all approximated as plain markdown.
+  mdx: () => [markdown()],
+  qmd: () => [markdown()],
+  rmd: () => [markdown()],
   // Styles
   css: () => [css()],
   // Languages
@@ -80,7 +95,8 @@ const EXT_MAP: Record<string, () => Extension[]> = {
   // Diff
   diff: () => [StreamLanguage.define(diffMode)],
   patch: () => [StreamLanguage.define(diffMode)],
-  // Misc config extensions
+  // Misc config extensions (shellMode is approximation — colorizes comments
+  // and strings reasonably even if it doesn't know section headers)
   env: () => [StreamLanguage.define(shellMode)],
   conf: () => [StreamLanguage.define(shellMode)],
   cfg: () => [StreamLanguage.define(shellMode)],
@@ -89,55 +105,229 @@ const EXT_MAP: Record<string, () => Extension[]> = {
   editorconfig: () => [StreamLanguage.define(shellMode)],
 };
 
-// ── Filename-based static mapping (dotfiles, special names) ──
-
-const FILENAME_MAP: Record<string, () => Extension[]> = {
-  ".gitignore": () => [StreamLanguage.define(shellMode)],
-  ".dockerignore": () => [StreamLanguage.define(shellMode)],
-  ".npmignore": () => [StreamLanguage.define(shellMode)],
-  ".prettierignore": () => [StreamLanguage.define(shellMode)],
-  ".eslintignore": () => [StreamLanguage.define(shellMode)],
-  ".env": () => [StreamLanguage.define(shellMode)],
-  ".prettierrc": () => [json()],
-  ".eslintrc": () => [json()],
-  ".babelrc": () => [json()],
-  ".swcrc": () => [json()],
-  ".editorconfig": () => [StreamLanguage.define(shellMode)],
-  Makefile: () => [StreamLanguage.define(shellMode)],
-  GNUmakefile: () => [StreamLanguage.define(shellMode)],
+/**
+ * Per-extension metadata. `kind` is a stable canonical language identifier
+ * (NOT the file extension), suitable for log aggregation / telemetry / UI
+ * labels. `approx` marks fallback approximations.
+ *
+ * Every key in EXT_MAP MUST have an entry here. The completeness test in
+ * __tests__/codemirror-languages.test.ts iterates EXT_MAP keys and asserts
+ * each has a META entry — adding an EXT_MAP entry without META will fail CI.
+ */
+const EXT_META: Record<string, { kind: string; approx: boolean }> = {
+  // TypeScript family
+  ts: { kind: "typescript", approx: false },
+  mts: { kind: "typescript", approx: false },
+  cts: { kind: "typescript", approx: false },
+  tsx: { kind: "typescript", approx: false },
+  // JavaScript family
+  js: { kind: "javascript", approx: false },
+  mjs: { kind: "javascript", approx: false },
+  cjs: { kind: "javascript", approx: false },
+  jsx: { kind: "javascript", approx: false },
+  // Markup
+  html: { kind: "html", approx: false },
+  htm: { kind: "html", approx: false },
+  // vue / liquid: handled by dynamic language-data fallback (real parsers)
+  svelte: { kind: "html", approx: true },
+  astro: { kind: "html", approx: true },
+  marko: { kind: "html", approx: true },
+  xml: { kind: "xml", approx: false },
+  svg: { kind: "xml", approx: false },
+  xsl: { kind: "xml", approx: false },
+  md: { kind: "markdown", approx: false },
+  markdown: { kind: "markdown", approx: false },
+  mdx: { kind: "markdown", approx: true },
+  qmd: { kind: "markdown", approx: true },
+  rmd: { kind: "markdown", approx: true },
+  // Styles
+  css: { kind: "css", approx: false },
+  // Languages
+  py: { kind: "python", approx: false },
+  rs: { kind: "rust", approx: false },
+  go: { kind: "go", approx: false },
+  java: { kind: "java", approx: false },
+  c: { kind: "c", approx: true }, // .c uses cpp() parser as approximation
+  cpp: { kind: "cpp", approx: false },
+  cc: { kind: "cpp", approx: false },
+  cxx: { kind: "cpp", approx: false },
+  h: { kind: "cpp", approx: false },
+  hpp: { kind: "cpp", approx: false },
+  // Data / config
+  json: { kind: "json", approx: false },
+  jsonc: { kind: "json", approx: false },
+  yaml: { kind: "yaml", approx: false },
+  yml: { kind: "yaml", approx: false },
+  toml: { kind: "toml", approx: false },
+  sql: { kind: "sql", approx: false },
+  // Shell family
+  sh: { kind: "shell", approx: false },
+  bash: { kind: "shell", approx: false },
+  zsh: { kind: "shell", approx: false },
+  ksh: { kind: "shell", approx: false },
+  // Diff
+  diff: { kind: "diff", approx: false },
+  patch: { kind: "diff", approx: false },
+  // Misc config (shellMode is approximation)
+  env: { kind: "shell", approx: true },
+  conf: { kind: "shell", approx: true },
+  cfg: { kind: "shell", approx: true },
+  ini: { kind: "shell", approx: true },
+  properties: { kind: "shell", approx: true },
+  editorconfig: { kind: "shell", approx: true },
 };
 
-/**
- * Resolve CodeMirror language extensions from a filename (sync, no dynamic import).
- *
- * Resolution order:
- * 1. Exact filename match (dotfiles, Makefile)
- * 2. `.env.*` pattern
- * 3. Extension-based mapping
- *
- * Returns `Extension[]` on match, `null` if caller should try dynamic fallback.
- */
-export function resolveStaticLanguage(filename: string): Extension[] | null {
-  // 1. Exact filename match
-  const fnFactory = FILENAME_MAP[filename];
-  if (fnFactory) return fnFactory();
-
-  // 2. .env.* pattern (e.g. .env.local, .env.production)
-  if (/^\.env\..+$/.test(filename)) {
-    return [StreamLanguage.define(shellMode)];
-  }
-
-  // 3. Extension-based
-  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
-  const extFactory = EXT_MAP[ext];
-  if (extFactory) return extFactory();
-
-  return null;
+export interface StaticLanguageInfo {
+  extensions: Extension[];
+  kind: string;
+  approx: boolean;
 }
 
 /**
- * Guess language from the first line of file content (shebang, XML declaration, etc.).
- * Used as a last-resort fallback for extensionless files.
+ * Resolve static language info from a filename's **extension only**.
+ * Does NOT consider bare-filename matches (Dockerfile, Makefile) — for
+ * those, callers must first try `resolveStaticFilenameInfo`. CodeEditor
+ * wires both in the documented order (filename → extension → dynamic →
+ * first-line).
+ *
+ * Returns null if the extension is unknown OR if EXT_META is missing the
+ * entry (intentional — the missing entry is a bug, not a fallback).
+ */
+export function resolveStaticExtensionInfo(name: string): StaticLanguageInfo | null {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  const factory = EXT_MAP[ext];
+  if (!factory) return null;
+  const meta = EXT_META[ext];
+  if (!meta) {
+    dbgWarn("code-editor", "static-meta-missing", { ext });
+    return null;
+  }
+  return { extensions: factory(), kind: meta.kind, approx: meta.approx };
+}
+
+/**
+ * @deprecated Do not use in new code. Kept for the test bridge against
+ * `resolveStaticExtensionInfo` and as a stable name for any older import
+ * sites. Semantics narrowed: extension-only — returns null for bare-filename
+ * matches like ".gitignore" or "Makefile" that the old composite version
+ * used to handle. New callers should use the explicit pair:
+ * `resolveStaticFilenameInfo(name) ?? resolveStaticExtensionInfo(name)`.
+ */
+export function resolveStaticLanguage(name: string): Extension[] | null {
+  return resolveStaticExtensionInfo(name)?.extensions ?? null;
+}
+
+/**
+ * @internal — exported only for the completeness test in
+ * __tests__/codemirror-languages.test.ts. Not a public API; do not consume
+ * from production code. The naming is deliberately un-API-ish so it's clear
+ * at the import site.
+ */
+export function __getStaticExtensionKeysForTest(): readonly string[] {
+  return Object.freeze(Object.keys(EXT_MAP));
+}
+
+// ── Filename-based static mapping (dotfiles, Dockerfile, prefix variants) ──
+
+type FilenameSpec = {
+  match: (n: string) => boolean;
+  load: () => Extension[];
+  kind: string;
+  approx: boolean;
+};
+
+function shellApproxSpec(match: (n: string) => boolean): FilenameSpec {
+  return {
+    match,
+    load: () => [StreamLanguage.define(shellMode)],
+    kind: "shell",
+    approx: true,
+  };
+}
+function jsonSpec(match: (n: string) => boolean): FilenameSpec {
+  return { match, load: () => [json()], kind: "json", approx: false };
+}
+function tomlSpec(match: (n: string) => boolean): FilenameSpec {
+  return {
+    match,
+    load: () => [StreamLanguage.define(tomlMode)],
+    kind: "toml",
+    approx: false,
+  };
+}
+
+// NOTE: "Dockerfile" intentionally OMITTED — language-data has a real
+// Dockerfile parser via @codemirror/legacy-modes/mode/dockerfile, which the
+// dynamic fallback will load (matched by its `^Dockerfile$` regex). We only
+// keep the variants (Dockerfile.dev, etc.) since dynamic doesn't cover those.
+// Containerfile/Makefile/Justfile/etc. don't have language-data entries.
+const SHELL_EXACT_FILENAMES = [
+  "Containerfile",
+  "Makefile",
+  "GNUmakefile",
+  "makefile",
+  "Justfile",
+  "justfile",
+  "Earthfile",
+  "Procfile",
+];
+
+const SHELL_DOTFILE_NAMES = [
+  ".gitignore",
+  ".dockerignore",
+  ".npmignore",
+  ".prettierignore",
+  ".eslintignore",
+  ".env",
+  ".editorconfig",
+];
+
+const JSON_DOTFILE_NAMES = [".prettierrc", ".eslintrc", ".babelrc", ".swcrc"];
+
+const FILENAMES: FilenameSpec[] = [
+  // Exact bare filenames (build/container)
+  ...SHELL_EXACT_FILENAMES.map((name) => shellApproxSpec((n) => n === name)),
+  // Existing dotfiles (preserved from old FILENAME_MAP)
+  ...SHELL_DOTFILE_NAMES.map((name) => shellApproxSpec((n) => n === name)),
+  ...JSON_DOTFILE_NAMES.map((name) => jsonSpec((n) => n === name)),
+  // Specific lock files
+  tomlSpec((n) => n === "Cargo.lock"),
+  // Prefix variants. Regex `^Name\..+$` — prefix is specific enough that we
+  // don't need a strict charset; allows Dockerfile.prod+ci, Makefile.cross-arm64.
+  shellApproxSpec((n) => /^(Dockerfile|Containerfile)\..+$/.test(n)),
+  shellApproxSpec((n) => /^(Makefile|makefile|GNUmakefile)\..+$/.test(n)),
+  shellApproxSpec((n) => /^(Justfile|justfile)\..+$/.test(n)),
+  // .env.* (.env.local, .env.production)
+  shellApproxSpec((n) => /^\.env\..+$/.test(n)),
+];
+
+/**
+ * Resolve static language info from a bare filename or filename prefix
+ * pattern (Containerfile, Makefile, Cargo.lock, .gitignore, .env.local,
+ * Dockerfile.dev, ...). Does NOT fall back to extension matching; callers
+ * should call `resolveStaticExtensionInfo` if this returns null.
+ *
+ * Exact "Dockerfile" is intentionally OMITTED — the dynamic loader has a
+ * real Dockerfile parser (legacy-modes/mode/dockerfile) that's strictly
+ * better than our shellMode approximation.
+ */
+export function resolveStaticFilenameInfo(name: string): StaticLanguageInfo | null {
+  for (const spec of FILENAMES) {
+    if (spec.match(name)) {
+      return { extensions: spec.load(), kind: spec.kind, approx: spec.approx };
+    }
+  }
+  return null;
+}
+
+/** Extensions-only thin wrapper for filename match. */
+export function resolveStaticFilename(name: string): Extension[] | null {
+  return resolveStaticFilenameInfo(name)?.extensions ?? null;
+}
+
+/**
+ * Guess language from the first line of file content (shebang, XML
+ * declaration, etc.). Used as a last-resort fallback for extensionless files.
  *
  * Returns `Extension[]` on match, `null` otherwise.
  */
@@ -147,6 +337,18 @@ export function resolveByFirstLine(firstLine: string): Extension[] | null {
   if (/^#!.*\bnode\b/.test(firstLine)) return [javascript()];
   if (/^<\?xml\b/.test(firstLine)) return [xml()];
   if (/^<!DOCTYPE\s+html/i.test(firstLine) || /^<html/i.test(firstLine)) return [html()];
+
+  // HTML-like first lines — split into two patterns so the intent is
+  // unambiguous and future maintainers don't accidentally widen `svelte:` to
+  // arbitrary `<svelte:foo>`. Both patterns require a tag boundary
+  // (whitespace, `>`, or end-of-line) to avoid matching `<scripty>` etc.
+  if (/^\s*<(script|template|style|astro)(\s|>|$)/i.test(firstLine)) return [html()];
+  if (/^\s*<svelte:options(\s|>|$)/i.test(firstLine)) return [html()];
+
+  // ⚠️ Intentionally NOT matching `---`: too broad without filename context.
+  //    YAML configs (no extension) often start with `---`; calling them
+  //    markdown is worse than plain text. mdx/qmd/rmd already covered by
+  //    EXT_MAP.
   if (/^\s*[{[]/.test(firstLine)) return [json()];
   return null;
 }


### PR DESCRIPTION
## Summary

Fixes missing syntax highlighting in `/explorer` for `.svelte` / `.astro` / `.mdx` and similar framework/DSL files. Root cause: these aren't official CodeMirror languages, `@codemirror/language-data` doesn't ship them either, so all three fallback levels miss → plain text.

- **EXT_MAP additions**: `svelte` / `astro` / `marko` → `html()` (approx — doesn't recognize `{#if}` directives), `mdx` / `qmd` / `rmd` → `markdown()` (approx — doesn't parse JSX/R/Python chunks). All flagged `approx: true` for honesty.
- **New sparse EXT_META** with canonical language names (`typescript` / `python` / `javascript`, not extension strings). The `kind` field is now stable for telemetry/log aggregation.
- **New FILENAMES array** for bare-filename matches: `Containerfile` / `Makefile` / `Justfile` / `Earthfile` / `Procfile` / `Cargo.lock`, plus prefix variants like `Dockerfile.dev` and `Makefile.linux`.
- **Intentionally NOT statically mapped**: `vue` / `liquid` (language-data has real `lang-vue` / `lang-liquid`) and exact `Dockerfile` (language-data has `legacy-modes/mode/dockerfile`). The dynamic loader supplies the better parser instead of being pre-empted by our HTML/shell approximations.
- **`resolveByFirstLine`** HTML-like rule split into two strict regexes — avoids matching `<scripty>` and unbounded `<svelte:foo>`.
- **`resolveStaticLanguage` marked `@deprecated`**: new callers should use the explicit pair `resolveStaticFilenameInfo(name) ?? resolveStaticExtensionInfo(name)`.
- **`__getStaticExtensionKeysForTest`**: internal export so the completeness test iterates every `EXT_MAP` key and asserts a matching `EXT_META` entry exists. Catches "added EXT_MAP, forgot META" at PR time.
- **`CodeEditor.svelte resolveLanguage`** gains step 1a (filename match before extension); logs include `kind` and `approx`.

## Stack

PR **5 of 5** (final). Base is the lazy-markdown PR (#108). Merge in order: #105 → #106 → #107 → #108 → this.

## Test plan

- [x] `npm test` passes (1241 → adds ~80 new assertions)
- [x] `npm run lint:fix && format && format:check && build` all pass
- [x] `cargo fmt` clean (pre-existing clippy warning in `history.rs:651` is unrelated)
- [ ] Manual: open `.svelte` / `Dockerfile` / `.mdx` in `/explorer` and confirm highlighting
- [ ] Manual: `localStorage.setItem("ocv:debug", "perf,code-editor")` and verify `filename-hit` / `static-hit` / `dynamic-hit` logs include `kind` and `approx`