### PR TITLE
feat: embed file preview in chat right pane (#101)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -955,6 +955,9 @@
   "bgTask_empty": "No background tasks",
   "filesPanel_noFiles": "No file operations yet",
   "filesPanel_notLocatable": "Cannot locate the corresponding tool call",
+  "filesPanel_noPreviewSelected": "Select a file above to preview",
+  "preview_remoteUnsupported": "File preview is not supported for remote sessions",
+  "toolDetail_previewFile": "Open in preview pane",
 
   "infoPanel_noInfo": "Session info will appear after the session starts.",
   "infoPanel_session": "Session",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -955,6 +955,9 @@
   "bgTask_empty": "暂无后台任务",
   "filesPanel_noFiles": "暂无文件操作",
   "filesPanel_notLocatable": "无法定位到对应工具调用",
+  "filesPanel_noPreviewSelected": "选择上方文件以预览",
+  "preview_remoteUnsupported": "远程会话暂不支持文件预览",
+  "toolDetail_previewFile": "在预览栏中打开",
 
   "infoPanel_noInfo": "会话启动后将显示会话信息。",
   "infoPanel_session": "会话",

--- a/src/lib/components/FilePreviewPane.svelte
+++ b/src/lib/components/FilePreviewPane.svelte
@@ -1,0 +1,446 @@
+<script lang="ts">
+  import { getGitDiff, readTextFile, readFileBase64, writeTextFile } from "$lib/api";
+  import { dbg } from "$lib/utils/debug";
+  import { fileName as pathFileName } from "$lib/utils/format";
+  import { t } from "$lib/i18n/index.svelte";
+  import CodeEditor from "$lib/components/CodeEditor.svelte";
+  import MarkdownContent from "$lib/components/MarkdownContent.svelte";
+  import { classifyPath, getExtension, isImage, isPreviewable } from "$lib/utils/preview-ext";
+
+  // ── Props ──
+  let {
+    cwd,
+    path,
+    mode = "preview",
+    editable = false,
+    isRemote = false,
+    scopeKey = "",
+    onLoaded,
+    onLoadFailed,
+    onCloseDiff,
+    onDirtyChange,
+  }: {
+    cwd: string;
+    path: string;
+    mode?: "preview" | "diff";
+    editable?: boolean;
+    isRemote?: boolean;
+    scopeKey?: string;
+    onLoaded?: (path: string) => void;
+    onLoadFailed?: (path: string, err: string) => void;
+    onCloseDiff?: () => void;
+    /** Fires whenever fileDirty transitions; parents can use this for navigation guards. */
+    onDirtyChange?: (dirty: boolean) => void;
+  } = $props();
+
+  // ── State ──
+  let fileContent = $state("");
+  let imageDataUrl = $state("");
+  let originalContent = "";
+  let fileLoading = $state(false);
+  let fileError = $state("");
+  let fileDirty = $state(false);
+  let fileSaving = $state(false);
+  let editorMode = $state<"edit" | "rendered">("edit");
+
+  let diffContent = $state("");
+  let diffLoading = $state(false);
+
+  let loadSeq = 0;
+
+  // ── Diff parsing ──
+  interface DiffLine {
+    text: string;
+    type: "add" | "del" | "context" | "hunk" | "header";
+    oldNum: number | null;
+    newNum: number | null;
+  }
+
+  function parseDiffLines(raw: string): DiffLine[] {
+    const result: DiffLine[] = [];
+    let oldLine = 0;
+    let newLine = 0;
+    for (const text of raw.split("\n")) {
+      if (text.startsWith("@@")) {
+        const match = text.match(/@@ -(\d+)(?:,\d+)? \+(\d+)/);
+        if (match) {
+          oldLine = parseInt(match[1], 10);
+          newLine = parseInt(match[2], 10);
+        }
+        result.push({ text, type: "hunk", oldNum: null, newNum: null });
+      } else if (
+        text.startsWith("diff ") ||
+        text.startsWith("index ") ||
+        text.startsWith("---") ||
+        text.startsWith("+++")
+      ) {
+        result.push({ text, type: "header", oldNum: null, newNum: null });
+      } else if (text.startsWith("+")) {
+        result.push({ text, type: "add", oldNum: null, newNum: newLine });
+        newLine++;
+      } else if (text.startsWith("-")) {
+        result.push({ text, type: "del", oldNum: oldLine, newNum: null });
+        oldLine++;
+      } else {
+        result.push({ text, type: "context", oldNum: oldLine, newNum: newLine });
+        oldLine++;
+        newLine++;
+      }
+    }
+    return result;
+  }
+
+  // ── Loaders ──
+  async function loadPreview(p: string, c: string): Promise<void> {
+    const seq = ++loadSeq;
+    fileError = "";
+    const ext = getExtension(p);
+    editorMode = isPreviewable(ext) ? "rendered" : "edit";
+    fileLoading = true;
+    fileDirty = false;
+    imageDataUrl = "";
+
+    try {
+      if (isImage(ext)) {
+        const [base64, mime] = await readFileBase64(p, c);
+        if (seq !== loadSeq) return;
+        imageDataUrl = `data:${mime};base64,${base64}`;
+        fileContent = "";
+        originalContent = "";
+      } else {
+        const content = await readTextFile(p, c);
+        if (seq !== loadSeq) return;
+        fileContent = content;
+        originalContent = content;
+      }
+      dbg("preview-pane", "file loaded", { path: p, size: fileContent.length });
+      onLoaded?.(p);
+    } catch (e) {
+      if (seq !== loadSeq) return;
+      fileContent = "";
+      originalContent = "";
+      imageDataUrl = "";
+      fileError = String(e);
+      onLoadFailed?.(p, String(e));
+    } finally {
+      if (seq === loadSeq) fileLoading = false;
+    }
+  }
+
+  async function loadDiff(p: string, c: string): Promise<void> {
+    const seq = ++loadSeq;
+    diffLoading = true;
+    diffContent = "";
+    try {
+      let content = await getGitDiff(c, false, p);
+      if (!content.trim()) {
+        content = await getGitDiff(c, true, p);
+      }
+      if (seq !== loadSeq) return;
+      diffContent = content;
+    } catch (e) {
+      if (seq !== loadSeq) return;
+      diffContent = String(e);
+    } finally {
+      if (seq === loadSeq) diffLoading = false;
+    }
+  }
+
+  async function saveFile(): Promise<void> {
+    if (!path || fileSaving || !fileDirty || !editable || isRemote) return;
+    // Snapshot what we're writing — user keystrokes during await must not be silently
+    // marked as saved.
+    const contentToSave = fileContent;
+    fileSaving = true;
+    try {
+      await writeTextFile(path, contentToSave, cwd);
+      originalContent = contentToSave;
+      // Re-evaluate dirty against the latest content; if user typed during the write,
+      // they remain dirty against the just-persisted snapshot.
+      fileDirty = fileContent !== contentToSave;
+      dbg("preview-pane", "file saved", { path, dirtyAfterSave: fileDirty });
+    } catch (e) {
+      dbg("preview-pane", "save error", e);
+    } finally {
+      fileSaving = false;
+    }
+  }
+
+  // ── Reactive load ──
+  // Svelte 5: read all reactive props inside the effect to register dependency tracking.
+  $effect(() => {
+    // Establish dependencies: cwd, path, mode, scopeKey, isRemote
+    void scopeKey;
+    const _cwd = cwd;
+    const _path = path;
+    const _mode = mode;
+    const _isRemote = isRemote;
+
+    // Reset on remote or empty path
+    if (_isRemote || !_path) {
+      ++loadSeq;
+      fileLoading = false;
+      diffLoading = false;
+      fileContent = "";
+      originalContent = "";
+      imageDataUrl = "";
+      diffContent = "";
+      fileError = "";
+      fileDirty = false;
+      return;
+    }
+
+    if (_mode === "diff") {
+      // Diff mode has no editable buffer — clear any lingering preview dirty state so
+      // navigation guards (parent's onDirtyChange mirror) don't keep prompting after the
+      // user already confirmed discard to enter diff.
+      fileDirty = false;
+      originalContent = fileContent;
+      loadDiff(_path, _cwd);
+    } else {
+      loadPreview(_path, _cwd);
+    }
+  });
+
+  // Track dirty state when CodeEditor updates content
+  $effect(() => {
+    if (!fileLoading) {
+      fileDirty = fileContent !== originalContent;
+    }
+  });
+
+  // Notify parent of dirty transitions (for navigation guards in editable contexts)
+  let _lastDirty = false;
+  $effect(() => {
+    const d = fileDirty;
+    if (d !== _lastDirty) {
+      _lastDirty = d;
+      onDirtyChange?.(d);
+    }
+  });
+
+  // ── Derived ──
+  let kind = $derived(classifyPath(path));
+  let displayName = $derived(path ? pathFileName(path) : "");
+  let canSave = $derived(editable && !isRemote && !fileSaving);
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+  {#if isRemote}
+    <!-- Remote unsupported -->
+    <div class="flex flex-1 items-center justify-center p-4">
+      <div class="flex flex-col items-center gap-2 text-center">
+        <svg
+          class="h-8 w-8 text-muted-foreground/40"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><circle cx="12" cy="12" r="10" /><path d="M2 12h20" /><path
+            d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+          /></svg
+        >
+        <p class="text-sm text-muted-foreground">{t("preview_remoteUnsupported")}</p>
+      </div>
+    </div>
+  {:else if !path}
+    <!-- Empty state -->
+    <div class="flex flex-1 items-center justify-center p-4">
+      <div class="flex flex-col items-center gap-2 text-center">
+        <svg
+          class="h-8 w-8 text-muted-foreground/30"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          ><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path
+            d="M14 2v4a2 2 0 0 0 2 2h4"
+          /></svg
+        >
+        <p class="text-sm text-muted-foreground">{t("filesPanel_noPreviewSelected")}</p>
+      </div>
+    </div>
+  {:else if mode === "diff"}
+    <!-- Diff header -->
+    <div class="flex items-center gap-2 border-b px-3 py-1.5 shrink-0">
+      {#if onCloseDiff}
+        <button
+          class="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          onclick={() => onCloseDiff?.()}
+          title={t("explorer_closeDiff")}
+        >
+          <svg
+            class="h-4 w-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="m15 18-6-6 6-6" /></svg
+          >
+        </button>
+      {/if}
+      <span class="text-sm font-medium text-foreground flex-1 min-w-0 truncate">{path}</span>
+    </div>
+    <!-- Diff content -->
+    <div class="flex-1 overflow-auto">
+      {#if diffLoading}
+        <div class="flex items-center justify-center py-12">
+          <div
+            class="h-5 w-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
+          ></div>
+        </div>
+      {:else if diffContent.trim()}
+        {@const diffLines = parseDiffLines(diffContent)}
+        <table class="w-full text-xs font-mono border-collapse">
+          <tbody>
+            {#each diffLines as dl}
+              <tr
+                class={dl.type === "add"
+                  ? "bg-green-500/10"
+                  : dl.type === "del"
+                    ? "bg-red-500/10"
+                    : dl.type === "hunk"
+                      ? "bg-blue-500/5"
+                      : ""}
+              >
+                <td
+                  class="select-none text-right pr-1 pl-2 text-muted-foreground/40 w-[1%] whitespace-nowrap {dl.type ===
+                    'hunk' || dl.type === 'header'
+                    ? 'border-y border-border/30'
+                    : ''}">{dl.oldNum ?? ""}</td
+                >
+                <td
+                  class="select-none text-right pr-2 text-muted-foreground/40 w-[1%] whitespace-nowrap {dl.type ===
+                    'hunk' || dl.type === 'header'
+                    ? 'border-y border-border/30'
+                    : ''}">{dl.newNum ?? ""}</td
+                >
+                <td
+                  class="whitespace-pre pr-4 {dl.type === 'add'
+                    ? 'text-green-600 dark:text-green-400'
+                    : dl.type === 'del'
+                      ? 'text-red-500 dark:text-red-400'
+                      : dl.type === 'hunk'
+                        ? 'text-blue-500 dark:text-blue-400'
+                        : dl.type === 'header'
+                          ? 'font-bold text-foreground'
+                          : ''} {dl.type === 'hunk' || dl.type === 'header'
+                    ? 'border-y border-border/30 py-1'
+                    : ''}">{dl.text}</td
+                >
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {:else}
+        <div class="flex flex-col items-center gap-2 py-12 text-center">
+          <svg
+            class="h-8 w-8 text-muted-foreground/40"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"><path d="M20 6 9 17l-5-5" /></svg
+          >
+          <p class="text-sm text-muted-foreground">{t("explorer_noChanges")}</p>
+        </div>
+      {/if}
+    </div>
+  {:else}
+    <!-- Preview header -->
+    <div class="flex items-center gap-2 border-b px-3 py-1.5 shrink-0">
+      <svg
+        class="h-3.5 w-3.5 shrink-0 opacity-40"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        ><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path
+          d="M14 2v4a2 2 0 0 0 2 2h4"
+        /></svg
+      >
+      <span class="text-sm font-medium text-foreground min-w-0 truncate">{displayName}</span>
+      {#if fileDirty}
+        <span class="h-2 w-2 rounded-full bg-amber-400 shrink-0" title={t("explorer_modified")}
+        ></span>
+      {/if}
+      <span class="text-[11px] text-muted-foreground truncate flex-1 min-w-0">{path}</span>
+      {#if kind === "markdown"}
+        <div class="flex rounded-md border bg-background p-0.5 shrink-0">
+          <button
+            class="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium transition-colors
+              {editorMode === 'edit'
+              ? 'bg-muted text-foreground'
+              : 'text-muted-foreground hover:text-foreground'}"
+            onclick={() => (editorMode = "edit")}
+          >
+            {t("common_edit")}
+          </button>
+          <button
+            class="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium transition-colors
+              {editorMode === 'rendered'
+              ? 'bg-muted text-foreground'
+              : 'text-muted-foreground hover:text-foreground'}"
+            onclick={() => (editorMode = "rendered")}
+          >
+            {t("common_preview")}
+          </button>
+        </div>
+      {/if}
+      {#if editable && kind !== "image"}
+        <button
+          class="rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors shrink-0 disabled:opacity-40 {fileDirty
+            ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+            : 'bg-muted text-muted-foreground cursor-default'}"
+          disabled={!fileDirty || !canSave || editorMode === "rendered"}
+          title={editorMode === "rendered" ? t("explorer_saveDisabledInPreview") : ""}
+          onclick={saveFile}
+        >
+          {fileSaving ? t("explorer_saving") : t("explorer_save")}
+        </button>
+      {/if}
+    </div>
+    <!-- Preview content -->
+    <div class="flex-1 overflow-hidden min-h-0">
+      {#if fileLoading}
+        <div class="flex items-center justify-center py-12">
+          <div
+            class="h-5 w-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
+          ></div>
+        </div>
+      {:else if fileError}
+        <div class="flex flex-1 items-center justify-center p-4">
+          <p class="text-sm text-destructive">{fileError}</p>
+        </div>
+      {:else if kind === "image" && imageDataUrl}
+        <div
+          class="flex items-center justify-center h-full overflow-auto p-4 bg-black/5 dark:bg-white/5"
+        >
+          <img
+            src={imageDataUrl}
+            alt={displayName}
+            class="max-w-full max-h-full object-contain rounded"
+          />
+        </div>
+      {:else if editorMode === "rendered" && kind === "markdown"}
+        <div class="flex-1 overflow-y-auto p-4 h-full">
+          {#if fileContent}
+            <MarkdownContent text={fileContent} basePath={path.replace(/[/\\][^/\\]*$/, "")} />
+          {:else}
+            <p class="text-sm text-muted-foreground italic">{t("explorer_emptyFile")}</p>
+          {/if}
+        </div>
+      {:else if editable}
+        <CodeEditor bind:content={fileContent} filePath={path} onsave={saveFile} class="h-full" />
+      {:else}
+        <CodeEditor bind:content={fileContent} filePath={path} readonly class="h-full" />
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/FilesPanel.svelte
+++ b/src/lib/components/FilesPanel.svelte
@@ -6,9 +6,13 @@
   let {
     fileEntries = [],
     onScrollToTool,
+    onPreview,
+    selectedPath,
   }: {
     fileEntries: FileEntry[];
     onScrollToTool?: (toolUseId: string) => void;
+    onPreview?: (path: string) => void;
+    selectedPath?: string;
   } = $props();
 
   function shortPath(p: string): string {
@@ -52,11 +56,35 @@
     {#each fileEntries as entry, i (entry.path + "-" + i)}
       {@const color = actionColor(entry.action)}
       {@const canJump = !!entry.toolUseId}
+      {@const isSelected = selectedPath !== undefined && entry.path === selectedPath}
       {#if canJump}
         <button
-          class="w-full text-left px-2.5 py-1 hover:bg-accent/50 rounded-sm transition-colors group"
-          onclick={() => onScrollToTool?.(entry.toolUseId!)}
+          class="w-full text-left px-2.5 py-1 rounded-sm transition-colors group {isSelected
+            ? 'bg-accent'
+            : 'hover:bg-accent/50'}"
+          onclick={() => {
+            onScrollToTool?.(entry.toolUseId!);
+            onPreview?.(entry.path);
+          }}
           title={t("toolActivity_scrollToTool")}
+        >
+          <div class="flex items-center gap-1.5">
+            <span
+              class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-bold {color.bg} {color.text}"
+            >
+              {actionLabel(entry.action)}
+            </span>
+            <span class="text-[11px] text-foreground truncate min-w-0 group-hover:underline"
+              >{shortPath(entry.path)}</span
+            >
+          </div>
+        </button>
+      {:else if onPreview}
+        <button
+          class="w-full text-left px-2.5 py-1 rounded-sm transition-colors group {isSelected
+            ? 'bg-accent'
+            : 'hover:bg-accent/50'}"
+          onclick={() => onPreview?.(entry.path)}
         >
           <div class="flex items-center gap-1.5">
             <span

--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -39,6 +39,7 @@
     planContent,
     latestPlanTool,
     showPermissionInPanel,
+    onPreviewFile,
   }: {
     tool: BusToolItem;
     subTimeline?: TimelineEntry[];
@@ -67,6 +68,8 @@
     latestPlanTool?: boolean;
     /** Whether generic tool permissions are handled by the floating PermissionPanel. */
     showPermissionInPanel?: boolean;
+    /** Click on Edit/Write/Read tool card's file path → open preview in right panel. */
+    onPreviewFile?: (path: string) => void;
   } = $props();
 
   // Look up the task notification for this specific Task tool
@@ -1705,7 +1708,7 @@
             </button>
           {/if}
         {:else}
-          <ToolDetailView tool={enrichedTool} {isInputStreaming} />
+          <ToolDetailView tool={enrichedTool} {isInputStreaming} {onPreviewFile} />
         {/if}
       </div>
     {/if}
@@ -1758,6 +1761,7 @@
             {onPermissionRespond}
             {taskNotifications}
             {showPermissionInPanel}
+            {onPreviewFile}
           />
         {/if}
       {/each}

--- a/src/lib/components/ToolActivity.svelte
+++ b/src/lib/components/ToolActivity.svelte
@@ -8,6 +8,8 @@
   import { t } from "$lib/i18n/index.svelte";
   import ContextHistoryPanel from "$lib/components/ContextHistoryPanel.svelte";
   import FilesPanel from "$lib/components/FilesPanel.svelte";
+  import FilePreviewPane from "$lib/components/FilePreviewPane.svelte";
+  import { onMount } from "svelte";
   import SessionInfoPanel from "$lib/components/SessionInfoPanel.svelte";
   import StatusIcon from "$lib/components/StatusIcon.svelte";
   import {
@@ -33,6 +35,10 @@
     requestedTab = $bindable(null as "tools" | "context" | "files" | "info" | "tasks" | null),
     backgroundTasks = new Map(),
     activeBackgroundTasks = [],
+    cwd = "",
+    runId = "",
+    isRemote = false,
+    requestedPreviewPath = $bindable(null as string | null),
   }: {
     timeline: TimelineEntry[];
     tools: HookEvent[];
@@ -47,6 +53,14 @@
     requestedTab?: "tools" | "context" | "files" | "info" | "tasks" | null;
     backgroundTasks?: Map<string, TaskNotificationItem>;
     activeBackgroundTasks?: TaskNotificationItem[];
+    /** Working directory for file preview (typically store.effectiveCwd). */
+    cwd?: string;
+    /** Run id — when it changes the preview is cleared. */
+    runId?: string;
+    /** Remote run flag — disables file preview (file APIs are local-only). */
+    isRemote?: boolean;
+    /** External request to open preview for a path (auto-switches to files tab). */
+    requestedPreviewPath?: string | null;
   } = $props();
 
   // ── Tab state ──
@@ -60,6 +74,135 @@
       requestedTab = null;
     }
   });
+
+  // ── Preview state ──
+  let previewPath = $state<string | null>(null);
+
+  // External preview request → set path + switch tab; consume by setting $bindable to null
+  $effect(() => {
+    if (requestedPreviewPath) {
+      previewPath = requestedPreviewPath;
+      activeTab = "files";
+      requestedPreviewPath = null;
+    }
+  });
+
+  // Clear preview when run changes (different session — paths from previous run no longer relevant)
+  $effect(() => {
+    void runId;
+    previewPath = null;
+  });
+
+  // ── Width state (browser-safe initialization) ──
+  const WIDTH_MIN = 280;
+  const WIDTH_MAX = 720;
+  const WIDTH_DEFAULT = 320;
+  const WIDTH_AUTO_PREVIEW = 560;
+
+  function clampWidth(v: number): number {
+    return Math.max(WIDTH_MIN, Math.min(WIDTH_MAX, v));
+  }
+
+  let savedWidth = $state(WIDTH_DEFAULT);
+  let viewportWidth = $state(1200);
+  /** True once the user has explicitly resized (or loaded a persisted resize). Disables auto-floor. */
+  let userHasResized = $state(false);
+
+  onMount(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem("ocv:toolactivity-width");
+    if (stored) {
+      const n = parseInt(stored, 10);
+      if (Number.isFinite(n)) {
+        savedWidth = clampWidth(n);
+        userHasResized = true;
+      }
+    }
+    viewportWidth = window.innerWidth;
+    const onResize = () => {
+      viewportWidth = window.innerWidth;
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  });
+
+  /**
+   * Effective width displayed:
+   * - If user has explicitly resized (or has a persisted preference) → always respect savedWidth.
+   * - Else if a preview is open → temporarily widen to accommodate code, but DO NOT persist.
+   * - Else → savedWidth (compact default).
+   *
+   * This keeps the auto-widening transient: closing the preview returns to savedWidth, and
+   * once the user drags the handle their preference is honored regardless of preview state.
+   */
+  let effectiveWidth = $derived.by(() => {
+    if (userHasResized) return clampWidth(savedWidth);
+    if (previewPath) {
+      const autoFloor = Math.min(WIDTH_AUTO_PREVIEW, 0.45 * viewportWidth);
+      return clampWidth(Math.max(savedWidth, autoFloor));
+    }
+    return clampWidth(savedWidth);
+  });
+
+  // ── Resize handle (VS Code-style: ghost line during drag, single commit on release) ──
+  // Why this approach: in-place live resize forces chat-main reflow on every pointermove,
+  // which is too expensive with thousands of chat DOM nodes. Instead, during drag we DON'T
+  // move any panel — only render a fixed-position vertical line at the cursor that previews
+  // the new boundary. On release we commit savedWidth ONCE → single reflow.
+  let resizing = $state(false);
+  let ghostX = $state(0);
+  let resizeStartX = 0;
+  let resizeStartWidth = 0;
+  let pendingWidth: number | null = null;
+  let rafId: number | null = null;
+  let asideEl: HTMLElement | undefined = $state();
+
+  function onResizeStart(e: PointerEvent) {
+    resizing = true;
+    resizeStartX = e.clientX;
+    resizeStartWidth = effectiveWidth;
+    pendingWidth = resizeStartWidth;
+    ghostX = e.clientX;
+    (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
+    e.preventDefault();
+  }
+
+  function flushGhostFrame() {
+    rafId = null;
+    // ghostX state already updated; this is just a frame-aligned re-render gate.
+  }
+
+  function onResizeMove(e: PointerEvent) {
+    if (!resizing) return;
+    const delta = resizeStartX - e.clientX; // dragging left grows the panel
+    pendingWidth = clampWidth(resizeStartWidth + delta);
+    // Snap ghost line to the new panel boundary (clamped). Aside is on the right side of
+    // the viewport, so its left edge after commit = window.innerWidth - pendingWidth.
+    const wantedX = typeof window !== "undefined" ? window.innerWidth - pendingWidth : e.clientX;
+    if (rafId === null && typeof window !== "undefined") {
+      rafId = window.requestAnimationFrame(flushGhostFrame);
+    }
+    ghostX = wantedX;
+  }
+
+  function onResizeEnd(e: PointerEvent) {
+    if (!resizing) return;
+    resizing = false;
+    if (rafId !== null && typeof window !== "undefined") {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    (e.target as HTMLElement).releasePointerCapture?.(e.pointerId);
+
+    if (pendingWidth !== null && pendingWidth !== savedWidth) {
+      savedWidth = pendingWidth;
+      userHasResized = true;
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("ocv:toolactivity-width", String(savedWidth));
+      }
+    }
+    pendingWidth = null;
+  }
 
   // ── Helpers ──
 
@@ -416,8 +559,45 @@
   {/if}
 {/snippet}
 
-{#if !collapsed}
-  <div class="flex h-full flex-col border-l border-border bg-muted/30" style="width: 280px;">
+<!--
+  Outer wrapper is ALWAYS mounted: width animates between 32px (collapsed) and effectiveWidth.
+  The expanded panel inside stays in the DOM at full width but is visually clipped + hidden when
+  collapsed, so CodeMirror (FilePreviewPane) is never torn down on collapse toggle. This is the
+  fix for "files tab + click expand briefly hangs".
+-->
+{#if resizing}
+  <!-- Ghost line during drag: zero-cost preview, no layout reflow elsewhere -->
+  <div
+    class="fixed top-0 bottom-0 w-0.5 bg-primary/60 z-[9999] pointer-events-none"
+    style="left: {ghostX}px;"
+  ></div>
+{/if}
+<aside
+  bind:this={asideEl}
+  class="relative h-full border-l border-border bg-muted/30 overflow-hidden"
+  style="width: {collapsed ? '32px' : effectiveWidth + 'px'}; contain: layout style;"
+>
+  <!-- Always-mounted expanded panel (visibility-hidden when collapsed) -->
+  <div
+    class="absolute top-0 left-0 h-full flex flex-col"
+    style="width: {effectiveWidth}px; visibility: {collapsed
+      ? 'hidden'
+      : 'visible'}; pointer-events: {collapsed ? 'none' : 'auto'};"
+    aria-hidden={collapsed}
+  >
+    <!-- Resize handle on the left edge -->
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      tabindex="-1"
+      class="absolute left-0 top-0 h-full w-1 cursor-col-resize hover:bg-primary/30 active:bg-primary/50 z-20 {resizing
+        ? 'bg-primary/50'
+        : ''}"
+      onpointerdown={onResizeStart}
+      onpointermove={onResizeMove}
+      onpointerup={onResizeEnd}
+      onpointercancel={onResizeEnd}
+    ></div>
     <!-- Header: 4 icon tabs -->
     <div class="px-2 py-1.5 border-b border-border">
       <div class="flex items-center justify-between">
@@ -625,7 +805,26 @@
     {:else if activeTab === "context"}
       <ContextHistoryPanel history={contextHistory} {turnUsages} {sessionInfo} />
     {:else if activeTab === "files"}
-      <FilesPanel {fileEntries} {onScrollToTool} />
+      <div class="flex flex-1 flex-col min-h-0">
+        <div class="flex-shrink-0 max-h-[40vh] overflow-y-auto border-b border-border/50">
+          <FilesPanel
+            {fileEntries}
+            {onScrollToTool}
+            onPreview={(p) => (previewPath = p)}
+            selectedPath={previewPath ?? undefined}
+          />
+        </div>
+        <div class="flex-1 min-h-0 overflow-hidden">
+          <FilePreviewPane
+            {cwd}
+            path={previewPath ?? ""}
+            mode="preview"
+            editable={false}
+            {isRemote}
+            scopeKey={runId}
+          />
+        </div>
+      </div>
     {:else if activeTab === "info"}
       <!-- Subagents section (shown above session info when Task tools exist) -->
       {#if subagents.length > 0}
@@ -864,155 +1063,156 @@
       {/if}
     {/if}
   </div>
-{:else}
-  <!-- Collapsed: thin bar with 4 icon buttons vertically -->
-  <div
-    class="flex flex-col items-center border-l border-border bg-muted/30 py-2 px-1 gap-1"
-    style="width: 32px;"
-  >
-    <button
-      class="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-accent"
-      onclick={onToggle}
-      title={t("toolActivity_show")}
+  {#if collapsed}
+    <!-- Collapsed: thin icon rail overlay (absolute, only mounted when collapsed) -->
+    <div
+      class="absolute top-0 left-0 h-full flex flex-col items-center py-2 px-1 gap-1"
+      style="width: 32px;"
     >
-      <svg
-        class="h-4 w-4"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+      <button
+        class="text-muted-foreground hover:text-foreground transition-colors p-1 rounded hover:bg-accent"
+        onclick={onToggle}
+        title={t("toolActivity_show")}
       >
-        <polyline points="9 18 15 12 9 6" />
-      </svg>
-    </button>
-    <!-- Collapsed icon buttons -->
-    <button
-      class="p-1 rounded transition-colors {activeTab === 'tools'
-        ? 'text-foreground bg-accent'
-        : 'text-muted-foreground/50 hover:text-muted-foreground'}"
-      onclick={() => {
-        activeTab = "tools";
-        onToggle();
-      }}
-      title={t("toolActivity_tabTools")}
-    >
-      <svg
-        class="h-3.5 w-3.5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        <svg
+          class="h-4 w-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+      <!-- Collapsed icon buttons -->
+      <button
+        class="p-1 rounded transition-colors {activeTab === 'tools'
+          ? 'text-foreground bg-accent'
+          : 'text-muted-foreground/50 hover:text-muted-foreground'}"
+        onclick={() => {
+          activeTab = "tools";
+          onToggle();
+        }}
+        title={t("toolActivity_tabTools")}
       >
-        <path
-          d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
-        />
-      </svg>
-    </button>
-    <button
-      class="p-1 rounded transition-colors {activeTab === 'context'
-        ? 'text-foreground bg-accent'
-        : 'text-muted-foreground/50 hover:text-muted-foreground'}"
-      onclick={() => {
-        activeTab = "context";
-        onToggle();
-      }}
-      title={t("toolActivity_tabContext")}
-    >
-      <svg
-        class="h-3.5 w-3.5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        <svg
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path
+            d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"
+          />
+        </svg>
+      </button>
+      <button
+        class="p-1 rounded transition-colors {activeTab === 'context'
+          ? 'text-foreground bg-accent'
+          : 'text-muted-foreground/50 hover:text-muted-foreground'}"
+        onclick={() => {
+          activeTab = "context";
+          onToggle();
+        }}
+        title={t("toolActivity_tabContext")}
       >
-        <circle cx="12" cy="12" r="10" />
-        <polyline points="12 6 12 12 16 14" />
-      </svg>
-    </button>
-    <button
-      class="p-1 rounded transition-colors {activeTab === 'files'
-        ? 'text-foreground bg-accent'
-        : 'text-muted-foreground/50 hover:text-muted-foreground'}"
-      onclick={() => {
-        activeTab = "files";
-        onToggle();
-      }}
-      title={t("toolActivity_tabFiles")}
-    >
-      <svg
-        class="h-3.5 w-3.5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        <svg
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+      </button>
+      <button
+        class="p-1 rounded transition-colors {activeTab === 'files'
+          ? 'text-foreground bg-accent'
+          : 'text-muted-foreground/50 hover:text-muted-foreground'}"
+        onclick={() => {
+          activeTab = "files";
+          onToggle();
+        }}
+        title={t("toolActivity_tabFiles")}
       >
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-        <polyline points="14 2 14 8 20 8" />
-      </svg>
-    </button>
-    <button
-      class="p-1 rounded transition-colors {activeTab === 'info'
-        ? 'text-foreground bg-accent'
-        : 'text-muted-foreground/50 hover:text-muted-foreground'}"
-      onclick={() => {
-        activeTab = "info";
-        onToggle();
-      }}
-      title={t("toolActivity_tabInfo")}
-    >
-      <svg
-        class="h-3.5 w-3.5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        <svg
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+        </svg>
+      </button>
+      <button
+        class="p-1 rounded transition-colors {activeTab === 'info'
+          ? 'text-foreground bg-accent'
+          : 'text-muted-foreground/50 hover:text-muted-foreground'}"
+        onclick={() => {
+          activeTab = "info";
+          onToggle();
+        }}
+        title={t("toolActivity_tabInfo")}
       >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="12" y1="16" x2="12" y2="12" />
-        <line x1="12" y1="8" x2="12.01" y2="8" />
-      </svg>
-    </button>
-    <button
-      class="p-1 rounded transition-colors relative {activeTab === 'tasks'
-        ? 'text-foreground bg-accent'
-        : 'text-muted-foreground/50 hover:text-muted-foreground'}"
-      onclick={() => {
-        activeTab = "tasks";
-        onToggle();
-      }}
-      title={t("toolActivity_tabTasks")}
-    >
-      <svg
-        class="h-3.5 w-3.5"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        <svg
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="16" x2="12" y2="12" />
+          <line x1="12" y1="8" x2="12.01" y2="8" />
+        </svg>
+      </button>
+      <button
+        class="p-1 rounded transition-colors relative {activeTab === 'tasks'
+          ? 'text-foreground bg-accent'
+          : 'text-muted-foreground/50 hover:text-muted-foreground'}"
+        onclick={() => {
+          activeTab = "tasks";
+          onToggle();
+        }}
+        title={t("toolActivity_tabTasks")}
       >
-        <rect x="3" y="3" width="18" height="18" rx="2" />
-        <path d="M9 12l2 2 4-4" />
-      </svg>
-      {#if activeBackgroundTasks.length > 0}
-        <span class="absolute top-0 right-0 h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse"
-        ></span>
+        <svg
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <rect x="3" y="3" width="18" height="18" rx="2" />
+          <path d="M9 12l2 2 4-4" />
+        </svg>
+        {#if activeBackgroundTasks.length > 0}
+          <span class="absolute top-0 right-0 h-1.5 w-1.5 rounded-full bg-blue-400 animate-pulse"
+          ></span>
+        {/if}
+      </button>
+      {#if toolStats.totalToolCount > 0}
+        <span class="mt-1 text-[10px] text-muted-foreground" style="writing-mode: vertical-rl;"
+          >{toolStats.totalToolCount}</span
+        >
       {/if}
-    </button>
-    {#if toolStats.totalToolCount > 0}
-      <span class="mt-1 text-[10px] text-muted-foreground" style="writing-mode: vertical-rl;"
-        >{toolStats.totalToolCount}</span
-      >
-    {/if}
-  </div>
-{/if}
+    </div>
+  {/if}
+</aside>

--- a/src/lib/components/ToolDetailView.svelte
+++ b/src/lib/components/ToolDetailView.svelte
@@ -33,9 +33,11 @@
   let {
     tool,
     isInputStreaming = false,
+    onPreviewFile,
   }: {
     tool: BusToolItem;
     isInputStreaming?: boolean;
+    onPreviewFile?: (path: string) => void;
   } = $props();
 
   // ── Helpers ──
@@ -598,7 +600,16 @@
     <!-- Read: syntax-highlighted code with line numbers or image -->
     {#if filePath}
       <div class="tool-file-header flex items-center justify-between rounded-t">
-        <span class="truncate">{filePath}</span>
+        {#if onPreviewFile}
+          <button
+            type="button"
+            class="truncate text-left hover:text-foreground hover:underline transition-colors min-w-0"
+            onclick={() => onPreviewFile?.(filePath)}
+            title={t("toolDetail_previewFile") ?? filePath}>{filePath}</button
+          >
+        {:else}
+          <span class="truncate">{filePath}</span>
+        {/if}
         <div class="flex items-center gap-2 shrink-0">
           {#if readLineInfo}
             <span class="text-[10px] text-muted-foreground/60">{readLineInfo}</span>
@@ -668,7 +679,16 @@
   {:else if tool.tool_name === "Edit" || tool.tool_name === "edit_file"}
     <!-- Edit: diff view — structured patch (preferred) or old/new fallback -->
     {#if filePath}
-      <div class="tool-file-header rounded-t">{filePath}</div>
+      {#if onPreviewFile}
+        <button
+          type="button"
+          class="tool-file-header rounded-t w-full text-left hover:text-foreground hover:underline transition-colors"
+          onclick={() => onPreviewFile?.(filePath)}
+          title={t("toolDetail_previewFile") ?? filePath}>{filePath}</button
+        >
+      {:else}
+        <div class="tool-file-header rounded-t">{filePath}</div>
+      {/if}
     {/if}
     {#if editHasPatches}
       <!-- Structured unified diff from tool_use_result (adjust line numbers if needed) -->
@@ -751,7 +771,16 @@
   {:else if tool.tool_name === "Write" || tool.tool_name === "write_file"}
     <!-- Write: structuredPatch diff (overwrite) or content preview (new file) -->
     {#if filePath}
-      <div class="tool-file-header rounded-t">{filePath}</div>
+      {#if onPreviewFile}
+        <button
+          type="button"
+          class="tool-file-header rounded-t w-full text-left hover:text-foreground hover:underline transition-colors"
+          onclick={() => onPreviewFile?.(filePath)}
+          title={t("toolDetail_previewFile") ?? filePath}>{filePath}</button
+        >
+      {:else}
+        <div class="tool-file-header rounded-t">{filePath}</div>
+      {/if}
     {/if}
     <!-- Plan file (.claude/plans/*.md): render content as markdown instead of diff/code.
          This intentionally takes priority over writeHasPatches — plan files are meant to be

--- a/src/lib/utils/__tests__/preview-ext.test.ts
+++ b/src/lib/utils/__tests__/preview-ext.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import {
+  IMAGE_EXTENSIONS,
+  PREVIEWABLE_EXTENSIONS,
+  classifyPath,
+  getExtension,
+  isImage,
+  isPreviewable,
+} from "../preview-ext";
+
+describe("getExtension", () => {
+  it("extracts lowercase extension", () => {
+    expect(getExtension("README.md")).toBe("md");
+    expect(getExtension("photo.PNG")).toBe("png");
+    expect(getExtension("path/to/file.TS")).toBe("ts");
+  });
+  it("returns empty string for files with no extension", () => {
+    expect(getExtension("Makefile")).toBe("makefile");
+    expect(getExtension("")).toBe("");
+  });
+  it("uses only the last dot segment", () => {
+    expect(getExtension("archive.tar.gz")).toBe("gz");
+  });
+});
+
+describe("isPreviewable", () => {
+  it("matches markdown extensions", () => {
+    expect(isPreviewable("md")).toBe(true);
+    expect(isPreviewable("markdown")).toBe(true);
+  });
+  it("rejects others", () => {
+    expect(isPreviewable("ts")).toBe(false);
+    expect(isPreviewable("png")).toBe(false);
+    expect(isPreviewable("")).toBe(false);
+  });
+});
+
+describe("isImage", () => {
+  it("matches common image extensions", () => {
+    for (const ext of ["png", "jpg", "jpeg", "gif", "svg", "webp", "ico", "bmp", "avif"]) {
+      expect(isImage(ext)).toBe(true);
+    }
+  });
+  it("rejects non-image", () => {
+    expect(isImage("md")).toBe(false);
+    expect(isImage("ts")).toBe(false);
+    expect(isImage("")).toBe(false);
+  });
+});
+
+describe("classifyPath", () => {
+  it("classifies markdown", () => {
+    expect(classifyPath("notes.md")).toBe("markdown");
+    expect(classifyPath("foo/bar.markdown")).toBe("markdown");
+  });
+  it("classifies images", () => {
+    expect(classifyPath("a.png")).toBe("image");
+    expect(classifyPath("dir/photo.JPEG")).toBe("image");
+  });
+  it("falls back to text", () => {
+    expect(classifyPath("src/main.ts")).toBe("text");
+    expect(classifyPath("Makefile")).toBe("text");
+    expect(classifyPath("")).toBe("text");
+  });
+});
+
+describe("constants", () => {
+  it("PREVIEWABLE includes md and markdown only", () => {
+    expect(PREVIEWABLE_EXTENSIONS.has("md")).toBe(true);
+    expect(PREVIEWABLE_EXTENSIONS.has("markdown")).toBe(true);
+    expect(PREVIEWABLE_EXTENSIONS.size).toBe(2);
+  });
+  it("IMAGE has expected entries", () => {
+    expect(IMAGE_EXTENSIONS.has("png")).toBe(true);
+    expect(IMAGE_EXTENSIONS.has("avif")).toBe(true);
+    expect(IMAGE_EXTENSIONS.has("md")).toBe(false);
+  });
+});

--- a/src/lib/utils/preview-ext.ts
+++ b/src/lib/utils/preview-ext.ts
@@ -1,0 +1,37 @@
+export const PREVIEWABLE_EXTENSIONS: ReadonlySet<string> = new Set(["md", "markdown"]);
+
+export const IMAGE_EXTENSIONS: ReadonlySet<string> = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "ico",
+  "bmp",
+  "avif",
+  "tif",
+  "tiff",
+  "jfif",
+]);
+
+export type PreviewKind = "markdown" | "image" | "text";
+
+export function getExtension(path: string): string {
+  return path.split(".").pop()?.toLowerCase() ?? "";
+}
+
+export function isPreviewable(ext: string): boolean {
+  return PREVIEWABLE_EXTENSIONS.has(ext);
+}
+
+export function isImage(ext: string): boolean {
+  return IMAGE_EXTENSIONS.has(ext);
+}
+
+export function classifyPath(path: string): PreviewKind {
+  const ext = getExtension(path);
+  if (isImage(ext)) return "image";
+  if (isPreviewable(ext)) return "markdown";
+  return "text";
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -130,31 +130,53 @@
   let searchRequestId = $state(0);
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // ── Sidebar resize ──
+  // ── Sidebar resize (ghost-line strategy: zero reflow during drag, single commit on release) ──
   function loadSidebarWidth(): number {
     if (typeof window === "undefined") return 280;
     const raw = parseInt(localStorage.getItem("ocv:sidebar-width") ?? "", 10);
     return Number.isFinite(raw) ? Math.min(500, Math.max(180, raw)) : 280;
   }
   let sidebarWidth = $state(loadSidebarWidth());
+  let sidebarResizing = $state(false);
+  let sidebarGhostX = $state(0);
   let resizeCleanup: (() => void) | null = null;
 
   function startResize(e: MouseEvent) {
     e.preventDefault();
     const startX = e.clientX;
     const startWidth = sidebarWidth;
+    let pendingWidth = startWidth;
+    sidebarResizing = true;
+    sidebarGhostX = startWidth; // ghost is anchored to sidebar's right edge (= width from left)
     dbg("layout", "sidebar resize start", { startWidth });
     document.body.style.userSelect = "none";
     document.body.style.cursor = "col-resize";
 
+    let rafId: number | null = null;
+    function flush() {
+      rafId = null;
+    }
+
     function onMove(ev: MouseEvent) {
-      sidebarWidth = Math.min(500, Math.max(180, startWidth + (ev.clientX - startX)));
+      pendingWidth = Math.min(500, Math.max(180, startWidth + (ev.clientX - startX)));
+      // Ghost line follows the cursor's clamped X so the user sees exactly where the
+      // boundary will land. (Aside's left edge varies with left rail width — this avoids
+      // having to query the aside's getBoundingClientRect every frame.)
+      sidebarGhostX = startX + (pendingWidth - startWidth);
+      if (rafId === null) rafId = window.requestAnimationFrame(flush);
     }
     function cleanup() {
       document.removeEventListener("mousemove", onMove);
       document.removeEventListener("mouseup", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
+      if (rafId !== null) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      // Commit ONCE on release → single layout reflow.
+      sidebarWidth = pendingWidth;
+      sidebarResizing = false;
       resizeCleanup = null;
       localStorage.setItem("ocv:sidebar-width", String(sidebarWidth));
       dbg("layout", "sidebar resize end", { width: sidebarWidth });
@@ -2225,6 +2247,14 @@
         ></div>
       </div>
     </aside>
+  {/if}
+
+  <!-- Ghost line during sidebar drag (zero-reflow preview) -->
+  {#if sidebarResizing}
+    <div
+      class="fixed top-0 bottom-0 w-0.5 bg-primary/60 z-[9999] pointer-events-none"
+      style="left: {sidebarGhostX}px;"
+    ></div>
   {/if}
 
   <!-- Main content -->

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -247,6 +247,24 @@
   let statusBarRef: SessionStatusBar | undefined = $state();
   let stashedInput: PromptInputSnapshot | null = $state(null);
   let sidebarRequestedTab = $state<"tools" | "context" | "files" | "info" | "tasks" | null>(null);
+  let requestedPreviewPath = $state<string | null>(null);
+
+  function openPreviewForPath(path: string) {
+    if (!path) return;
+    requestedPreviewPath = path;
+    sidebarRequestedTab = "files";
+    if (sidebarCollapsed) sidebarCollapsed = false;
+  }
+
+  // Clear preview when run changes (defense-in-depth; ToolActivity also clears via its runId effect)
+  let _lastPreviewClearRunId = "__unset__";
+  $effect(() => {
+    const id = store.run?.id ?? "";
+    if (id !== _lastPreviewClearRunId) {
+      _lastPreviewClearRunId = id;
+      requestedPreviewPath = null;
+    }
+  });
 
   // ── Verbose state (chat page level) ──
   let verboseEnabled = $state(false);
@@ -3953,6 +3971,7 @@
                               latestPlanTool={entry.kind === "tool" &&
                                 entry.tool.tool_use_id === latestPlanToolId}
                               showPermissionInPanel={showPermissionPanel}
+                              onPreviewFile={openPreviewForPath}
                             />
                           </div>
                         </div>
@@ -4643,6 +4662,10 @@
       bind:requestedTab={sidebarRequestedTab}
       backgroundTasks={store.taskNotifications}
       activeBackgroundTasks={store.activeBackgroundTasks}
+      cwd={store.effectiveCwd}
+      runId={store.run?.id ?? ""}
+      isRemote={store.isRemote}
+      bind:requestedPreviewPath
     />
   {/if}
 

--- a/src/routes/explorer/+page.svelte
+++ b/src/routes/explorer/+page.svelte
@@ -1,270 +1,109 @@
 <script lang="ts">
-  import { getGitDiff, readTextFile, readFileBase64, writeTextFile } from "$lib/api";
   import { dbg, dbgWarn } from "$lib/utils/debug";
-  import { fileName as pathFileName } from "$lib/utils/format";
-  import { t } from "$lib/i18n/index.svelte";
   import { onMount } from "svelte";
-  import CodeEditor from "$lib/components/CodeEditor.svelte";
-  import MarkdownContent from "$lib/components/MarkdownContent.svelte";
+  import FilePreviewPane from "$lib/components/FilePreviewPane.svelte";
+  import { t } from "$lib/i18n/index.svelte";
   import { getCachedFile, setCachedFile, clearCachedFile } from "$lib/utils/explorer-state";
 
   // ── State ──
 
   let selectedFilePath = $state("");
   let diffViewFile = $state<string | null>(null);
-  let diffViewContent = $state("");
-  let diffViewLoading = $state(false);
-
-  let fileContent = $state("");
-  let fileLoading = $state(false);
-  let fileSaving = $state(false);
-  let fileDirty = $state(false);
-  let fileError = $state("");
   let activeView = $state<"preview" | "diff">("preview");
-  let editorMode = $state<"edit" | "rendered">("edit");
-
-  const PREVIEWABLE_EXTENSIONS = new Set(["md", "markdown"]);
-  const IMAGE_EXTENSIONS = new Set([
-    "png",
-    "jpg",
-    "jpeg",
-    "gif",
-    "svg",
-    "webp",
-    "ico",
-    "bmp",
-    "avif",
-    "tif",
-    "tiff",
-    "jfif",
-  ]);
-
-  let selectedExt = $derived(selectedFilePath.split(".").pop()?.toLowerCase() ?? "");
-  let isPreviewable = $derived(PREVIEWABLE_EXTENSIONS.has(selectedExt));
-  let isImage = $derived(IMAGE_EXTENSIONS.has(selectedExt));
-
-  /** Base64 data URL for image preview */
-  let imageDataUrl = $state("");
 
   let projectCwd = $state(
     typeof window !== "undefined" ? (localStorage.getItem("ocv:project-cwd") ?? "") : "",
   );
 
-  // Track original content to detect dirty state
-  let originalContent = "";
+  /** True while we're restoring from cache — onLoadFailed should clear that cache entry. */
+  let restoringFromCache = false;
 
-  // ── Diff parsing ──
+  /** Mirror of FilePreviewPane.fileDirty for navigation guards. */
+  let paneDirty = $state(false);
 
-  interface DiffLine {
-    text: string;
-    type: "add" | "del" | "context" | "hunk" | "header";
-    oldNum: number | null;
-    newNum: number | null;
+  /** Returns true if it's safe to navigate away (no dirty changes, or user confirmed discard). */
+  function canDiscardEdits(): boolean {
+    if (!paneDirty) return true;
+    return confirm(t("explorer_discardConfirm"));
   }
 
-  function parseDiffLines(raw: string): DiffLine[] {
-    const result: DiffLine[] = [];
-    let oldLine = 0;
-    let newLine = 0;
-    for (const text of raw.split("\n")) {
-      if (text.startsWith("@@")) {
-        const match = text.match(/@@ -(\d+)(?:,\d+)? \+(\d+)/);
-        if (match) {
-          oldLine = parseInt(match[1], 10);
-          newLine = parseInt(match[2], 10);
-        }
-        result.push({ text, type: "hunk", oldNum: null, newNum: null });
-      } else if (
-        text.startsWith("diff ") ||
-        text.startsWith("index ") ||
-        text.startsWith("---") ||
-        text.startsWith("+++")
-      ) {
-        result.push({ text, type: "header", oldNum: null, newNum: null });
-      } else if (text.startsWith("+")) {
-        result.push({ text, type: "add", oldNum: null, newNum: newLine });
-        newLine++;
-      } else if (text.startsWith("-")) {
-        result.push({ text, type: "del", oldNum: oldLine, newNum: null });
-        oldLine++;
-      } else {
-        result.push({ text, type: "context", oldNum: oldLine, newNum: newLine });
-        oldLine++;
-        newLine++;
-      }
-    }
-    return result;
-  }
+  // ── Pane control ──
 
-  // ── File preview ──
-
-  type LoadResult = "loaded" | "failed" | "stale";
-  let loadSeq = 0;
-
-  async function loadFilePreview(path: string, skipDirtyCheck = false): Promise<LoadResult> {
-    if (!skipDirtyCheck && fileDirty && !confirm(t("explorer_discardConfirm"))) return "stale";
-
-    const seq = ++loadSeq;
-    const requestedCwd = projectCwd;
-
+  function selectFile(path: string) {
+    if (path === selectedFilePath && activeView === "preview") return;
+    if (!canDiscardEdits()) return;
     selectedFilePath = path;
     activeView = "preview";
-    fileError = "";
-    const ext = path.split(".").pop()?.toLowerCase() ?? "";
-    editorMode = PREVIEWABLE_EXTENSIONS.has(ext) ? "rendered" : "edit";
-    fileLoading = true;
-    fileDirty = false;
-    imageDataUrl = "";
-
-    try {
-      if (IMAGE_EXTENSIONS.has(ext)) {
-        const [base64, mime] = await readFileBase64(path, requestedCwd);
-        if (seq !== loadSeq) return "stale";
-        imageDataUrl = `data:${mime};base64,${base64}`;
-        fileContent = "";
-        originalContent = "";
-      } else {
-        const content = await readTextFile(path, requestedCwd);
-        if (seq !== loadSeq) return "stale";
-        fileContent = content;
-        originalContent = content;
-      }
-      setCachedFile(requestedCwd, path);
-      dbg("explorer", "file loaded", { path, size: fileContent.length });
-      return "loaded";
-    } catch (e) {
-      if (seq !== loadSeq) return "stale";
-      fileContent = "";
-      originalContent = "";
-      imageDataUrl = "";
-      fileError = String(e);
-      return "failed";
-    } finally {
-      if (seq === loadSeq) fileLoading = false;
-    }
+    diffViewFile = null;
   }
 
-  async function saveFile() {
-    if (!selectedFilePath || fileSaving || !fileDirty) return;
-    fileSaving = true;
-    try {
-      await writeTextFile(selectedFilePath, fileContent, projectCwd);
-      originalContent = fileContent;
-      fileDirty = false;
-      dbg("explorer", "file saved", { path: selectedFilePath });
-    } catch (e) {
-      dbg("explorer", "save error", e);
-    } finally {
-      fileSaving = false;
-    }
-  }
-
-  // Track dirty state when CodeEditor updates content
-  $effect(() => {
-    if (!fileLoading) {
-      fileDirty = fileContent !== originalContent;
-    }
-  });
-
-  async function openFileDiff(filePath: string) {
+  function openFileDiff(filePath: string) {
+    if (!canDiscardEdits()) return;
     diffViewFile = filePath;
     activeView = "diff";
-    diffViewLoading = true;
-    diffViewContent = "";
-    try {
-      let content = await getGitDiff(projectCwd, false, filePath);
-      if (!content.trim()) {
-        content = await getGitDiff(projectCwd, true, filePath);
-      }
-      diffViewContent = content;
-    } catch (e) {
-      diffViewContent = String(e);
-    } finally {
-      diffViewLoading = false;
-    }
   }
 
   function closeDiffView() {
     diffViewFile = null;
-    diffViewContent = "";
     activeView = "preview";
   }
 
-  function fileName(path: string): string {
-    return pathFileName(path);
+  function handleLoaded(p: string) {
+    setCachedFile(projectCwd, p);
+    restoringFromCache = false;
+  }
+
+  function handleLoadFailed(p: string, err: string) {
+    if (restoringFromCache) {
+      dbgWarn("explorer", "cache restore failed, clearing", { cwd: projectCwd, cached: p, err });
+      clearCachedFile(projectCwd);
+      selectedFilePath = "";
+      restoringFromCache = false;
+      window.dispatchEvent(new CustomEvent("ocv:explorer-file-selected", { detail: { path: "" } }));
+    }
   }
 
   // ── Lifecycle ──
 
   onMount(() => {
-    // Listen for file selection from sidebar (layout)
     function onExplorerFile(e: Event) {
       const path = (e as CustomEvent).detail?.path;
-      if (path) loadFilePreview(path);
+      if (path) selectFile(path);
     }
     window.addEventListener("ocv:explorer-file", onExplorerFile);
 
-    // Listen for diff selection from sidebar Git tab (layout)
     function onExplorerDiff(e: Event) {
       const path = (e as CustomEvent).detail?.path;
       if (path) openFileDiff(path);
     }
     window.addEventListener("ocv:explorer-diff", onExplorerDiff);
 
-    // Listen for project cwd changes from layout
     function onProjectChanged(e: Event) {
       const cwd = (e as CustomEvent).detail?.cwd ?? "";
       if (cwd === projectCwd) return;
-      if (fileDirty && !confirm(t("explorer_discardConfirm"))) return;
+      if (!canDiscardEdits()) return;
 
-      // Save current project state
+      // Save current project state before switching
       if (projectCwd && selectedFilePath) {
         setCachedFile(projectCwd, selectedFilePath);
       }
 
-      // Invalidate in-flight async loads
-      ++loadSeq;
-      fileLoading = false;
-
-      // Clear dirty state
-      fileDirty = false;
-      originalContent = fileContent;
-
-      // Switch project
+      // Switch project; pane will see scopeKey change and reset
       projectCwd = cwd;
       diffViewFile = null;
-      diffViewContent = "";
       activeView = "preview";
-      fileError = "";
-      imageDataUrl = "";
 
-      // Restore cached state
       const cached = getCachedFile(cwd);
       if (cached) {
-        const restoreCwd = cwd;
         dbg("explorer", "restoring cached file on project switch", { cwd, cached });
+        restoringFromCache = true;
+        selectedFilePath = cached;
         window.dispatchEvent(
           new CustomEvent("ocv:explorer-file-selected", { detail: { path: cached } }),
         );
-        loadFilePreview(cached, true).then((result) => {
-          if (result === "failed") {
-            dbgWarn("explorer", "cache restore failed, clearing", { cwd: restoreCwd, cached });
-            clearCachedFile(restoreCwd);
-            selectedFilePath = "";
-            fileContent = "";
-            originalContent = "";
-            imageDataUrl = "";
-            fileError = "";
-            window.dispatchEvent(
-              new CustomEvent("ocv:explorer-file-selected", { detail: { path: "" } }),
-            );
-          }
-        });
       } else {
         dbg("explorer", "no cache for project, clearing", { cwd });
         selectedFilePath = "";
-        fileContent = "";
-        originalContent = "";
         window.dispatchEvent(
           new CustomEvent("ocv:explorer-file-selected", { detail: { path: "" } }),
         );
@@ -272,32 +111,18 @@
     }
     window.addEventListener("ocv:project-changed", onProjectChanged);
 
-    // Restore cached file state on mount (e.g. navigating back to /explorer)
+    // Restore cached file state on mount
     const cached = getCachedFile(projectCwd);
     if (cached && !selectedFilePath) {
-      const restoreCwd = projectCwd;
       dbg("explorer", "restoring cached file on mount", { cwd: projectCwd, cached });
+      restoringFromCache = true;
+      selectedFilePath = cached;
       window.dispatchEvent(
         new CustomEvent("ocv:explorer-file-selected", { detail: { path: cached } }),
       );
-      loadFilePreview(cached, true).then((result) => {
-        if (result === "failed") {
-          dbgWarn("explorer", "mount cache restore failed, clearing", { cwd: restoreCwd, cached });
-          clearCachedFile(restoreCwd);
-          selectedFilePath = "";
-          fileContent = "";
-          originalContent = "";
-          imageDataUrl = "";
-          fileError = "";
-          window.dispatchEvent(
-            new CustomEvent("ocv:explorer-file-selected", { detail: { path: "" } }),
-          );
-        }
-      });
     }
 
     return () => {
-      // Save state on unmount (leaving /explorer)
       if (projectCwd && selectedFilePath) {
         dbg("explorer", "saving file state on unmount", {
           cwd: projectCwd,
@@ -310,241 +135,22 @@
       window.removeEventListener("ocv:project-changed", onProjectChanged);
     };
   });
+
+  // Path passed to pane: in diff mode use diffViewFile, else selectedFilePath
+  let panePath = $derived(activeView === "diff" ? (diffViewFile ?? "") : selectedFilePath);
 </script>
 
 <div class="flex h-full flex-col overflow-hidden">
-  <!-- Preview / Diff area -->
-  <div class="flex flex-1 flex-col overflow-hidden min-h-0">
-    {#if activeView === "diff" && diffViewFile}
-      <!-- Diff view header -->
-      <div class="flex items-center gap-2 border-b px-4 py-2 shrink-0">
-        <button
-          class="flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-          onclick={closeDiffView}
-          title={t("explorer_closeDiff")}
-        >
-          <svg
-            class="h-4 w-4"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"><path d="m15 18-6-6 6-6" /></svg
-          >
-        </button>
-        <span class="text-sm font-medium text-foreground flex-1 min-w-0 truncate"
-          >{diffViewFile}</span
-        >
-      </div>
-      <!-- Diff content -->
-      <div class="flex-1 overflow-auto">
-        {#if diffViewLoading}
-          <div class="flex items-center justify-center py-12">
-            <div
-              class="h-5 w-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
-            ></div>
-          </div>
-        {:else if diffViewContent.trim()}
-          {@const diffLines = parseDiffLines(diffViewContent)}
-          <table class="w-full text-xs font-mono border-collapse">
-            {#each diffLines as dl}
-              <tr
-                class={dl.type === "add"
-                  ? "bg-green-500/10"
-                  : dl.type === "del"
-                    ? "bg-red-500/10"
-                    : dl.type === "hunk"
-                      ? "bg-blue-500/5"
-                      : ""}
-              >
-                <td
-                  class="select-none text-right pr-1 pl-2 text-muted-foreground/40 w-[1%] whitespace-nowrap {dl.type ===
-                    'hunk' || dl.type === 'header'
-                    ? 'border-y border-border/30'
-                    : ''}">{dl.oldNum ?? ""}</td
-                >
-                <td
-                  class="select-none text-right pr-2 text-muted-foreground/40 w-[1%] whitespace-nowrap {dl.type ===
-                    'hunk' || dl.type === 'header'
-                    ? 'border-y border-border/30'
-                    : ''}">{dl.newNum ?? ""}</td
-                >
-                <td
-                  class="whitespace-pre pr-4 {dl.type === 'add'
-                    ? 'text-green-600 dark:text-green-400'
-                    : dl.type === 'del'
-                      ? 'text-red-500 dark:text-red-400'
-                      : dl.type === 'hunk'
-                        ? 'text-blue-500 dark:text-blue-400'
-                        : dl.type === 'header'
-                          ? 'font-bold text-foreground'
-                          : ''} {dl.type === 'hunk' || dl.type === 'header'
-                    ? 'border-y border-border/30 py-1'
-                    : ''}">{dl.text}</td
-                >
-              </tr>
-            {/each}
-          </table>
-        {:else}
-          <div class="flex flex-col items-center gap-2 py-12 text-center">
-            <svg
-              class="h-8 w-8 text-muted-foreground/40"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="1.5"><path d="M20 6 9 17l-5-5" /></svg
-            >
-            <p class="text-sm text-muted-foreground">{t("explorer_noChanges")}</p>
-          </div>
-        {/if}
-      </div>
-    {:else if activeView === "preview" && selectedFilePath}
-      <!-- File editor header -->
-      <div class="flex items-center gap-2 border-b px-4 py-2 shrink-0">
-        <svg
-          class="h-3.5 w-3.5 shrink-0 opacity-40"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          ><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path
-            d="M14 2v4a2 2 0 0 0 2 2h4"
-          /></svg
-        >
-        <span class="text-sm font-medium text-foreground min-w-0 truncate"
-          >{fileName(selectedFilePath)}</span
-        >
-        {#if fileDirty}
-          <span class="h-2 w-2 rounded-full bg-amber-400 shrink-0" title={t("explorer_modified")}
-          ></span>
-        {/if}
-        <span class="text-xs text-muted-foreground truncate flex-1 min-w-0">{selectedFilePath}</span
-        >
-        {#if isPreviewable && !isImage}
-          <div class="flex rounded-md border bg-background p-0.5 shrink-0">
-            <button
-              class="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium transition-colors
-                {editorMode === 'edit'
-                ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:text-foreground'}"
-              onclick={() => (editorMode = "edit")}
-            >
-              <svg
-                class="h-3 w-3"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                ><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" /><path
-                  d="m15 5 4 4"
-                /></svg
-              >
-              {t("common_edit")}
-            </button>
-            <button
-              class="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium transition-colors
-                {editorMode === 'rendered'
-                ? 'bg-muted text-foreground'
-                : 'text-muted-foreground hover:text-foreground'}"
-              onclick={() => (editorMode = "rendered")}
-            >
-              <svg
-                class="h-3 w-3"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                ><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z" /><circle
-                  cx="12"
-                  cy="12"
-                  r="3"
-                /></svg
-              >
-              {t("common_preview")}
-            </button>
-          </div>
-        {/if}
-        {#if !isImage}
-          <button
-            class="rounded-md px-2.5 py-1 text-[11px] font-medium transition-colors shrink-0 disabled:opacity-40 {fileDirty
-              ? 'bg-primary text-primary-foreground hover:bg-primary/90'
-              : 'bg-muted text-muted-foreground cursor-default'}"
-            disabled={!fileDirty || fileSaving || editorMode === "rendered"}
-            title={editorMode === "rendered" ? t("explorer_saveDisabledInPreview") : ""}
-            onclick={saveFile}
-          >
-            {fileSaving ? t("explorer_saving") : t("explorer_save")}
-          </button>
-        {/if}
-      </div>
-      <!-- File content -->
-      <div class="flex-1 overflow-hidden min-h-0">
-        {#if fileLoading}
-          <div class="flex items-center justify-center py-12">
-            <div
-              class="h-5 w-5 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
-            ></div>
-          </div>
-        {:else if fileError}
-          <div class="flex flex-1 items-center justify-center p-4">
-            <p class="text-sm text-destructive">{fileError}</p>
-          </div>
-        {:else if isImage && imageDataUrl}
-          <div
-            class="flex items-center justify-center h-full overflow-auto p-4 bg-black/5 dark:bg-white/5"
-          >
-            <img
-              src={imageDataUrl}
-              alt={fileName(selectedFilePath)}
-              class="max-w-full max-h-full object-contain rounded"
-            />
-          </div>
-        {:else if editorMode === "rendered" && isPreviewable}
-          <div class="flex-1 overflow-y-auto p-4 h-full">
-            {#if fileContent}
-              <MarkdownContent
-                text={fileContent}
-                basePath={selectedFilePath.replace(/[/\\][^/\\]*$/, "")}
-              />
-            {:else}
-              <p class="text-sm text-muted-foreground italic">{t("explorer_emptyFile")}</p>
-            {/if}
-          </div>
-        {:else}
-          <CodeEditor
-            bind:content={fileContent}
-            filePath={selectedFilePath}
-            onsave={saveFile}
-            class="h-full"
-          />
-        {/if}
-      </div>
-    {:else}
-      <!-- Empty state -->
-      <div class="flex flex-1 items-center justify-center">
-        <div class="flex flex-col items-center gap-2 text-center">
-          <svg
-            class="h-10 w-10 text-muted-foreground/20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            ><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" /><path
-              d="M14 2v4a2 2 0 0 0 2 2h4"
-            /></svg
-          >
-          <p class="text-sm text-muted-foreground">{t("explorer_selectFile")}</p>
-        </div>
-      </div>
-    {/if}
-  </div>
+  <FilePreviewPane
+    cwd={projectCwd}
+    path={panePath}
+    mode={activeView}
+    editable={true}
+    isRemote={false}
+    scopeKey={projectCwd}
+    onLoaded={handleLoaded}
+    onLoadFailed={handleLoadFailed}
+    onCloseDiff={closeDiffView}
+    onDirtyChange={(d) => (paneDirty = d)}
+  />
 </div>


### PR DESCRIPTION
## Summary

Closes #101 — file preview and chat were unable to coexist. Adds a unified file-preview pane embedded in ToolActivity's files tab so users can read code while chatting.

- New `FilePreviewPane.svelte` consolidates preview / edit / diff / image rendering with `editable` + `isRemote` + `scopeKey` props
- ToolActivity files tab restructured into "file list + preview" two-pane; reuses chat tool-card click events
- Clicking Edit/Write/Read tool cards (including subagent sub-cards) auto-switches to the files tab and previews the file
- `/explorer` refactored to use the same component; cache control kept in the parent via `onLoaded` / `onLoadFailed` callbacks
- Collapsing the right pane no longer unmounts the expanded panel; CodeMirror instance stays alive
- Resize uses ghost-line preview (VS Code style): zero reflow during drag, single commit on release; same for both left and right resize
- New `preview-ext.ts` utility + 12 unit tests

## Stack

This PR is the **first** in a stack of 5. Subsequent PRs depend on this one being merged first:
1. **This PR** — file preview component
2. perf: streaming raw text + tab lazy keep-alive + perf instrumentation
3. perf: chat file preview uses hljs (avoids CodeMirror style storm)
4. perf: lazy markdown + reliable hljs registration
5. feat: extend syntax highlighting for framework/DSL files (#104)

## Test plan

- [x] `npm test` (preview-ext.test.ts: 12 new tests)
- [x] `npm run lint:fix && format && build`
- [ ] Manual: click an Edit/Write/Read card in chat, confirm right pane switches to files tab and shows the file
- [ ] Manual: resize the right pane via drag — confirm ghost line follows cursor and content reflows only on release