### PR TITLE
perf: streaming raw text + tab lazy keep-alive + perf instrumentation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -957,6 +957,7 @@
   "filesPanel_notLocatable": "Cannot locate the corresponding tool call",
   "filesPanel_noPreviewSelected": "Select a file above to preview",
   "preview_remoteUnsupported": "File preview is not supported for remote sessions",
+  "preview_tooLarge": "File too large to preview inline. Open in Explorer.",
   "toolDetail_previewFile": "Open in preview pane",
 
   "infoPanel_noInfo": "Session info will appear after the session starts.",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -957,6 +957,7 @@
   "filesPanel_notLocatable": "无法定位到对应工具调用",
   "filesPanel_noPreviewSelected": "选择上方文件以预览",
   "preview_remoteUnsupported": "远程会话暂不支持文件预览",
+  "preview_tooLarge": "文件太大，请用 Explorer 打开预览",
   "toolDetail_previewFile": "在预览栏中打开",
 
   "infoPanel_noInfo": "会话启动后将显示会话信息。",

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -162,6 +162,25 @@ pub fn read_text_file(path: String, cwd: Option<String>) -> Result<String, Strin
         .map_err(|e| format!("Failed to read {}: {}", validated.display(), e))
 }
 
+/// Cheap file size lookup. Lets the frontend gate `read_text_file` for very large files
+/// without paying the full read + IPC + JS string allocation cost first.
+/// Returns size in bytes on success; returns Err on validation failure or stat failure
+/// (caller should fall back to read_text_file in that case — Err does NOT mean size 0).
+#[tauri::command]
+pub fn stat_text_file(path: String, cwd: Option<String>) -> Result<u64, String> {
+    log::debug!("[files] stat_text_file: path={}, cwd={:?}", path, cwd);
+    let validated = validate_file_path(&path, cwd.as_deref())?;
+    let size = fs::metadata(&validated)
+        .map(|m| m.len())
+        .map_err(|e| format!("Failed to stat {}: {}", validated.display(), e))?;
+    log::debug!(
+        "[files] stat_text_file: result path={} size={}",
+        validated.display(),
+        size
+    );
+    Ok(size)
+}
+
 const MAX_TASK_OUTPUT_BYTES: u64 = 512 * 1024; // 512KB
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -174,6 +174,7 @@ pub fn run() {
             commands::export::export_conversation,
             commands::export::write_html_export,
             commands::files::read_text_file,
+            commands::files::stat_text_file,
             commands::files::write_text_file,
             commands::files::read_task_output,
             commands::files::list_memory_files,

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -222,6 +222,12 @@ pub async fn dispatch_command(
             let content = crate::commands::files::read_text_file(path, cwd)?;
             Ok(json!(content))
         }
+        "stat_text_file" => {
+            let path = extract_str(&params, "path")?;
+            let cwd = params.get("cwd").and_then(|v| v.as_str()).map(String::from);
+            let size = crate::commands::files::stat_text_file(path, cwd)?;
+            Ok(json!(size))
+        }
         "write_text_file" => {
             let path = extract_str(&params, "path")?;
             let content = extract_str(&params, "content")?;

--- a/src/app.css
+++ b/src/app.css
@@ -631,10 +631,16 @@
   border-bottom: 1px solid hsl(var(--border) / 0.5);
 }
 
-/* Content-visibility optimization (disabled on WebKit via IS_WEBKIT) */
+/* Content-visibility optimization: skip layout/paint for off-screen entries.
+ * - content-visibility: auto → off-screen elements skip layout/paint entirely
+ * - contain: layout style paint → visible elements have bounded reflow scope
+ *   (their internal layout changes don't bubble up to ancestors, and ancestor
+ *   width changes don't force unbounded re-measurement of internal text)
+ * - contain-intrinsic-size auto 300px → representative placeholder for off-screen */
 .cv-auto {
   content-visibility: auto;
-  contain-intrinsic-size: auto 100px;
+  contain: layout style paint;
+  contain-intrinsic-size: auto 300px;
 }
 
 /* Scrollbar-hide utility (for horizontal pill rows) */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -298,6 +298,12 @@ export async function readTextFile(path: string, cwd?: string): Promise<string> 
   return invoke<string>("read_text_file", { path, cwd: cwd ?? null });
 }
 
+/** Cheap file size lookup — used by FilePreviewPane to skip readTextFile for huge files. */
+export async function statTextFile(path: string, cwd?: string): Promise<number> {
+  dbg("api", "statTextFile", path, { cwd });
+  return invoke<number>("stat_text_file", { path, cwd: cwd ?? null });
+}
+
 export async function writeTextFile(path: string, content: string, cwd?: string): Promise<void> {
   dbg("api", "writeTextFile", path, { cwd });
   return invoke("write_text_file", { path, content, cwd: cwd ?? null });

--- a/src/lib/components/CodeEditor.svelte
+++ b/src/lib/components/CodeEditor.svelte
@@ -20,6 +20,7 @@
   import { languages } from "@codemirror/language-data";
   import { oneDark } from "@codemirror/theme-one-dark";
   import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { perfMark, perfMarkAsync } from "$lib/utils/perf";
   import { fileName } from "$lib/utils/format";
   import { resolveStaticLanguage, resolveByFirstLine } from "$lib/utils/codemirror-languages";
 
@@ -130,54 +131,56 @@
     const dark = isDarkMode();
     dbg("code-editor", "mount", { filePath, readonly, dark });
 
-    const state = EditorState.create({
-      doc: content,
-      extensions: [
-        lineNumbers(),
-        highlightActiveLineGutter(),
-        highlightActiveLine(),
-        drawSelection(), // Renders CM6 cursor (native caret is hidden via caret-color: transparent in app.css)
-        bracketMatching(),
-        history(),
-        keymap.of([
-          {
-            key: "Mod-s",
-            run: () => {
-              onsave?.();
-              return true;
-            },
-          },
-          ...defaultKeymap,
-          ...historyKeymap,
-        ]),
-        syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
-        // Static tok-* class fallback: if style-mod CSS injection fails
-        // (observed on Intel Mac WKWebView), the static CSS in <style> below
-        // provides baseline syntax highlighting via classHighlighter.
-        syntaxHighlighting(classHighlighter),
-        EditorView.editable.of(!readonly),
-        EditorState.readOnly.of(readonly),
-        themeCompartment.of(dark ? oneDark : []),
-        langCompartment.of([]),
-        EditorView.updateListener.of((update) => {
-          if (update.docChanged && !updating) {
-            updating = true;
-            content = update.state.doc.toString();
-            updating = false;
-          }
-        }),
-      ],
-    });
+    perfMark(
+      "cm-create-view",
+      () => {
+        const state = EditorState.create({
+          doc: content,
+          extensions: [
+            lineNumbers(),
+            highlightActiveLineGutter(),
+            highlightActiveLine(),
+            drawSelection(), // Renders CM6 cursor (native caret is hidden via caret-color: transparent in app.css)
+            bracketMatching(),
+            history(),
+            keymap.of([
+              {
+                key: "Mod-s",
+                run: () => {
+                  onsave?.();
+                  return true;
+                },
+              },
+              ...defaultKeymap,
+              ...historyKeymap,
+            ]),
+            syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+            // Static tok-* class fallback: if style-mod CSS injection fails
+            // (observed on Intel Mac WKWebView), the static CSS in <style> below
+            // provides baseline syntax highlighting via classHighlighter.
+            syntaxHighlighting(classHighlighter),
+            EditorView.editable.of(!readonly),
+            EditorState.readOnly.of(readonly),
+            themeCompartment.of(dark ? oneDark : []),
+            langCompartment.of([]),
+            EditorView.updateListener.of((update) => {
+              if (update.docChanged && !updating) {
+                updating = true;
+                content = update.state.doc.toString();
+                updating = false;
+              }
+            }),
+          ],
+        });
+        view = new EditorView({ state, parent: editorEl });
+      },
+      { chars: content.length },
+    );
 
-    view = new EditorView({ state, parent: editorEl });
-
-    // Load language support
-    const seq = ++langSeq;
-    resolveLanguage(filePath).then((lang) => {
-      if (seq !== langSeq || !view) return; // stale — user already switched files
-      view.dispatch({ effects: langCompartment.reconfigure(lang) });
-      if (lang.length > 0) verifySyntaxStyles(view);
-    });
+    // Note: language resolution is owned by the $effect below. It runs once `view` becomes
+    // reactive (i.e., immediately after assignment above) AND on every filePath change.
+    // Doing it here too would issue a duplicate request whose result becomes stale —
+    // this also distorted the `cm-resolve-lang` perf metric.
 
     // Watch dark mode changes via MutationObserver on <html> class
     const observer = new MutationObserver(() => {
@@ -210,16 +213,25 @@
     }
   });
 
-  // Reconfigure language when filePath changes
+  // Reconfigure language on initial mount (when view becomes available) and on filePath change.
+  // Owns the only resolveLanguage call path — onMount no longer runs it.
   $effect(() => {
     if (!view) return;
     const _path = filePath; // track dependency
     const seq = ++langSeq;
-    resolveLanguage(_path).then((lang) => {
-      if (seq !== langSeq || !view) return; // stale — user already switched files
-      view.dispatch({ effects: langCompartment.reconfigure(lang) });
-      if (lang.length > 0) verifySyntaxStyles(view);
-    });
+    // Wrap the FULL flow (resolve + dispatch reconfigure + verify) so perf reflects total
+    // language-load cost, not just the dynamic import. The dispatch triggers re-parse +
+    // syntax highlight over the document, which can be the dominant cost for large files.
+    perfMarkAsync(
+      "cm-resolve-lang",
+      async () => {
+        const lang = await resolveLanguage(_path);
+        if (seq !== langSeq || !view) return; // stale — user already switched files
+        view.dispatch({ effects: langCompartment.reconfigure(lang) });
+        if (lang.length > 0) verifySyntaxStyles(view);
+      },
+      { filePath: _path },
+    );
   });
 </script>
 

--- a/src/lib/components/FilePreviewPane.svelte
+++ b/src/lib/components/FilePreviewPane.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getGitDiff, readTextFile, readFileBase64, writeTextFile } from "$lib/api";
+  import { getGitDiff, readTextFile, readFileBase64, writeTextFile, statTextFile } from "$lib/api";
   import { dbg } from "$lib/utils/debug";
   import { fileName as pathFileName } from "$lib/utils/format";
   import { t } from "$lib/i18n/index.svelte";
@@ -15,6 +15,7 @@
     editable = false,
     isRemote = false,
     scopeKey = "",
+    active = true,
     onLoaded,
     onLoadFailed,
     onCloseDiff,
@@ -26,6 +27,8 @@
     editable?: boolean;
     isRemote?: boolean;
     scopeKey?: string;
+    /** When false (parent tab inactive), do NOT initiate new loads; existing content is preserved. */
+    active?: boolean;
     onLoaded?: (path: string) => void;
     onLoadFailed?: (path: string, err: string) => void;
     onCloseDiff?: () => void;
@@ -42,6 +45,12 @@
   let fileDirty = $state(false);
   let fileSaving = $state(false);
   let editorMode = $state<"edit" | "rendered">("edit");
+  /** True when file exceeds size threshold — show warning instead of loading into CodeMirror. */
+  let fileTooLarge = $state(false);
+  let fileSize = $state(0);
+
+  /** Files larger than this are not auto-previewed (CodeMirror init becomes very slow). */
+  const MAX_PREVIEW_SIZE = 1_000_000; // 1MB
 
   let diffContent = $state("");
   let diffLoading = $state(false);
@@ -94,6 +103,8 @@
   async function loadPreview(p: string, c: string): Promise<void> {
     const seq = ++loadSeq;
     fileError = "";
+    fileTooLarge = false;
+    fileSize = 0;
     const ext = getExtension(p);
     editorMode = isPreviewable(ext) ? "rendered" : "edit";
     fileLoading = true;
@@ -108,12 +119,42 @@
         fileContent = "";
         originalContent = "";
       } else {
-        const content = await readTextFile(p, c);
-        if (seq !== loadSeq) return;
-        fileContent = content;
-        originalContent = content;
+        // Stat first (cheap metadata) so multi-MB files don't pay readTextFile's full
+        // disk-read + IPC + JS string allocation cost just to be discarded by the size guard.
+        // Stat failures fall through to readTextFile so the existing error path stays intact.
+        let preReadSize: number | null = null;
+        try {
+          preReadSize = await statTextFile(p, c);
+          if (seq !== loadSeq) return;
+        } catch (e) {
+          dbg("preview-pane", "stat failed, falling through to read", { path: p, err: String(e) });
+        }
+        if (preReadSize !== null && preReadSize > MAX_PREVIEW_SIZE) {
+          fileSize = preReadSize;
+          fileTooLarge = true;
+          fileContent = "";
+          originalContent = "";
+        } else {
+          const content = await readTextFile(p, c);
+          if (seq !== loadSeq) return;
+          fileSize = content.length;
+          // Defense-in-depth: stat may return stale/inaccurate size on some filesystems
+          // (e.g. sparse files, network mounts). Re-check after read.
+          if (content.length > MAX_PREVIEW_SIZE) {
+            fileTooLarge = true;
+            fileContent = "";
+            originalContent = "";
+          } else {
+            fileContent = content;
+            originalContent = content;
+          }
+        }
       }
-      dbg("preview-pane", "file loaded", { path: p, size: fileContent.length });
+      dbg("preview-pane", "file loaded", {
+        path: p,
+        size: fileSize,
+        tooLarge: fileTooLarge,
+      });
       onLoaded?.(p);
     } catch (e) {
       if (seq !== loadSeq) return;
@@ -169,12 +210,17 @@
   // ── Reactive load ──
   // Svelte 5: read all reactive props inside the effect to register dependency tracking.
   $effect(() => {
-    // Establish dependencies: cwd, path, mode, scopeKey, isRemote
+    // Establish dependencies: cwd, path, mode, scopeKey, isRemote, active
     void scopeKey;
     const _cwd = cwd;
     const _path = path;
     const _mode = mode;
     const _isRemote = isRemote;
+    const _active = active;
+
+    // Inactive (parent tab hidden): keep already-loaded content visible, but don't
+    // initiate new IPC loads on cwd/path/mode/scopeKey changes.
+    if (!_active) return;
 
     // Reset on remote or empty path
     if (_isRemote || !_path) {
@@ -417,6 +463,12 @@
       {:else if fileError}
         <div class="flex flex-1 items-center justify-center p-4">
           <p class="text-sm text-destructive">{fileError}</p>
+        </div>
+      {:else if fileTooLarge}
+        <div class="flex flex-1 items-center justify-center p-4">
+          <p class="text-xs text-muted-foreground text-center">
+            {t("preview_tooLarge")} ({Math.round(fileSize / 1024)} KB)
+          </p>
         </div>
       {:else if kind === "image" && imageDataUrl}
         <div

--- a/src/lib/components/FilesPanel.svelte
+++ b/src/lib/components/FilesPanel.svelte
@@ -57,18 +57,28 @@
       {@const color = actionColor(entry.action)}
       {@const canJump = !!entry.toolUseId}
       {@const isSelected = selectedPath !== undefined && entry.path === selectedPath}
-      {#if canJump}
-        <button
-          class="w-full text-left px-2.5 py-1 rounded-sm transition-colors group {isSelected
+      {@const isClickable = !!onPreview || canJump}
+      {#if isClickable}
+        <!--
+          Row click = preview only (no chat re-render). Use a small "jump" icon button at
+          the end (only when canJump && onScrollToTool) to scroll the chat to that tool card.
+          Splitting these prevents the chat from re-rendering every time the user just wants
+          to peek at a file.
+        -->
+        <div
+          class="group flex items-center gap-1 px-2.5 py-1 rounded-sm transition-colors {isSelected
             ? 'bg-accent'
             : 'hover:bg-accent/50'}"
-          onclick={() => {
-            onScrollToTool?.(entry.toolUseId!);
-            onPreview?.(entry.path);
-          }}
-          title={t("toolActivity_scrollToTool")}
         >
-          <div class="flex items-center gap-1.5">
+          <button
+            type="button"
+            class="flex-1 min-w-0 flex items-center gap-1.5 text-left"
+            onclick={() => {
+              if (onPreview) onPreview(entry.path);
+              else if (canJump) onScrollToTool?.(entry.toolUseId!);
+            }}
+            title={onPreview ? entry.path : t("toolActivity_scrollToTool")}
+          >
             <span
               class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-bold {color.bg} {color.text}"
             >
@@ -77,26 +87,29 @@
             <span class="text-[11px] text-foreground truncate min-w-0 group-hover:underline"
               >{shortPath(entry.path)}</span
             >
-          </div>
-        </button>
-      {:else if onPreview}
-        <button
-          class="w-full text-left px-2.5 py-1 rounded-sm transition-colors group {isSelected
-            ? 'bg-accent'
-            : 'hover:bg-accent/50'}"
-          onclick={() => onPreview?.(entry.path)}
-        >
-          <div class="flex items-center gap-1.5">
-            <span
-              class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-[10px] font-bold {color.bg} {color.text}"
+          </button>
+          {#if canJump && onScrollToTool && onPreview}
+            <button
+              type="button"
+              class="shrink-0 opacity-0 group-hover:opacity-100 transition-opacity p-0.5 text-muted-foreground/60 hover:text-foreground"
+              onclick={() => onScrollToTool?.(entry.toolUseId!)}
+              title={t("toolActivity_scrollToTool")}
+              aria-label={t("toolActivity_scrollToTool")}
             >
-              {actionLabel(entry.action)}
-            </span>
-            <span class="text-[11px] text-foreground truncate min-w-0 group-hover:underline"
-              >{shortPath(entry.path)}</span
-            >
-          </div>
-        </button>
+              <svg
+                class="h-3 w-3"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polyline points="9 18 15 12 9 6" />
+              </svg>
+            </button>
+          {/if}
+        </div>
       {:else}
         <div class="px-2.5 py-1 cursor-default">
           <div class="flex items-center gap-1.5">

--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -1748,7 +1748,10 @@
               <pre
                 class="text-xs font-mono whitespace-pre-wrap break-words text-blue-300/70 italic mb-1 leading-relaxed">{subEntry.thinkingText.trimEnd()}</pre>
             {/if}
-            <MarkdownContent text={subEntry.content} />
+            <MarkdownContent
+              text={subEntry.content}
+              streaming={subEntry.id?.startsWith("__sub_stream_") ?? false}
+            />
           </div>
         {:else if subEntry.kind === "tool"}
           <svelte:self

--- a/src/lib/components/MarkdownContent.svelte
+++ b/src/lib/components/MarkdownContent.svelte
@@ -2,6 +2,7 @@
   import { renderMarkdown } from "$lib/utils/markdown";
   import { readFileBase64 } from "$lib/api";
   import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { onDestroy } from "svelte";
 
   let {
     text = "",
@@ -17,22 +18,59 @@
 
   let container: HTMLDivElement | undefined = $state();
 
-  // Throttled text for streaming mode: updates at most every 150ms
-  let throttledText = $state(text);
+  // ── Streaming display: rAF-coalesced raw <pre>; non-streaming: full markdown render ──
+  // Streaming mode shows raw text in a <pre> (zero parse cost). DOM writes are coalesced
+  // to one per animation frame so high-frequency token deltas don't thrash text nodes.
+  // On streaming → false, $derived recomputes html once and the {#if/:else} branch swaps.
+  // Init to empty — `$state(text)` would only capture text's value at component creation,
+  // and Svelte 5 warns about that pattern. The effect below runs on mount and seeds
+  // displayText from current `text` (either via the !streaming branch or firstSyncDone).
+  let displayText = $state("");
+  let rafId: number | null = null;
+  // Non-reactive flag: set/read here doesn't trigger Svelte effect tracking.
+  // We use this instead of reading `displayText` inside the effect — reading $state
+  // would make the rAF callback's `displayText = text` trigger an effect rerun,
+  // wasting one no-op frame per real text change.
+  let firstSyncDone = false;
+
+  function cancelPendingFrame() {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  }
+
   $effect(() => {
-    const t = text;
-    if (streaming) {
-      const timer = setTimeout(() => {
-        throttledText = t;
-      }, 150);
-      return () => clearTimeout(timer);
-    } else {
-      throttledText = t;
+    if (!streaming) {
+      // Leaving streaming: cancel any pending rAF, sync immediately.
+      cancelPendingFrame();
+      displayText = text;
+      firstSyncDone = false; // reset for next streaming session
+      return;
+    }
+    // First frame on (re)entering streaming with content: sync immediately to avoid
+    // visible "first character delay one frame".
+    if (!firstSyncDone && text !== "") {
+      displayText = text;
+      firstSyncDone = true;
+      return;
+    }
+    // Streaming: at most one rAF-pending update; high-frequency tokens coalesce.
+    // ⚠️ Do NOT cancel rAF in $effect cleanup — Svelte runs cleanup before each rerun, so
+    //    if text ticks faster than vsync we'd repeatedly cancel→reschedule and starve the flush.
+    if (rafId === null) {
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        displayText = text;
+      });
     }
   });
 
-  // Single render path: $derived ensures renderMarkdown is called exactly once per text change
-  let html = $derived(throttledText ? renderMarkdown(throttledText) : "");
+  // Cancel pending rAF on unmount only (not on every effect rerun).
+  onDestroy(cancelPendingFrame);
+
+  // Non-streaming: $derived runs renderMarkdown once per text change. Streaming: skipped.
+  let html = $derived(streaming ? "" : displayText ? renderMarkdown(displayText) : "");
 
   $effect(() => {
     if (!container || !html) return;
@@ -92,15 +130,20 @@
   });
 </script>
 
-<div
-  bind:this={container}
-  class="prose prose-sm dark:prose-invert max-w-none
-    prose-p:text-foreground prose-p:leading-relaxed
-    prose-a:text-primary prose-a:underline prose-a:underline-offset-2
-    prose-code:rounded prose-code:bg-muted/70 prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:font-mono prose-code:before:content-none prose-code:after:content-none
-    prose-pre:m-0 prose-pre:p-0 prose-pre:bg-transparent prose-pre:border-0
-    prose-li:text-foreground
-    {className}"
->
-  {@html html}
-</div>
+{#if streaming}
+  <pre
+    class="whitespace-pre-wrap break-words font-sans text-sm leading-relaxed text-foreground/90 m-0 {className}">{displayText}</pre>
+{:else}
+  <div
+    bind:this={container}
+    class="prose prose-sm dark:prose-invert max-w-none
+      prose-p:text-foreground prose-p:leading-relaxed
+      prose-a:text-primary prose-a:underline prose-a:underline-offset-2
+      prose-code:rounded prose-code:bg-muted/70 prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:font-mono prose-code:before:content-none prose-code:after:content-none
+      prose-pre:m-0 prose-pre:p-0 prose-pre:bg-transparent prose-pre:border-0
+      prose-li:text-foreground
+      {className}"
+  >
+    {@html html}
+  </div>
+{/if}

--- a/src/lib/components/ToolActivity.svelte
+++ b/src/lib/components/ToolActivity.svelte
@@ -10,6 +10,7 @@
   import FilesPanel from "$lib/components/FilesPanel.svelte";
   import FilePreviewPane from "$lib/components/FilePreviewPane.svelte";
   import { onMount } from "svelte";
+  import { fpsCounter, isPerfEnabled } from "$lib/utils/perf";
   import SessionInfoPanel from "$lib/components/SessionInfoPanel.svelte";
   import StatusIcon from "$lib/components/StatusIcon.svelte";
   import {
@@ -67,6 +68,34 @@
   type SidebarPanel = "tools" | "context" | "files" | "info" | "tasks";
   let activeTab: SidebarPanel = $state("tools");
 
+  // Lazy keep-alive: a tab is mounted on first activation and stays mounted thereafter.
+  // Switching back to a previously-opened tab is then visibility-only (no remount).
+  // Svelte 5: $state(Set) requires reassignment to trigger reactivity (mutation methods
+  // alone won't), mirroring the existing collapsedTurns pattern below.
+  let mountedTabs = $state(new Set<SidebarPanel>(["tools"]));
+  $effect(() => {
+    if (!mountedTabs.has(activeTab)) {
+      mountedTabs = new Set(mountedTabs).add(activeTab);
+    }
+  });
+
+  // Perf: measure tab-switch frame cost. Tracks the gap between activeTab change and the next
+  // animation frame — proxy for "how much work was queued by switching".
+  // Gated by isPerfEnabled() so non-debug runs don't pay performance.now() + rAF overhead.
+  let _prevTab: SidebarPanel | null = null;
+  $effect(() => {
+    const cur = activeTab;
+    const from = _prevTab;
+    _prevTab = cur;
+    if (from === null || from === cur) return;
+    if (!isPerfEnabled()) return;
+    const t0 = performance.now();
+    requestAnimationFrame(() => {
+      const dt = performance.now() - t0;
+      if (dt > 1) dbg("perf", "tab-switch", { from, to: cur, ms: +dt.toFixed(2) });
+    });
+  });
+
   // ── External tab request ──
   $effect(() => {
     if (requestedTab) {
@@ -94,55 +123,31 @@
   });
 
   // ── Width state (browser-safe initialization) ──
+  // Note: auto-widening on previewPath change was removed because the width change forced
+  // chat-main to reflow its thousands of message nodes every time previewPath transitioned,
+  // causing perceptible lag. Users drag the handle to adjust (persisted to localStorage).
+  // Default bumped from 320 → 420 to give more reasonable starting room for code preview;
+  // 320 was too narrow for typical lines. Users can still drag narrower if desired.
   const WIDTH_MIN = 280;
   const WIDTH_MAX = 720;
-  const WIDTH_DEFAULT = 320;
-  const WIDTH_AUTO_PREVIEW = 560;
+  const WIDTH_DEFAULT = 420;
 
   function clampWidth(v: number): number {
     return Math.max(WIDTH_MIN, Math.min(WIDTH_MAX, v));
   }
 
   let savedWidth = $state(WIDTH_DEFAULT);
-  let viewportWidth = $state(1200);
-  /** True once the user has explicitly resized (or loaded a persisted resize). Disables auto-floor. */
-  let userHasResized = $state(false);
 
   onMount(() => {
     if (typeof window === "undefined") return;
     const stored = window.localStorage.getItem("ocv:toolactivity-width");
     if (stored) {
       const n = parseInt(stored, 10);
-      if (Number.isFinite(n)) {
-        savedWidth = clampWidth(n);
-        userHasResized = true;
-      }
+      if (Number.isFinite(n)) savedWidth = clampWidth(n);
     }
-    viewportWidth = window.innerWidth;
-    const onResize = () => {
-      viewportWidth = window.innerWidth;
-    };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
   });
 
-  /**
-   * Effective width displayed:
-   * - If user has explicitly resized (or has a persisted preference) → always respect savedWidth.
-   * - Else if a preview is open → temporarily widen to accommodate code, but DO NOT persist.
-   * - Else → savedWidth (compact default).
-   *
-   * This keeps the auto-widening transient: closing the preview returns to savedWidth, and
-   * once the user drags the handle their preference is honored regardless of preview state.
-   */
-  let effectiveWidth = $derived.by(() => {
-    if (userHasResized) return clampWidth(savedWidth);
-    if (previewPath) {
-      const autoFloor = Math.min(WIDTH_AUTO_PREVIEW, 0.45 * viewportWidth);
-      return clampWidth(Math.max(savedWidth, autoFloor));
-    }
-    return clampWidth(savedWidth);
-  });
+  let effectiveWidth = $derived(clampWidth(savedWidth));
 
   // ── Resize handle (VS Code-style: ghost line during drag, single commit on release) ──
   // Why this approach: in-place live resize forces chat-main reflow on every pointermove,
@@ -156,6 +161,7 @@
   let pendingWidth: number | null = null;
   let rafId: number | null = null;
   let asideEl: HTMLElement | undefined = $state();
+  let dragFpsStop: (() => void) | null = null;
 
   function onResizeStart(e: PointerEvent) {
     resizing = true;
@@ -165,6 +171,7 @@
     ghostX = e.clientX;
     (e.target as HTMLElement).setPointerCapture?.(e.pointerId);
     e.preventDefault();
+    dragFpsStop = fpsCounter("aside-drag");
   }
 
   function flushGhostFrame() {
@@ -196,12 +203,13 @@
 
     if (pendingWidth !== null && pendingWidth !== savedWidth) {
       savedWidth = pendingWidth;
-      userHasResized = true;
       if (typeof window !== "undefined") {
         window.localStorage.setItem("ocv:toolactivity-width", String(savedWidth));
       }
     }
     pendingWidth = null;
+    dragFpsStop?.();
+    dragFpsStop = null;
   }
 
   // ── Helpers ──
@@ -568,8 +576,8 @@
 {#if resizing}
   <!-- Ghost line during drag: zero-cost preview, no layout reflow elsewhere -->
   <div
-    class="fixed top-0 bottom-0 w-0.5 bg-primary/60 z-[9999] pointer-events-none"
-    style="left: {ghostX}px;"
+    class="fixed top-0 bottom-0 z-[9999] pointer-events-none bg-primary"
+    style="left: {ghostX - 1}px; width: 3px; box-shadow: 0 0 8px hsl(var(--primary) / 0.6);"
   ></div>
 {/if}
 <aside
@@ -742,326 +750,383 @@
       </div>
     </div>
 
-    {#if activeTab === "tasks"}
-      <!-- Background tasks panel -->
-      <div class="flex-1 overflow-y-auto">
-        {#if backgroundTasks.size === 0}
-          <div class="flex items-center justify-center h-32 text-xs text-muted-foreground/50">
-            {t("bgTask_empty")}
-          </div>
-        {:else}
-          <div class="py-1 space-y-0.5">
-            {#each sortedBgTasks as item (item.task_id)}
-              {@const isDone = item.status === "completed"}
-              {@const isFailed = item.status === "failed" || item.status === "error"}
-              {@const isActive = !isDone && !isFailed}
-              {@const rawData = (item.data as Record<string, unknown> | undefined)?.data as
-                | Record<string, unknown>
-                | undefined}
-              {@const usage = rawData?.usage as
-                | { duration_ms?: number; tool_uses?: number; total_tokens?: number }
-                | undefined}
-              {@const toolUseId = item.tool_use_id}
-              <button
-                class="w-full text-left mx-1.5 rounded px-2 py-1.5 transition-colors {isDone
-                  ? 'text-foreground/40 hover:bg-accent/30'
-                  : isFailed
-                    ? 'bg-destructive/5 text-foreground/50 hover:bg-destructive/10'
-                    : 'bg-blue-500/5 text-foreground/70 hover:bg-blue-500/10'}"
-                onclick={() => {
-                  if (toolUseId) onScrollToTool?.(toolUseId);
-                }}
-                title={toolUseId ? t("toolActivity_scrollToTool") : ""}
-              >
-                <div class="flex items-center gap-2">
-                  <StatusIcon status={isActive ? "running" : isDone ? "done" : "error"} size="sm" />
-                  <span class="flex-1 min-w-0 truncate text-[11px]"
-                    >{item.summary || item.message}</span
+    <!-- Lazy keep-alive: each tab mounts on first activation and stays mounted (visibility-only after).
+         Tab content is absolutely positioned within this relative wrapper so all mounted tabs share
+         the same layout slot but only the active one is visible/interactive. -->
+    <div class="flex-1 flex flex-col min-h-0 relative">
+      {#if mountedTabs.has("tasks")}
+        <div
+          class="absolute inset-0 flex flex-col"
+          style="visibility: {activeTab === 'tasks'
+            ? 'visible'
+            : 'hidden'}; pointer-events: {activeTab === 'tasks' ? 'auto' : 'none'};"
+        >
+          <!-- Background tasks panel -->
+          <div class="flex-1 overflow-y-auto">
+            {#if backgroundTasks.size === 0}
+              <div class="flex items-center justify-center h-32 text-xs text-muted-foreground/50">
+                {t("bgTask_empty")}
+              </div>
+            {:else}
+              <div class="py-1 space-y-0.5">
+                {#each sortedBgTasks as item (item.task_id)}
+                  {@const isDone = item.status === "completed"}
+                  {@const isFailed = item.status === "failed" || item.status === "error"}
+                  {@const isActive = !isDone && !isFailed}
+                  {@const rawData = (item.data as Record<string, unknown> | undefined)?.data as
+                    | Record<string, unknown>
+                    | undefined}
+                  {@const usage = rawData?.usage as
+                    | { duration_ms?: number; tool_uses?: number; total_tokens?: number }
+                    | undefined}
+                  {@const toolUseId = item.tool_use_id}
+                  <button
+                    class="w-full text-left mx-1.5 rounded px-2 py-1.5 transition-colors {isDone
+                      ? 'text-foreground/40 hover:bg-accent/30'
+                      : isFailed
+                        ? 'bg-destructive/5 text-foreground/50 hover:bg-destructive/10'
+                        : 'bg-blue-500/5 text-foreground/70 hover:bg-blue-500/10'}"
+                    onclick={() => {
+                      if (toolUseId) onScrollToTool?.(toolUseId);
+                    }}
+                    title={toolUseId ? t("toolActivity_scrollToTool") : ""}
                   >
-                  {#if isActive}
-                    <span class="shrink-0 text-[10px] text-foreground/30 tabular-nums"
-                      >{bgElapsed(item.startedAt)}</span
-                    >
-                  {/if}
-                </div>
-                {#if usage && (usage.tool_uses || usage.total_tokens || usage.duration_ms)}
-                  <div class="mt-0.5 text-[10px] text-muted-foreground/60 pl-5">
-                    {#if usage.tool_uses}{usage.tool_uses} tools{/if}
-                    {#if usage.tool_uses && usage.duration_ms}
-                      ·
+                    <div class="flex items-center gap-2">
+                      <StatusIcon
+                        status={isActive ? "running" : isDone ? "done" : "error"}
+                        size="sm"
+                      />
+                      <span class="flex-1 min-w-0 truncate text-[11px]"
+                        >{item.summary || item.message}</span
+                      >
+                      {#if isActive}
+                        <span class="shrink-0 text-[10px] text-foreground/30 tabular-nums"
+                          >{bgElapsed(item.startedAt)}</span
+                        >
+                      {/if}
+                    </div>
+                    {#if usage && (usage.tool_uses || usage.total_tokens || usage.duration_ms)}
+                      <div class="mt-0.5 text-[10px] text-muted-foreground/60 pl-5">
+                        {#if usage.tool_uses}{usage.tool_uses} tools{/if}
+                        {#if usage.tool_uses && usage.duration_ms}
+                          ·
+                        {/if}
+                        {#if usage.duration_ms}{formatDuration(usage.duration_ms)}{/if}
+                        {#if (usage.tool_uses || usage.duration_ms) && usage.total_tokens}
+                          ·
+                        {/if}
+                        {#if usage.total_tokens}{formatTokenCount(usage.total_tokens)} tok{/if}
+                      </div>
                     {/if}
-                    {#if usage.duration_ms}{formatDuration(usage.duration_ms)}{/if}
-                    {#if (usage.tool_uses || usage.duration_ms) && usage.total_tokens}
-                      ·
-                    {/if}
-                    {#if usage.total_tokens}{formatTokenCount(usage.total_tokens)} tok{/if}
-                  </div>
-                {/if}
-              </button>
-            {/each}
-          </div>
-        {/if}
-      </div>
-    {:else if activeTab === "context"}
-      <ContextHistoryPanel history={contextHistory} {turnUsages} {sessionInfo} />
-    {:else if activeTab === "files"}
-      <div class="flex flex-1 flex-col min-h-0">
-        <div class="flex-shrink-0 max-h-[40vh] overflow-y-auto border-b border-border/50">
-          <FilesPanel
-            {fileEntries}
-            {onScrollToTool}
-            onPreview={(p) => (previewPath = p)}
-            selectedPath={previewPath ?? undefined}
-          />
-        </div>
-        <div class="flex-1 min-h-0 overflow-hidden">
-          <FilePreviewPane
-            {cwd}
-            path={previewPath ?? ""}
-            mode="preview"
-            editable={false}
-            {isRemote}
-            scopeKey={runId}
-          />
-        </div>
-      </div>
-    {:else if activeTab === "info"}
-      <!-- Subagents section (shown above session info when Task tools exist) -->
-      {#if subagents.length > 0}
-        <div class="px-3 py-2 border-b border-border/50">
-          <div
-            class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-1.5"
-          >
-            {t("tool_subagents", { count: String(subagents.length) })}
-          </div>
-          <div class="space-y-1.5">
-            {#each subagents as sa (sa.toolUseId)}
-              {@const isDone = sa.status === "success"}
-              {@const isError = sa.status === "error" || sa.status === "denied"}
-              {@const isRunning = !isDone && !isError}
-              <button
-                class="w-full text-left rounded-md border border-border/50 bg-background/50 px-2.5 py-1.5 hover:bg-accent/30 transition-colors"
-                onclick={() => onScrollToTool?.(sa.toolUseId)}
-                title="Scroll to tool"
-              >
-                <div class="flex items-center gap-1.5">
-                  <span class="text-[11px] font-medium text-foreground">{sa.meta.subagentType}</span
-                  >
-                  {#if sa.meta.model}
-                    <span
-                      class="text-[10px] px-1 py-0.5 rounded bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 font-medium"
-                      >{sa.meta.model}</span
-                    >
-                  {/if}
-                  <span class="ml-auto">
-                    {#if isDone}
-                      <StatusIcon status="done" size="sm" />
-                    {:else if isError}
-                      <StatusIcon status="error" size="sm" />
-                    {:else if isRunning}
-                      <StatusIcon status="running" size="sm" />
-                    {/if}
-                  </span>
-                </div>
-                {#if sa.meta.description}
-                  <div class="text-[10px] text-muted-foreground truncate mt-0.5">
-                    {sa.meta.description}
-                  </div>
-                {/if}
-                {#if sa.toolCount > 0 || sa.durationMs != null}
-                  <div class="text-[10px] text-muted-foreground/60 mt-0.5">
-                    {#if sa.toolCount > 0}{sa.toolCount} tools{/if}
-                    {#if sa.toolCount > 0 && sa.durationMs != null}
-                      ·
-                    {/if}
-                    {#if sa.durationMs != null}{formatDuration(sa.durationMs)}{/if}
-                  </div>
-                {/if}
-              </button>
-            {/each}
-          </div>
-        </div>
-      {/if}
-      <SessionInfoPanel info={sessionInfo} {activeTab} />
-    {:else}
-      <!-- Tools panel -->
-      <!-- Summary chips -->
-      {#if toolStats.summary.length > 1}
-        <div class="flex flex-wrap gap-1 px-2.5 py-1.5 border-b border-border/50">
-          {#each toolStats.summary as [name, count]}
-            {@const style = getToolColor(name)}
-            <span
-              class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded {style.bg} {style.text} font-medium"
-            >
-              {name}
-              <span class="opacity-70">{count}</span>
-            </span>
-          {/each}
-        </div>
-      {/if}
-
-      <!-- Tool list -->
-      <div class="flex-1 overflow-y-auto py-0.5">
-        {#if toolStats.totalToolCount === 0}
-          <div class="flex items-center justify-center h-32 text-xs text-muted-foreground/50">
-            {t("toolActivity_noToolCalls")}
-          </div>
-        {:else if useTimeline}
-          <!-- Timeline mode: grouped by turn -->
-          {#each turns as turn (turn.turnIndex)}
-            {@const isCollapsed = collapsedTurns.has(turn.turnIndex)}
-            {@const tu = usageByTurn.get(turn.turnIndex)}
-            {@const hasTools = turn.tools.length > 0}
-            <!-- Turn header: div with two sibling buttons (no nesting) -->
-            <div
-              class="flex items-center w-full px-2.5 py-1.5 hover:bg-accent/50 transition-colors border-b border-border/30"
-            >
-              <button
-                class="flex-1 flex items-center gap-1.5 text-left min-w-0"
-                onclick={() => {
-                  if (hasTools) {
-                    toggleTurn(turn.turnIndex);
-                  } else if (turn.anchorId) {
-                    dbg("tool-activity", "scroll to turn (no tools)", {
-                      turnIndex: turn.turnIndex,
-                      anchorId: turn.anchorId,
-                    });
-                    onScrollToTurn?.(turn.anchorId);
-                  }
-                }}
-              >
-                {#if hasTools}
-                  <svg
-                    class="h-3 w-3 text-muted-foreground/50 shrink-0 transition-transform {isCollapsed
-                      ? ''
-                      : 'rotate-90'}"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <polyline points="9 18 15 12 9 6" />
-                  </svg>
-                {/if}
-                <span class="text-[11px] font-medium text-muted-foreground truncate">
-                  {#if turn.userPreview}
-                    {t("toolActivity_turn", { index: String(turn.turnIndex) })}
-                    <span class="text-foreground/70">{truncate(turn.userPreview, 25)}</span>
-                  {:else}
-                    <span class="text-muted-foreground/60">{t("toolActivity_systemResume")}</span>
-                  {/if}
-                </span>
-                <span class="ml-auto flex items-center gap-1.5 shrink-0">
-                  {#if tu}
-                    <span class="text-[10px] text-muted-foreground"
-                      >{formatTokenCount(tu.inputTokens + tu.outputTokens)}</span
-                    >
-                  {/if}
-                  {#if hasTools}
-                    <span
-                      class="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground font-medium"
-                      >{countToolNodes(turn.tools)}</span
-                    >
-                  {/if}
-                </span>
-              </button>
-              {#if turn.anchorId}
-                <button
-                  class="shrink-0 ml-1 p-0.5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted transition-colors"
-                  onclick={() => {
-                    dbg("tool-activity", "scroll to turn", {
-                      turnIndex: turn.turnIndex,
-                      anchorId: turn.anchorId,
-                    });
-                    onScrollToTurn?.(turn.anchorId!);
-                  }}
-                  title={t("toolActivity_scrollToTurn")}
-                >
-                  <svg
-                    class="h-3 w-3"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    ><circle cx="12" cy="12" r="3" /><path d="M12 2v4m0 12v4M2 12h4m12 0h4" /></svg
-                  >
-                </button>
-              {/if}
-            </div>
-
-            <!-- Tools in this turn (only render if turn has tools) -->
-            {#if hasTools && !isCollapsed}
-              <div class="py-0.5">
-                {#each turn.tools as node (node.tool.tool_use_id)}
-                  {@render toolNodeView(node)}
+                  </button>
                 {/each}
               </div>
             {/if}
-          {/each}
-        {:else}
-          <!-- HookEvent fallback mode (pipe/PTY) -->
-          {#each hookToolEvents as event, ei (ei)}
-            {@const style = getToolColor(event.tool_name ?? "")}
-            {@const detail = getHookDetail(event)}
-            {@const cat = categorizeHookStatus(event.status)}
-            <div class="px-2.5 py-1">
-              <div class="flex items-center gap-1.5">
-                {@render statusIcon(cat)}
-                <div class="flex h-4 w-4 shrink-0 items-center justify-center rounded {style.bg}">
-                  <svg
-                    class="h-2.5 w-2.5 {style.text}"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <path d={style.icon} />
-                  </svg>
-                </div>
-                <span class="text-[11px] font-medium text-foreground shrink-0"
-                  >{event.tool_name ?? event.hook_type}</span
-                >
-                {#if detail}
-                  <span class="text-[10px] text-muted-foreground truncate min-w-0">{detail}</span>
-                {/if}
-              </div>
-            </div>
-          {/each}
-        {/if}
-      </div>
-
-      <!-- Stats footer (status counts only, tools tab only) -->
-      {#if toolStats.totalToolCount > 0}
-        <div class="border-t border-border px-3 py-1.5">
-          <div class="flex items-center gap-3 text-[11px]">
-            {#if toolStats.doneCount > 0}
-              <span class="flex items-center gap-1 text-emerald-500 dark:text-emerald-400">
-                <StatusIcon status="done" size="sm" />
-                {toolStats.doneCount}
-              </span>
-            {/if}
-            {#if toolStats.runningCount > 0}
-              <span class="flex items-center gap-1 text-muted-foreground">
-                <StatusIcon status="running" size="sm" />
-                {toolStats.runningCount}
-              </span>
-            {/if}
-            {#if toolStats.errorCount > 0}
-              <span class="flex items-center gap-1 text-destructive">
-                <StatusIcon status="error" size="sm" />
-                {toolStats.errorCount}
-              </span>
-            {/if}
           </div>
         </div>
       {/if}
-    {/if}
+      {#if mountedTabs.has("context")}
+        <div
+          class="absolute inset-0 flex flex-col"
+          style="visibility: {activeTab === 'context'
+            ? 'visible'
+            : 'hidden'}; pointer-events: {activeTab === 'context' ? 'auto' : 'none'};"
+        >
+          <ContextHistoryPanel history={contextHistory} {turnUsages} {sessionInfo} />
+        </div>
+      {/if}
+      {#if mountedTabs.has("files")}
+        <div
+          class="absolute inset-0 flex flex-col"
+          style="visibility: {activeTab === 'files'
+            ? 'visible'
+            : 'hidden'}; pointer-events: {activeTab === 'files' ? 'auto' : 'none'};"
+        >
+          <div class="flex flex-1 flex-col min-h-0">
+            <div class="flex-shrink-0 max-h-[40vh] overflow-y-auto border-b border-border/50">
+              <FilesPanel
+                {fileEntries}
+                {onScrollToTool}
+                onPreview={(p) => (previewPath = p)}
+                selectedPath={previewPath ?? undefined}
+              />
+            </div>
+            <div class="flex-1 min-h-0 overflow-hidden">
+              <FilePreviewPane
+                {cwd}
+                path={previewPath ?? ""}
+                mode="preview"
+                editable={false}
+                {isRemote}
+                scopeKey={runId}
+                active={activeTab === "files"}
+              />
+            </div>
+          </div>
+        </div>
+      {/if}
+      {#if mountedTabs.has("info")}
+        <div
+          class="absolute inset-0 flex flex-col overflow-y-auto"
+          style="visibility: {activeTab === 'info'
+            ? 'visible'
+            : 'hidden'}; pointer-events: {activeTab === 'info' ? 'auto' : 'none'};"
+        >
+          <!-- Subagents section (shown above session info when Task tools exist) -->
+          {#if subagents.length > 0}
+            <div class="px-3 py-2 border-b border-border/50">
+              <div
+                class="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-1.5"
+              >
+                {t("tool_subagents", { count: String(subagents.length) })}
+              </div>
+              <div class="space-y-1.5">
+                {#each subagents as sa (sa.toolUseId)}
+                  {@const isDone = sa.status === "success"}
+                  {@const isError = sa.status === "error" || sa.status === "denied"}
+                  {@const isRunning = !isDone && !isError}
+                  <button
+                    class="w-full text-left rounded-md border border-border/50 bg-background/50 px-2.5 py-1.5 hover:bg-accent/30 transition-colors"
+                    onclick={() => onScrollToTool?.(sa.toolUseId)}
+                    title="Scroll to tool"
+                  >
+                    <div class="flex items-center gap-1.5">
+                      <span class="text-[11px] font-medium text-foreground"
+                        >{sa.meta.subagentType}</span
+                      >
+                      {#if sa.meta.model}
+                        <span
+                          class="text-[10px] px-1 py-0.5 rounded bg-cyan-500/15 text-cyan-600 dark:text-cyan-400 font-medium"
+                          >{sa.meta.model}</span
+                        >
+                      {/if}
+                      <span class="ml-auto">
+                        {#if isDone}
+                          <StatusIcon status="done" size="sm" />
+                        {:else if isError}
+                          <StatusIcon status="error" size="sm" />
+                        {:else if isRunning}
+                          <StatusIcon status="running" size="sm" />
+                        {/if}
+                      </span>
+                    </div>
+                    {#if sa.meta.description}
+                      <div class="text-[10px] text-muted-foreground truncate mt-0.5">
+                        {sa.meta.description}
+                      </div>
+                    {/if}
+                    {#if sa.toolCount > 0 || sa.durationMs != null}
+                      <div class="text-[10px] text-muted-foreground/60 mt-0.5">
+                        {#if sa.toolCount > 0}{sa.toolCount} tools{/if}
+                        {#if sa.toolCount > 0 && sa.durationMs != null}
+                          ·
+                        {/if}
+                        {#if sa.durationMs != null}{formatDuration(sa.durationMs)}{/if}
+                      </div>
+                    {/if}
+                  </button>
+                {/each}
+              </div>
+            </div>
+          {/if}
+          <SessionInfoPanel info={sessionInfo} {activeTab} />
+        </div>
+      {/if}
+      {#if mountedTabs.has("tools")}
+        <div
+          class="absolute inset-0 flex flex-col"
+          style="visibility: {activeTab === 'tools'
+            ? 'visible'
+            : 'hidden'}; pointer-events: {activeTab === 'tools' ? 'auto' : 'none'};"
+        >
+          <!-- Tools panel -->
+          <!-- Summary chips -->
+          {#if toolStats.summary.length > 1}
+            <div class="flex flex-wrap gap-1 px-2.5 py-1.5 border-b border-border/50">
+              {#each toolStats.summary as [name, count]}
+                {@const style = getToolColor(name)}
+                <span
+                  class="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded {style.bg} {style.text} font-medium"
+                >
+                  {name}
+                  <span class="opacity-70">{count}</span>
+                </span>
+              {/each}
+            </div>
+          {/if}
+
+          <!-- Tool list -->
+          <div class="flex-1 overflow-y-auto py-0.5">
+            {#if toolStats.totalToolCount === 0}
+              <div class="flex items-center justify-center h-32 text-xs text-muted-foreground/50">
+                {t("toolActivity_noToolCalls")}
+              </div>
+            {:else if useTimeline}
+              <!-- Timeline mode: grouped by turn -->
+              {#each turns as turn (turn.turnIndex)}
+                {@const isCollapsed = collapsedTurns.has(turn.turnIndex)}
+                {@const tu = usageByTurn.get(turn.turnIndex)}
+                {@const hasTools = turn.tools.length > 0}
+                <!-- Turn header: div with two sibling buttons (no nesting) -->
+                <div
+                  class="flex items-center w-full px-2.5 py-1.5 hover:bg-accent/50 transition-colors border-b border-border/30"
+                >
+                  <button
+                    class="flex-1 flex items-center gap-1.5 text-left min-w-0"
+                    onclick={() => {
+                      if (hasTools) {
+                        toggleTurn(turn.turnIndex);
+                      } else if (turn.anchorId) {
+                        dbg("tool-activity", "scroll to turn (no tools)", {
+                          turnIndex: turn.turnIndex,
+                          anchorId: turn.anchorId,
+                        });
+                        onScrollToTurn?.(turn.anchorId);
+                      }
+                    }}
+                  >
+                    {#if hasTools}
+                      <svg
+                        class="h-3 w-3 text-muted-foreground/50 shrink-0 transition-transform {isCollapsed
+                          ? ''
+                          : 'rotate-90'}"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <polyline points="9 18 15 12 9 6" />
+                      </svg>
+                    {/if}
+                    <span class="text-[11px] font-medium text-muted-foreground truncate">
+                      {#if turn.userPreview}
+                        {t("toolActivity_turn", { index: String(turn.turnIndex) })}
+                        <span class="text-foreground/70">{truncate(turn.userPreview, 25)}</span>
+                      {:else}
+                        <span class="text-muted-foreground/60"
+                          >{t("toolActivity_systemResume")}</span
+                        >
+                      {/if}
+                    </span>
+                    <span class="ml-auto flex items-center gap-1.5 shrink-0">
+                      {#if tu}
+                        <span class="text-[10px] text-muted-foreground"
+                          >{formatTokenCount(tu.inputTokens + tu.outputTokens)}</span
+                        >
+                      {/if}
+                      {#if hasTools}
+                        <span
+                          class="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground font-medium"
+                          >{countToolNodes(turn.tools)}</span
+                        >
+                      {/if}
+                    </span>
+                  </button>
+                  {#if turn.anchorId}
+                    <button
+                      class="shrink-0 ml-1 p-0.5 rounded text-muted-foreground/40 hover:text-foreground hover:bg-muted transition-colors"
+                      onclick={() => {
+                        dbg("tool-activity", "scroll to turn", {
+                          turnIndex: turn.turnIndex,
+                          anchorId: turn.anchorId,
+                        });
+                        onScrollToTurn?.(turn.anchorId!);
+                      }}
+                      title={t("toolActivity_scrollToTurn")}
+                    >
+                      <svg
+                        class="h-3 w-3"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        ><circle cx="12" cy="12" r="3" /><path
+                          d="M12 2v4m0 12v4M2 12h4m12 0h4"
+                        /></svg
+                      >
+                    </button>
+                  {/if}
+                </div>
+
+                <!-- Tools in this turn (only render if turn has tools) -->
+                {#if hasTools && !isCollapsed}
+                  <div class="py-0.5">
+                    {#each turn.tools as node (node.tool.tool_use_id)}
+                      {@render toolNodeView(node)}
+                    {/each}
+                  </div>
+                {/if}
+              {/each}
+            {:else}
+              <!-- HookEvent fallback mode (pipe/PTY) -->
+              {#each hookToolEvents as event, ei (ei)}
+                {@const style = getToolColor(event.tool_name ?? "")}
+                {@const detail = getHookDetail(event)}
+                {@const cat = categorizeHookStatus(event.status)}
+                <div class="px-2.5 py-1">
+                  <div class="flex items-center gap-1.5">
+                    {@render statusIcon(cat)}
+                    <div
+                      class="flex h-4 w-4 shrink-0 items-center justify-center rounded {style.bg}"
+                    >
+                      <svg
+                        class="h-2.5 w-2.5 {style.text}"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <path d={style.icon} />
+                      </svg>
+                    </div>
+                    <span class="text-[11px] font-medium text-foreground shrink-0"
+                      >{event.tool_name ?? event.hook_type}</span
+                    >
+                    {#if detail}
+                      <span class="text-[10px] text-muted-foreground truncate min-w-0"
+                        >{detail}</span
+                      >
+                    {/if}
+                  </div>
+                </div>
+              {/each}
+            {/if}
+          </div>
+
+          <!-- Stats footer (status counts only, tools tab only) -->
+          {#if toolStats.totalToolCount > 0}
+            <div class="border-t border-border px-3 py-1.5">
+              <div class="flex items-center gap-3 text-[11px]">
+                {#if toolStats.doneCount > 0}
+                  <span class="flex items-center gap-1 text-emerald-500 dark:text-emerald-400">
+                    <StatusIcon status="done" size="sm" />
+                    {toolStats.doneCount}
+                  </span>
+                {/if}
+                {#if toolStats.runningCount > 0}
+                  <span class="flex items-center gap-1 text-muted-foreground">
+                    <StatusIcon status="running" size="sm" />
+                    {toolStats.runningCount}
+                  </span>
+                {/if}
+                {#if toolStats.errorCount > 0}
+                  <span class="flex items-center gap-1 text-destructive">
+                    <StatusIcon status="error" size="sm" />
+                    {toolStats.errorCount}
+                  </span>
+                {/if}
+              </div>
+            </div>
+          {/if}
+        </div>
+      {/if}
+    </div>
   </div>
   {#if collapsed}
     <!-- Collapsed: thin icon rail overlay (absolute, only mounted when collapsed) -->

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,5 +1,6 @@
 import { Marked } from "marked";
 import { escapeHtml } from "$lib/utils/ansi";
+import { perfMark } from "$lib/utils/perf";
 import hljs from "highlight.js/lib/core";
 import javascript from "highlight.js/lib/languages/javascript";
 import typescript from "highlight.js/lib/languages/typescript";
@@ -106,11 +107,15 @@ marked.use({
 });
 
 export function renderMarkdown(text: string): string {
-  const raw = marked.parse(text);
-  if (typeof raw !== "string") {
-    return "";
-  }
-  return DOMPurify.sanitize(raw, {
-    ADD_ATTR: ["class", "target", "data-code-copy"],
-  });
+  return perfMark(
+    "md-render",
+    () => {
+      const raw = marked.parse(text);
+      if (typeof raw !== "string") return "";
+      return DOMPurify.sanitize(raw, {
+        ADD_ATTR: ["class", "target", "data-code-copy"],
+      });
+    },
+    { chars: text.length, codeFenceCount: text.match(/```/g)?.length ?? 0 },
+  );
 }

--- a/src/lib/utils/perf.ts
+++ b/src/lib/utils/perf.ts
@@ -1,0 +1,69 @@
+import { dbg } from "./debug";
+
+/**
+ * Runtime perf-mode check. Read on every call so toggling localStorage doesn't require a refresh.
+ * localStorage hits short-circuit; URL fallback uses cheap string includes.
+ *
+ * Cost when disabled: one localStorage.getItem (~1µs). Insertion points are sparse, negligible.
+ *
+ * Exported for ad-hoc gates (e.g., manual `performance.now()` blocks that don't fit perfMark).
+ */
+export function isPerfEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  if (localStorage.getItem("ocv:debug")) return true;
+  return window.location.search.includes("debug");
+}
+
+/** Wrap a synchronous fn; logs duration via `dbg("perf", label, ...)` when enabled and >1ms. */
+export function perfMark<T>(label: string, fn: () => T, meta?: Record<string, unknown>): T {
+  if (!isPerfEnabled()) return fn();
+  const t0 = performance.now();
+  const result = fn();
+  const dt = performance.now() - t0;
+  if (dt > 1) dbg("perf", label, { ms: +dt.toFixed(2), ...(meta ?? {}) });
+  return result;
+}
+
+/** Async variant. Same gating as perfMark. */
+export async function perfMarkAsync<T>(
+  label: string,
+  fn: () => Promise<T>,
+  meta?: Record<string, unknown>,
+): Promise<T> {
+  if (!isPerfEnabled()) return fn();
+  const t0 = performance.now();
+  const result = await fn();
+  const dt = performance.now() - t0;
+  if (dt > 1) dbg("perf", label, { ms: +dt.toFixed(2), ...(meta ?? {}) });
+  return result;
+}
+
+/**
+ * rAF-based fps counter. Returns a stop fn that emits average fps over the measurement window.
+ * Use for diagnosing drag/scroll smoothness.
+ *
+ * Example:
+ *   const stop = fpsCounter("aside-drag");
+ *   // ... user dragging ...
+ *   stop();  // emits "[ocv:perf] aside-drag fps { fps: 58.3, frames: 233, ms: 4000 }"
+ */
+export function fpsCounter(label: string): () => void {
+  if (!isPerfEnabled()) return () => {};
+  let frames = 0;
+  let rafId = 0;
+  const t0 = performance.now();
+  const tick = () => {
+    frames++;
+    rafId = requestAnimationFrame(tick);
+  };
+  rafId = requestAnimationFrame(tick);
+  return () => {
+    cancelAnimationFrame(rafId);
+    const dt = performance.now() - t0;
+    dbg("perf", `${label} fps`, {
+      fps: +((frames / dt) * 1000).toFixed(1),
+      frames,
+      ms: +dt.toFixed(0),
+    });
+  };
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,6 +43,7 @@
   import { goto, afterNavigate } from "$app/navigation";
   import { onMount, setContext, untrack } from "svelte";
   import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { fpsCounter } from "$lib/utils/perf";
   import { PLATFORM_PRESETS } from "$lib/utils/platform-presets";
   import { loadAgentSettingsCache } from "$lib/stores/agent-settings-cache.svelte";
   import type { PlatformCredential } from "$lib/types";
@@ -130,7 +131,10 @@
   let searchRequestId = $state(0);
   let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
-  // ── Sidebar resize (ghost-line strategy: zero reflow during drag, single commit on release) ──
+  // ── Sidebar resize (ghost-line strategy, same as right panel) ──
+  // chat-main reflow during drag is still expensive even with cv-auto: visible tool cards
+  // contain markdown / hljs code blocks that re-measure on every width change. Ghost line
+  // gives zero-reflow drag preview and commits once on release.
   function loadSidebarWidth(): number {
     if (typeof window === "undefined") return 280;
     const raw = parseInt(localStorage.getItem("ocv:sidebar-width") ?? "", 10);
@@ -141,52 +145,56 @@
   let sidebarGhostX = $state(0);
   let resizeCleanup: (() => void) | null = null;
 
-  function startResize(e: MouseEvent) {
+  /** Ghost line DOM element — bound after sidebarResizing toggles true.
+   *  Used only for imperative DOM writes during drag, but declared as $state to satisfy
+   *  Svelte 5's bind:this reactivity contract (silences non_reactive_update warning). */
+  let sidebarGhostEl: HTMLElement | null = $state(null);
+
+  function startResize(e: PointerEvent) {
     e.preventDefault();
     const startX = e.clientX;
     const startWidth = sidebarWidth;
     let pendingWidth = startWidth;
     sidebarResizing = true;
-    sidebarGhostX = startWidth; // ghost is anchored to sidebar's right edge (= width from left)
+    sidebarGhostX = e.clientX; // initial position via Svelte (single render)
+    const handle = e.currentTarget as HTMLElement;
+    handle.setPointerCapture?.(e.pointerId);
     dbg("layout", "sidebar resize start", { startWidth });
     document.body.style.userSelect = "none";
     document.body.style.cursor = "col-resize";
+    const stopFps = fpsCounter("sidebar-drag");
 
-    let rafId: number | null = null;
-    function flush() {
-      rafId = null;
-    }
-
-    function onMove(ev: MouseEvent) {
+    function onMove(ev: PointerEvent) {
       pendingWidth = Math.min(500, Math.max(180, startWidth + (ev.clientX - startX)));
-      // Ghost line follows the cursor's clamped X so the user sees exactly where the
-      // boundary will land. (Aside's left edge varies with left rail width — this avoids
-      // having to query the aside's getBoundingClientRect every frame.)
-      sidebarGhostX = startX + (pendingWidth - startWidth);
-      if (rafId === null) rafId = window.requestAnimationFrame(flush);
+      const x = startX + (pendingWidth - startWidth);
+      // BYPASS Svelte: write DOM directly. Svelte's reactive batching + WKWebView's pointer
+      // capture don't cooperate during drag — updates pile up until pointerup. Direct DOM
+      // write is synchronous and the browser repaints on the next frame regardless.
+      if (sidebarGhostEl) {
+        sidebarGhostEl.style.left = x - 1 + "px";
+      }
     }
     function cleanup() {
-      document.removeEventListener("mousemove", onMove);
-      document.removeEventListener("mouseup", onUp);
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", onUp);
+      handle.removeEventListener("pointercancel", onUp);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
-      if (rafId !== null) {
-        window.cancelAnimationFrame(rafId);
-        rafId = null;
-      }
-      // Commit ONCE on release → single layout reflow.
       sidebarWidth = pendingWidth;
       sidebarResizing = false;
+      sidebarGhostEl = null;
       resizeCleanup = null;
       localStorage.setItem("ocv:sidebar-width", String(sidebarWidth));
       dbg("layout", "sidebar resize end", { width: sidebarWidth });
+      stopFps();
     }
     function onUp() {
       cleanup();
     }
 
-    document.addEventListener("mousemove", onMove);
-    document.addEventListener("mouseup", onUp);
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointercancel", onUp);
     resizeCleanup = cleanup;
   }
 
@@ -2243,7 +2251,7 @@
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
           class="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/20 active:bg-primary/30 transition-colors z-10"
-          onmousedown={startResize}
+          onpointerdown={startResize}
         ></div>
       </div>
     </aside>
@@ -2252,8 +2260,10 @@
   <!-- Ghost line during sidebar drag (zero-reflow preview) -->
   {#if sidebarResizing}
     <div
-      class="fixed top-0 bottom-0 w-0.5 bg-primary/60 z-[9999] pointer-events-none"
-      style="left: {sidebarGhostX}px;"
+      bind:this={sidebarGhostEl}
+      class="fixed top-0 bottom-0 z-[9999] pointer-events-none bg-primary"
+      style="left: {sidebarGhostX -
+        1}px; width: 3px; box-shadow: 0 0 8px hsl(var(--primary) / 0.6);"
     ></div>
   {/if}
 

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -30,7 +30,6 @@
     TimelineEntry,
   } from "$lib/types";
   import { PLATFORM_PRESETS, findCredential } from "$lib/utils/platform-presets";
-  import { IS_WEBKIT } from "$lib/utils/platform";
   import {
     detectBatchGroups,
     detectToolBursts,
@@ -3019,8 +3018,19 @@
     }
     const el = document.getElementById("tool-" + toolUseId);
     if (el) {
+      // Temporarily disable content-visibility so the browser knows real heights and
+      // scrollIntoView lands at the correct offset (mirrors scrollToMessage).
+      const container = chatAreaRef;
+      const cvEls = container
+        ? Array.from(container.querySelectorAll<HTMLElement>(".cv-auto"))
+        : [];
+      for (const c of cvEls) c.style.contentVisibility = "visible";
+      el.getBoundingClientRect();
       el.scrollIntoView({ behavior: "smooth", block: "center" });
       el.classList.add("ring-2", "ring-primary/50");
+      requestAnimationFrame(() => {
+        for (const c of cvEls) c.style.contentVisibility = "";
+      });
       setTimeout(() => el.classList.remove("ring-2", "ring-primary/50"), 2000);
     }
   }
@@ -3865,7 +3875,7 @@
                 {#if !(burstHiddenIndices.has(i) && !toolBursts.has(i))}
                   <div
                     id="msg-{entry.anchorId}"
-                    class:cv-auto={!IS_WEBKIT && entry.kind !== "tool"}
+                    class:cv-auto={true}
                     class="group/msg"
                     class:opacity-40={lastClearSepId !== null &&
                       (timelineIdIndex.get(entry.id) ?? 0) <


### PR DESCRIPTION
## Summary

Reduces chat-page lag based on Ghostty source-code analysis (synchronized output / wakeup coalesce / per-row dirty) plus measured pinpoints. Synchronous markdown parsing on the main thread is the biggest bottleneck; tab-switch unmount is the second.

### Stage 1 — Streaming uses raw `<pre>`; full markdown render only when turn ends
- `MarkdownContent` streaming branch shows raw text; rAF-coalesced `displayText` writes avoid high-frequency DOM updates
- Drop the 150ms throttle (no longer needed); `onDestroy` cleans up pending rAF
- Non-reactive `firstSyncDone` flag avoids effect self-trigger frames
- Subagent synthetic streaming path now sets the streaming flag (detected by id prefix)

### Stage 2 — ToolActivity tab lazy keep-alive
- `mountedTabs` Set tracks activated tabs; first activation mounts, later switches just toggle visibility
- 5 tabs share one layout slot via `absolute` + `visibility` + `pointer-events`
- `FilePreviewPane` gains `active` prop: inactive tabs skip new IPC loads but keep already-loaded content
- Default width 320 → 420 for more code-preview real-estate

### Stage 3 — Perf instrumentation
- New `perf.ts`: `perfMark` / `perfMarkAsync` / `fpsCounter`; runtime `isPerfEnabled` reads localStorage
- 5 instrumented sites: md-render / cm-create-view / cm-resolve-lang / tab-switch / drag fps
- Enable via `localStorage.setItem("ocv:debug", "perf")`
- `cm-resolve-lang` wraps the full resolve+dispatch+verify span

### Large-file defense
- Backend `stat_text_file` command (`fs::metadata.len` with debug log)
- Registered on both Tauri invoke and web_server dispatch paths
- `FilePreviewPane` stats before `readTextFile`; >1MB short-circuits to `fileTooLarge` without reading

## Stack

PR **2 of 5**. Base is the file-preview PR (#105). Merge in order.

## Test plan

- [x] `npm test` + `build` + lint pass
- [ ] Manual: scroll chat with long history; confirm timeline scroll feels smooth
- [ ] Manual: switch right-pane tabs rapidly; confirm no remount flash
- [ ] Manual: open >1MB file — confirms `fileTooLarge` short-circuit