### PR TITLE
feat: add Xiaomi MiMo Token Plan subscription preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ You can re-run the wizard anytime from **Settings > General > Setup Wizard**.
 | MiniMax | `api.minimax.io/anthropic` | Bearer |
 | MiniMax (China) | `api.minimaxi.com/anthropic` | Bearer |
 | Xiaomi MiMo (小米) | `api.xiaomimimo.com/anthropic` | Bearer |
+| Xiaomi MiMo (Token Plan) | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
 
 ### API Gateway
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -162,6 +162,7 @@ npm run tauri dev
 | MiniMax | `api.minimax.io/anthropic` | Bearer |
 | MiniMax（中国） | `api.minimaxi.com/anthropic` | Bearer |
 | 小米 MiMo | `api.xiaomimimo.com/anthropic` | Bearer |
+| 小米 MiMo（订阅 Token Plan） | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
 
 ### API 代理
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.1.55"
+version = "0.1.56"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -434,6 +434,7 @@ pub(crate) fn preset_name(pid: &str) -> String {
         "minimax" => "MiniMax",
         "minimax-cn" => "MiniMax (China)",
         "mimo" => "Xiaomi MiMo (小米)",
+        "mimo-tp" => "Xiaomi MiMo (Token Plan)",
         "vercel" => "Vercel AI Gateway",
         "openrouter" => "OpenRouter",
         "siliconflow" => "SiliconFlow (硅基流动)",

--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -163,6 +163,13 @@ fn known_provider_defaults(pid: &str) -> Option<ProviderDefaults> {
             key_optional: false,
             auth_env_var: None,
         }),
+        "mimo-tp" => Some(ProviderDefaults {
+            base_url: Some("https://token-plan-cn.xiaomimimo.com/anthropic"),
+            models: Some(vec!["mimo-v2.5-pro".to_string()]),
+            extra_env: None,
+            key_optional: false,
+            auth_env_var: None,
+        }),
         "openrouter" => Some(ProviderDefaults {
             base_url: Some("https://openrouter.ai/api"),
             models: None,

--- a/src/lib/utils/platform-presets.ts
+++ b/src/lib/utils/platform-presets.ts
@@ -112,10 +112,22 @@ export const PLATFORM_PRESETS: PlatformPreset[] = [
     name: "Xiaomi MiMo (\u5c0f\u7c73)",
     base_url: "https://api.xiaomimimo.com/anthropic",
     auth_env_var: "ANTHROPIC_AUTH_TOKEN",
-    description: "Xiaomi AI",
+    description: "Xiaomi AI \u2014 pay-as-you-go",
     key_placeholder: "your-mimo-key",
     category: "provider",
     models: ["mimo-v2-flash"],
+    docs_url: "https://platform.xiaomimimo.com/docs/zh-CN/integration/claudecode",
+  },
+  {
+    id: "mimo-tp",
+    name: "Xiaomi MiMo (Token Plan)",
+    base_url: "https://token-plan-cn.xiaomimimo.com/anthropic",
+    auth_env_var: "ANTHROPIC_AUTH_TOKEN",
+    description: "Xiaomi subscription plan",
+    key_placeholder: "tp-xxxxx",
+    category: "provider",
+    models: ["mimo-v2.5-pro"],
+    docs_url: "https://platform.xiaomimimo.com/docs/zh-CN/integration/claudecode",
   },
 
   // ── API Proxy ──


### PR DESCRIPTION
## Summary

- Add `mimo-tp` preset for Xiaomi MiMo Token Plan subscription (`token-plan-cn.xiaomimimo.com/anthropic`, key format `tp-xxxxx`).
- Per Xiaomi docs, the subscription endpoint and key are exclusive — not interchangeable with the pay-as-you-go API. Splitting into a separate preset (mirrors kimi/kimi-coding) keeps the platform_id ↔ credential one-to-one model intact.
- Backfill `docs_url` on the existing `mimo` entry.
- Sync `Cargo.lock` to 0.1.56.

## Files

- `src/lib/utils/platform-presets.ts` — new `mimo-tp` entry, `docs_url` on `mimo`
- `src-tauri/src/storage/settings.rs` — `ProviderDefaults` for `mimo-tp`
- `src-tauri/src/commands/onboarding.rs` — display name mapping
- `README.md` / `README.zh-CN.md` — provider table row
- `src-tauri/Cargo.lock` — version bump sync

`pricing.rs`'s `model.contains("mimo")` already covers the new model — no change needed.

## Test plan

- [ ] Open Settings → API → Platforms grid shows new "Xiaomi MiMo (Token Plan)" tile
- [ ] Click the tile → base URL prefilled to `https://token-plan-cn.xiaomimimo.com/anthropic`, model defaults to `mimo-v2.5-pro`
- [ ] Save a `tp-` key, start a chat, verify request hits subscription endpoint
- [ ] Existing `mimo` entry still works as before