### PR TITLE
feat: add Tencent Hunyuan provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ You can re-run the wizard anytime from **Settings > General > Setup Wizard**.
 | MiniMax (China) | `api.minimaxi.com/anthropic` | Bearer |
 | Xiaomi MiMo (小米) | `api.xiaomimimo.com/anthropic` | Bearer |
 | Xiaomi MiMo (Token Plan) | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
+| Tencent Hunyuan (混元) | `api.hunyuan.cloud.tencent.com/anthropic` | Bearer |
 | SiliconFlow (硅基流动) | `api.siliconflow.com/` | Bearer |
 
 ### API Gateway

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,6 +164,7 @@ npm run tauri dev
 | MiniMax（中国） | `api.minimaxi.com/anthropic` | Bearer |
 | 小米 MiMo | `api.xiaomimimo.com/anthropic` | Bearer |
 | 小米 MiMo（订阅 Token Plan） | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
+| 腾讯混元 | `api.hunyuan.cloud.tencent.com/anthropic` | Bearer |
 | SiliconFlow（硅基流动） | `api.siliconflow.com/` | Bearer |
 
 ### API 代理

--- a/src-tauri/src/commands/onboarding.rs
+++ b/src-tauri/src/commands/onboarding.rs
@@ -436,6 +436,7 @@ pub(crate) fn preset_name(pid: &str) -> String {
         "minimax-cn" => "MiniMax (China)",
         "mimo" => "Xiaomi MiMo (小米)",
         "mimo-tp" => "Xiaomi MiMo (Token Plan)",
+        "hunyuan" => "Tencent Hunyuan (混元)",
         "vercel" => "Vercel AI Gateway",
         "openrouter" => "OpenRouter",
         "siliconflow" => "SiliconFlow (硅基流动)",

--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -179,6 +179,16 @@ fn known_provider_defaults(pid: &str) -> Option<ProviderDefaults> {
             key_optional: false,
             auth_env_var: None,
         }),
+        "hunyuan" => Some(ProviderDefaults {
+            base_url: Some("https://api.hunyuan.cloud.tencent.com/anthropic"),
+            models: Some(vec![
+                "hunyuan-2.0-thinking-20251109".to_string(),
+                "hunyuan-2.0-instruct-20251111".to_string(),
+            ]),
+            extra_env: None,
+            key_optional: false,
+            auth_env_var: None,
+        }),
         "openrouter" => Some(ProviderDefaults {
             base_url: Some("https://openrouter.ai/api"),
             models: None,

--- a/src/lib/utils/platform-presets.ts
+++ b/src/lib/utils/platform-presets.ts
@@ -143,6 +143,17 @@ export const PLATFORM_PRESETS: PlatformPreset[] = [
     docs_url: "https://platform.xiaomimimo.com/docs/zh-CN/integration/claudecode",
   },
   {
+    id: "hunyuan",
+    name: "Tencent Hunyuan (\u6df7\u5143)",
+    base_url: "https://api.hunyuan.cloud.tencent.com/anthropic",
+    auth_env_var: "ANTHROPIC_AUTH_TOKEN",
+    description: "Tencent AI",
+    key_placeholder: "sk-xxxxxxxx",
+    category: "provider",
+    models: ["hunyuan-2.0-thinking-20251109", "hunyuan-2.0-instruct-20251111"],
+    docs_url: "https://cloud.tencent.com/document/product/1729/127293",
+  },
+  {
     id: "siliconflow",
     name: "SiliconFlow (\u7845\u57fa\u6d41\u52a8)",
     base_url: "https://api.siliconflow.com/",


### PR DESCRIPTION
**Stacked on top of #111** (which is stacked on #110). Merge order: #110 → #111 → this.

## Summary

Adds Tencent Hunyuan (混元) as a provider preset. Verified against [Tencent's official docs](https://cloud.tencent.com/document/product/1729/127293):

- **Base URL**: \`https://api.hunyuan.cloud.tencent.com/anthropic\`
- **Auth**: \`ANTHROPIC_AUTH_TOKEN\`, key prefix \`sk-\`
- **Models**: \`hunyuan-2.0-thinking-20251109\` (default), \`hunyuan-2.0-instruct-20251111\`

Hunyuan exposes its own models in native Anthropic Messages API format — not OpenAI-compat translation. Fills a gap for users on Tencent Cloud where direct Anthropic API access is restricted.

## Files

- \`src/lib/utils/platform-presets.ts\` — new \`hunyuan\` entry
- \`src-tauri/src/storage/settings.rs\` — matching ProviderDefaults
- \`src-tauri/src/commands/onboarding.rs\` — display name mapping
- \`README.md\` / \`README.zh-CN.md\` — provider table row

## Test plan

- [ ] Settings → API → Platforms grid shows new "Tencent Hunyuan (混元)" tile
- [ ] Click tile → base URL prefilled, default model \`hunyuan-2.0-thinking-20251109\`
- [ ] Save \`sk-\` key, verify request reaches Hunyuan endpoint