### PR TITLE
fix: progressive timeline render + chunked replay (#119)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ See [README.md](README.md) for detailed prerequisites (Rust, Node.js, Tauri CLI)
 
 - **TypeScript** — strict mode enabled
 - **Svelte 5** — use runes (`$state`, `$derived`, `$effect`, `$props()`, `$bindable()`), no legacy stores or `<slot>`
+- **Comments** — only comment the *why*, not the *what*. See "Comment Standards" in `CLAUDE.md` for detailed rules
 - Run `npm run fix` to auto-format and lint-fix before committing
 
 ## Testing

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -19,6 +19,7 @@ import type {
   SessionMode,
 } from "$lib/types";
 import { dbg, dbgWarn } from "$lib/utils/debug";
+import { yieldToMain } from "$lib/utils/yield";
 import { IMAGE_TYPES } from "$lib/utils/file-types";
 import { uuid } from "$lib/utils/uuid";
 import {
@@ -1009,13 +1010,9 @@ export class SessionStore {
     this._reduce(ev, null);
   }
 
-  /** Apply a batch of events (e.g. during loadRun replay). Avoids N reactive updates.
-   *  opts.replayOnly=true skips phase and error assignments (used during resume).
-   *  Returns elapsed milliseconds. */
-  applyEventBatch(events: BusEvent[], opts?: { replayOnly?: boolean }): number {
-    const t0 = performance.now();
-    const replayOnly = opts?.replayOnly ?? false;
-    // Build tool indexes from existing state for batch processing
+  /** Build a reducer context snapshotted from current store state. Caller drives the
+   * reduce loop and then passes the ctx to `_commitReduceCtx`. */
+  private _createReduceCtx(): ReduceCtx {
     const batchTlIndex = new Map<string, number>();
     for (let i = 0; i < this.timeline.length; i++) {
       const e = this.timeline[i];
@@ -1026,7 +1023,7 @@ export class SessionStore {
       const tid = (this.tools[i] as Record<string, unknown>).tool_use_id as string | undefined;
       if (tid && !batchHeIndex.has(tid)) batchHeIndex.set(tid, i);
     }
-    const ctx: ReduceCtx = {
+    return {
       tl: [...this.timeline],
       he: [...this.tools],
       streamText: this.streamingText,
@@ -1044,12 +1041,11 @@ export class SessionStore {
       toolTlIndex: batchTlIndex,
       toolHeIndex: batchHeIndex,
     };
-    for (const ev of events) {
-      // Track WS sequence checkpoint
-      const evSeq = ((ev as Record<string, unknown>)._seq as number) ?? 0;
-      if (evSeq > 0) this._lastProcessedSeq = Math.max(this._lastProcessedSeq, evSeq);
-      this._reduce(ev, ctx, replayOnly);
-    }
+  }
+
+  /** Apply the reducer ctx to live store state. Runs synchronously — no awaits inside,
+   * so a stale check before this call is sufficient to skip publishing. */
+  private _commitReduceCtx(ctx: ReduceCtx, replayOnly: boolean): void {
     // If the session ended, resolve any leftover incomplete tools
     // (running, ask_pending, permission_prompt — these will never receive results)
     const runStatus = this.run?.status;
@@ -1061,7 +1057,6 @@ export class SessionStore {
         let changed = false;
         const result = tl.map((e) => {
           if (e.kind !== "tool") return e;
-          // Recurse into subTimeline first
           const newSub = e.subTimeline ? finalizeTools(e.subTimeline) : e.subTimeline;
           const needsFinalize = staleStatuses.has(e.tool.status);
           if (!needsFinalize && newSub === e.subTimeline) return e;
@@ -1079,12 +1074,6 @@ export class SessionStore {
       ctx.tl = finalizeTools(ctx.tl);
     }
 
-    // Single reactive assignment
-    const t1 = performance.now();
-    dbg(
-      "store",
-      `applyEventBatch: ${events.length} events processed in ${(t1 - t0).toFixed(1)}ms, timeline=${ctx.tl.length} entries`,
-    );
     this.timeline = ctx.tl;
     this.tools = ctx.he;
     this.streamingText = ctx.streamText;
@@ -1096,11 +1085,9 @@ export class SessionStore {
     this._seenToolIds = ctx.seenToolIds;
     this._toolTlIndex = ctx.toolTlIndex;
     this._toolHeIndex = ctx.toolHeIndex;
-    // Phase and error only assigned in live mode (not during resume replay)
     if (!replayOnly) {
       this._setPhase(ctx.phase);
       this.error = ctx.error;
-      // Sync run.status and session_id for non-terminal states from batch
       if ((ctx.runStatus || ctx.sessionId) && this.run) {
         const updates: Partial<TaskRun> = {};
         if (ctx.runStatus) updates.status = ctx.runStatus as RunStatus;
@@ -1115,14 +1102,86 @@ export class SessionStore {
       }
     }
 
-    // Ralph: mark interrupted loops after replay
-    // If ralphLoop.active is true but session is not live, the loop was interrupted
     if (this.ralphLoop?.active && replayOnly) {
       this.ralphLoop = { ...this.ralphLoop, active: false, reason: "interrupted" };
       dbg("store", "ralph loop marked interrupted after replay");
     }
+  }
 
-    return performance.now() - t0;
+  /** Apply a batch of events (e.g. during loadRun replay). Avoids N reactive updates.
+   *  opts.replayOnly=true skips phase and error assignments (used during resume).
+   *  Returns elapsed milliseconds. Synchronous — for chunked replay use
+   *  `applyEventBatchAsync` which yields between chunks. */
+  applyEventBatch(events: BusEvent[], opts?: { replayOnly?: boolean }): number {
+    const t0 = performance.now();
+    const replayOnly = opts?.replayOnly ?? false;
+    const ctx = this._createReduceCtx();
+    for (const ev of events) {
+      const evSeq = ((ev as Record<string, unknown>)._seq as number) ?? 0;
+      if (evSeq > 0) this._lastProcessedSeq = Math.max(this._lastProcessedSeq, evSeq);
+      this._reduce(ev, ctx, replayOnly);
+    }
+    const cpuMs = performance.now() - t0;
+    dbg(
+      "store",
+      `applyEventBatch:sync: ${events.length} events in ${cpuMs.toFixed(1)}ms cpu, timeline=${ctx.tl.length}`,
+    );
+    this._commitReduceCtx(ctx, replayOnly);
+    return cpuMs;
+  }
+
+  /**
+   * Async variant for replay paths (loadRun / resume / fork / idle catchup).
+   *
+   * Always reduces into a local ctx + `localSeq`; on stale abort neither
+   * `this.timeline` nor `this._lastProcessedSeq` is touched (so a quick run
+   * switch can't pollute the next subscribe's seq checkpoint).
+   *
+   * Large batches (> CHUNK_THRESHOLD) yield between chunks to keep the main
+   * thread responsive. Small batches use the same code path but skip the
+   * yields — slightly more overhead than the public sync `applyEventBatch`,
+   * but worth it for the stale-safety guarantee.
+   *
+   * Returns elapsed ms (wall-time when chunked, cpu-time otherwise), or `null`
+   * if `opts.isStale()` reported stale — caller must skip subsequent
+   * subscribe/snapshot work in that case.
+   */
+  async applyEventBatchAsync(
+    events: BusEvent[],
+    opts: { replayOnly?: boolean; isStale?: () => boolean } = {},
+  ): Promise<number | null> {
+    if (opts.isStale?.()) return null;
+    const t0 = performance.now();
+    const isStale = opts.isStale ?? (() => false);
+    const replayOnly = opts.replayOnly ?? false;
+    // Local accumulators — both ctx and `_lastProcessedSeq` stay isolated until commit.
+    // This prevents stale aborts from polluting store state mid-replay.
+    const ctx = this._createReduceCtx();
+    let localSeq = this._lastProcessedSeq;
+    const CHUNK = 200;
+    const CHUNK_THRESHOLD = 500;
+    const shouldYield = events.length > CHUNK_THRESHOLD;
+    for (let i = 0; i < events.length; i += CHUNK) {
+      if (isStale()) return null;
+      const end = Math.min(i + CHUNK, events.length);
+      for (let j = i; j < end; j++) {
+        const ev = events[j];
+        const evSeq = ((ev as Record<string, unknown>)._seq as number) ?? 0;
+        if (evSeq > 0 && evSeq > localSeq) localSeq = evSeq;
+        this._reduce(ev, ctx, replayOnly);
+      }
+      if (shouldYield) await yieldToMain();
+    }
+    if (isStale()) return null;
+    // Atomic commit: seq + timeline + tools + phase land together.
+    this._lastProcessedSeq = localSeq;
+    this._commitReduceCtx(ctx, replayOnly);
+    const wallMs = performance.now() - t0;
+    dbg(
+      "store",
+      `applyEventBatch:async: ${events.length} events in ${wallMs.toFixed(1)}ms ${shouldYield ? "wall" : "cpu"}, timeline=${ctx.tl.length}`,
+    );
+    return wallMs;
   }
 
   /** Apply a hook event (from hook-event Tauri listener). */
@@ -1545,7 +1604,13 @@ export class SessionStore {
                 if (gen !== this._loadGen) return;
                 if (catchupEvents.length > 0) {
                   dbg("store", "idle snapshot catchup", { count: catchupEvents.length });
-                  this.applyEventBatch(catchupEvents, { replayOnly: false });
+                  const catchupMs = await this.applyEventBatchAsync(catchupEvents, {
+                    replayOnly: false,
+                    isStale: () => gen !== this._loadGen,
+                  });
+                  // Stale (catchupMs === null) means a newer load owns the store —
+                  // do NOT touch _isLoadingReplay; the new owner manages it.
+                  if (catchupMs === null) return;
                   const catchupSt = this.run?.status;
                   if (
                     catchupSt === "idle" ||
@@ -1576,7 +1641,13 @@ export class SessionStore {
             dbg("store", "stale after getBusEvents, gen=", gen);
             return;
           }
-          reducerMs = this.applyEventBatch(busEvents, { replayOnly: isTerminal });
+          const ms = await this.applyEventBatchAsync(busEvents, {
+            replayOnly: isTerminal,
+            isStale: () => gen !== this._loadGen,
+          });
+          // Stale: a newer load owns the store; do not touch _isLoadingReplay.
+          if (ms === null) return;
+          reducerMs = ms;
           this._wsSubscribeAfterLoad(id, busEvents);
           // Write guard: distinguish "legit empty session" from "reducer anomaly"
           if (snapshotEligible && (this.timeline.length > 0 || busEvents.length === 0)) {
@@ -1917,8 +1988,9 @@ export class SessionStore {
         throw new Error("No session_id available for resume");
       }
 
-      // Invalidate any concurrent loadRun
-      this._loadGen++;
+      // Invalidate any concurrent loadRun, then snapshot the gen for our own
+      // stale-check (a later loadRun would bump _loadGen and we'd see the change).
+      const loadGen = ++this._loadGen;
       const resumeT0 = performance.now();
 
       // ★ Phase 1: async data fetch BEFORE clearing state (avoids flash)
@@ -1960,7 +2032,12 @@ export class SessionStore {
             if (!this._resumeGuard.isMounted) return runId;
           }
           if (busEvents.length > 0) {
-            reducerMs = this.applyEventBatch(busEvents, { replayOnly: true });
+            const ms = await this.applyEventBatchAsync(busEvents, {
+              replayOnly: true,
+              isStale: () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
+            });
+            if (ms === null) return runId;
+            reducerMs = ms;
           }
           // Always subscribe — even empty history needs real-time events
           this._wsSubscribeAfterLoad(runId, busEvents);
@@ -2052,6 +2129,7 @@ export class SessionStore {
    *  Step 2 (connectSession) is called by the frontend after dismissing the fork overlay. */
   private async _handleFork(runId: string): Promise<string> {
     dbg("store", "resumeSession: two-step fork", { runId });
+    const loadGen = this._loadGen;
 
     // Clear any subscription to prevent source RunState(stopped) interference
     getEventMiddleware().subscribeCurrent("", this);
@@ -2065,23 +2143,31 @@ export class SessionStore {
 
     this.run = newRun;
 
-    // Subscribe to NEW run — live events from stream-json will route here
-    getEventMiddleware().subscribeCurrent(newRunId, this);
-    dbg("store", "fork: middleware subscribed to new run", newRunId);
-
     // Reset display state — start fresh for the fork run.
     // Without this, the source session's timeline stays in state and
     // message_delta events accumulate as duplicate streamingText.
     this._clearContentState();
 
-    // Replay copied parent events for immediate display
+    // Replay copied parent events for immediate display.
+    // Subscribe to live events AFTER replay so a live applyEvent during chunked
+    // replay can't slip in and be overwritten by `_commitReduceCtx` snapshotting
+    // a now-stale `this.timeline`.
     const allForkEvents = await api.getBusEvents(newRunId);
     if (!this._resumeGuard.isMounted) throw new Error("Unmounted during fork");
     const newEvents = allForkEvents.filter((ev) => ev.run_id === newRunId);
     if (newEvents.length > 0) {
       dbg("store", "fork: replaying", newEvents.length, "parent events");
-      this.applyEventBatch(newEvents, { replayOnly: true });
+      const ms = await this.applyEventBatchAsync(newEvents, {
+        replayOnly: true,
+        isStale: () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
+      });
+      // Match the existing fork pattern (line ~2157): treat a stale/unmount
+      // mid-replay as a fatal interruption so the caller's catch path runs.
+      if (ms === null) throw new Error("Stale during fork replay");
     }
+    // Subscribe to NEW run — live events from stream-json will route here.
+    getEventMiddleware().subscribeCurrent(newRunId, this);
+    dbg("store", "fork: middleware subscribed to new run", newRunId);
     this._wsSubscribeAfterLoad(newRunId, allForkEvents);
 
     // Step 2 (stream-json resume) is NOT started here.

--- a/src/lib/utils/yield.ts
+++ b/src/lib/utils/yield.ts
@@ -1,0 +1,24 @@
+/**
+ * Yield to the browser's main thread before continuing.
+ *
+ * Prefers `requestAnimationFrame` so the browser can paint and process input
+ * between chunks. Falls back to a 50ms `setTimeout` in case `rAF` is throttled
+ * (backgrounded WebView, hidden tab) — first to fire wins, the other is cleared.
+ */
+export function yieldToMain(): Promise<void> {
+  if (typeof requestAnimationFrame !== "function") {
+    return new Promise((r) => setTimeout(r, 0));
+  }
+  return new Promise<void>((resolve) => {
+    let done = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      if (timer !== null) clearTimeout(timer);
+      resolve();
+    };
+    requestAnimationFrame(finish);
+    timer = setTimeout(finish, 50);
+  });
+}

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -65,6 +65,7 @@
   import ReleaseNotesCard from "$lib/components/ReleaseNotesCard.svelte";
   import { t } from "$lib/i18n/index.svelte";
   import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { yieldToMain } from "$lib/utils/yield";
   import { shouldAutoName } from "$lib/utils/auto-name";
   import { resolvePermissionOptimistic } from "$lib/utils/resolve-permission";
   import { getToolColor } from "$lib/utils/tool-colors";
@@ -309,8 +310,16 @@
   }
 
   // ── Timeline rendering ──
-  let renderLimit = $state(Infinity);
+  // Progressive render: start with the most recent N entries, grow on upward scroll.
+  // Switching to a multi-thousand-entry run with `Infinity` would mount thousands of
+  // ChatMessage components in one frame and freeze the WebView (issue #119).
+  const INITIAL_RENDER_LIMIT = 100;
+  const RENDER_GROWTH_STEP = 100;
+  let renderLimit = $state(INITIAL_RENDER_LIMIT);
   let progressiveGen = 0; // generation counter for stale-callback protection
+  let loadingMore = $state(false);
+  let loadMoreArmed = $state(true); // throttle: re-armed by handleChatScroll
+  let _suppressLoadMoreRearm = false; // raised during programmatic scrollTop adjustment
 
   async function syncVerboseState(runId: string | undefined) {
     const key = runId ?? "__no_run__";
@@ -628,23 +637,142 @@
 
   // ── Progressive timeline rendering ── helpers
 
+  /** Invalidate any in-flight async load so its post-await side effects bail out. */
   function cancelProgressive() {
     progressiveGen++;
-    renderLimit = Infinity;
+  }
+
+  /** Bump the load generation and return it — caller compares against `progressiveGen`. */
+  function nextProgressiveGen(): number {
+    return ++progressiveGen;
   }
 
   /**
-   * Load a run and render its full timeline in one frame.
-   * content-visibility:auto on entries lets the browser skip layout/paint
-   * for off-screen items, keeping scroll performance smooth.
+   * Expand `renderLimit` enough that `targetIndex` (in `filteredTimeline`) is mounted,
+   * with `margin` extra entries above for context. No-op if already covered.
+   */
+  function expandRenderLimitTo(targetIndex: number, margin = 50) {
+    const ft = filteredTimeline;
+    if (targetIndex < 0 || targetIndex >= ft.length) return;
+    if (renderLimit === Infinity) return;
+    const needed = ft.length - targetIndex + margin;
+    if (renderLimit < needed) renderLimit = Math.min(needed, ft.length);
+  }
+
+  /**
+   * If `visibleIdx` (visibleTimeline-local) sits inside a collapsed tool burst,
+   * force-expand that burst via `manualOverrides` so the entry's DOM mounts.
+   * Caller must pass an index in the visibleTimeline namespace, not filteredTimeline.
+   */
+  async function ensureBurstExpandedFor(visibleIdx: number) {
+    if (!burstHiddenIndices.has(visibleIdx)) return;
+    for (const [, burst] of toolBursts) {
+      if (visibleIdx >= burst.startIndex && visibleIdx <= burst.endIndex) {
+        const next = new Map(manualOverrides);
+        next.set(burst.key, true);
+        manualOverrides = next;
+        await tick();
+        return;
+      }
+    }
+  }
+
+  // Sentinel above the visible list — when it intersects the chat viewport, grow renderLimit.
+  let topSentinel = $state<HTMLDivElement | null>(null);
+  let _topObserver: IntersectionObserver | null = null;
+
+  $effect(() => {
+    if (!topSentinel || !chatAreaRef) {
+      _topObserver?.disconnect();
+      _topObserver = null;
+      return;
+    }
+    _topObserver?.disconnect();
+    _topObserver = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry?.isIntersecting) return;
+        if (!loadMoreArmed || loadingMore) return;
+        const hidden = filteredTimeline.length - renderLimit;
+        if (hidden <= 0) return;
+        dbg("chat", "progressive-load-more", { renderLimit, hidden });
+        void loadMoreEarlier();
+      },
+      { root: chatAreaRef, rootMargin: "200px 0px 0px 0px", threshold: 0 },
+    );
+    _topObserver.observe(topSentinel);
+    return () => {
+      _topObserver?.disconnect();
+      _topObserver = null;
+    };
+  });
+
+  /**
+   * Grow `renderLimit` by `RENDER_GROWTH_STEP` and preserve the user's scroll position.
+   * Browser-native scroll anchoring is unreliable on WKWebView with content-visibility,
+   * so we measure the first rendered entry's offset before/after and adjust scrollTop
+   * by the delta.
+   */
+  async function loadMoreEarlier() {
+    if (loadingMore || !loadMoreArmed) return;
+    loadingMore = true;
+    loadMoreArmed = false; // re-armed by handleChatScroll on next user scroll
+    try {
+      const anchor = chatAreaRef?.querySelector<HTMLElement>("[data-entry-id]") ?? null;
+      const anchorId = anchor?.dataset.entryId ?? null;
+      const beforeTop = anchor?.getBoundingClientRect().top ?? 0;
+      const beforeScroll = chatAreaRef?.scrollTop ?? 0;
+
+      renderLimit = Math.min(renderLimit + RENDER_GROWTH_STEP, filteredTimeline.length);
+      await tick();
+      await yieldToMain();
+
+      if (anchorId && chatAreaRef) {
+        let after: HTMLElement | null = null;
+        try {
+          after = chatAreaRef.querySelector<HTMLElement>(
+            `[data-entry-id="${CSS.escape(anchorId)}"]`,
+          );
+        } catch {
+          after =
+            Array.from(chatAreaRef.querySelectorAll<HTMLElement>("[data-entry-id]")).find(
+              (el) => el.dataset.entryId === anchorId,
+            ) ?? null;
+        }
+        if (after) {
+          const afterTop = after.getBoundingClientRect().top;
+          // Suppress re-arm so the programmatic scrollTop write doesn't immediately
+          // rearm the observer — the sentinel may still be in view post-prepend.
+          _suppressLoadMoreRearm = true;
+          chatAreaRef.scrollTop = beforeScroll + (afterTop - beforeTop);
+          // Clear suppression after the scroll event has dispatched + been handled.
+          // yieldToMain has a 50ms timeout fallback so a backgrounded WebView with
+          // throttled rAF can't strand the suppression flag.
+          await yieldToMain();
+          _suppressLoadMoreRearm = false;
+        }
+      }
+    } finally {
+      loadingMore = false;
+    }
+  }
+
+  /**
+   * Load a run and render its timeline progressively.
+   * Starts with the most recent `INITIAL_RENDER_LIMIT` entries; the top sentinel
+   * grows `renderLimit` as the user scrolls up.
    */
   async function loadRunProgressive(
     id: string,
     xtermRef?: { clear(): void; writeText(s: string): void },
   ) {
     toolFilter = null;
-    cancelProgressive();
-    const gen = ++progressiveGen;
+    // Reset progressive state so a previous run's expanded renderLimit (e.g. after
+    // an anchor jump) doesn't leak into the new run.
+    renderLimit = INITIAL_RENDER_LIMIT;
+    loadingMore = false;
+    loadMoreArmed = true;
+    const gen = nextProgressiveGen();
 
     // Capture scrollTo BEFORE loadRun — URL may change during async load
     const scrollTo = $page.url.searchParams.get("scrollTo");
@@ -681,8 +809,11 @@
     }
 
     if (gen !== progressiveGen) return;
-    renderLimit = Infinity;
-    dbg("chat", "loadRun complete", { timeline: filteredTimeline.length, gen });
+    dbg("chat", "loadRun complete", {
+      timeline: filteredTimeline.length,
+      renderLimit,
+      gen,
+    });
 
     if (scrollTo) {
       await tick();
@@ -1636,6 +1767,12 @@
     const dist = chatAreaRef.scrollHeight - chatAreaRef.scrollTop - chatAreaRef.clientHeight;
     isChatAutoScroll = dist < SCROLL_BOTTOM_THRESHOLD;
     if (isChatAutoScroll) showChatScrollHint = false;
+    // Re-arm progressive load-more after a user-initiated scroll. The IntersectionObserver
+    // fires once per arm; this prevents short timelines from runaway-expanding while the
+    // sentinel remains in view after a prepend. Programmatic scrollTop adjustments
+    // (loadMoreEarlier's anchor compensation) raise `_suppressLoadMoreRearm` so the
+    // anchor-correction scroll doesn't immediately re-arm the observer.
+    if (!loadMoreArmed && !_suppressLoadMoreRearm) loadMoreArmed = true;
   }
 
   function scrollChatToBottom() {
@@ -3031,16 +3168,23 @@
   }
 
   async function scrollToTool(toolUseId: string) {
-    // Cancel progressive rendering so full timeline is available
-    if (renderLimit !== Infinity) {
-      cancelProgressive();
-      await tick();
-    }
-    // Clear filter first (target tool may be filtered out)
+    // Clear filter first — target may be filtered out, and burst/visible indices
+    // depend on the unfiltered timeline.
     if (toolFilter) {
       toolFilter = null;
       await tick();
     }
+    // Locate target in the data layer (DOM may not be mounted yet under progressive render).
+    const ft = filteredTimeline;
+    const ftIdx = ft.findIndex((e) => e.kind === "tool" && e.tool.tool_use_id === toolUseId);
+    if (ftIdx < 0) return;
+    expandRenderLimitTo(ftIdx);
+    await tick();
+    // Re-map to visibleTimeline-local index for burst expansion.
+    const visibleIdx = visibleTimeline.findIndex(
+      (e) => e.kind === "tool" && e.tool.tool_use_id === toolUseId,
+    );
+    if (visibleIdx >= 0) await ensureBurstExpandedFor(visibleIdx);
     const el = document.getElementById("tool-" + toolUseId);
     if (el) {
       // Temporarily disable content-visibility so the browser knows real heights and
@@ -3062,29 +3206,25 @@
 
   async function scrollToMessage(ts: string) {
     dbg("chat", "scrollToMessage", { ts });
-    // Cancel progressive rendering so full timeline is available
-    if (renderLimit !== Infinity) {
-      cancelProgressive();
-      await tick();
-    }
-    // Clear filter first (target message may be filtered out)
     if (toolFilter) {
       toolFilter = null;
       await tick();
     }
-    // Primary: lookup by anchorId (stable event ID)
-    let el = document.getElementById("msg-" + ts);
-    // Fallback: search timeline by multiple fields (ts, anchorId, cliUuid, id)
-    if (!el) {
-      const match = store.timeline.find(
-        (e) =>
-          e.ts === ts ||
-          e.anchorId === ts ||
-          (e.kind === "user" && e.cliUuid === ts) ||
-          e.id === ts,
-      );
-      if (match) el = document.getElementById("msg-" + match.anchorId);
-    }
+    // Resolve target from data — `ts` may be ts, anchorId, cliUuid, or id.
+    const match = store.timeline.find(
+      (e) =>
+        e.ts === ts || e.anchorId === ts || (e.kind === "user" && e.cliUuid === ts) || e.id === ts,
+    );
+    if (!match) return;
+    const ft = filteredTimeline;
+    const ftIdx = ft.findIndex((e) => e.id === match.id);
+    if (ftIdx < 0) return;
+    expandRenderLimitTo(ftIdx);
+    await tick();
+    const visibleIdx = visibleTimeline.findIndex((e) => e.id === match.id);
+    if (visibleIdx >= 0) await ensureBurstExpandedFor(visibleIdx);
+    // DOM id uses anchorId (see `id="msg-{entry.anchorId}"` in the each block).
+    const el = document.getElementById("msg-" + match.anchorId);
     if (el) {
       // Temporarily disable content-visibility on ALL entries so the browser
       // knows real heights and scrollIntoView lands at the correct offset.
@@ -3896,10 +4036,14 @@
                   </div>
                 </div>
               {/if}
+              {#if filteredTimeline.length - renderLimit > 0}
+                <div bind:this={topSentinel} aria-hidden="true" class="h-px w-full"></div>
+              {/if}
               {#each visibleTimeline as entry, i (entry.id)}
                 {#if !(burstHiddenIndices.has(i) && !toolBursts.has(i))}
                   <div
                     id="msg-{entry.anchorId}"
+                    data-entry-id={entry.id}
                     class:cv-auto={true}
                     class="group/msg"
                     class:opacity-40={lastClearSepId !== null &&


### PR DESCRIPTION
## Summary
- **Phase 1 — progressive render**: `renderLimit` now starts at 100 and grows on upward scroll via a top-of-list `IntersectionObserver` sentinel. Switching to a multi-thousand-event session no longer mounts every `ChatMessage` in one frame (which `content-visibility: auto` could not avoid because Svelte instantiation runs regardless).
- **Phase 2 — chunked replay**: new `applyEventBatchAsync` reduces into a local `ctx` + `localSeq`, yields every 200 events when the batch exceeds 500, and atomically commits both the timeline and `_lastProcessedSeq`. `loadRun` (no-snapshot + idle catchup), `resumeSession`, and `_handleFork` use it with `isStale` closures combining `_loadGen` and `_resumeGuard.isMounted`. The synchronous `applyEventBatch` is unchanged so 100+ test call sites and the `event-middleware` live delivery path keep working.

Also drops the existing `cancelProgressive() { renderLimit = Infinity }` side-effect: `cancelProgressive` now only bumps the gen counter, anchor-jump paths use the new `expandRenderLimitTo` + visible-index re-mapping + `ensureBurstExpandedFor` (force-expand collapsed bursts via `manualOverrides`), and `_handleFork` subscribes to live events **after** the chunked replay so an interleaved `applyEvent` can't be overwritten by the replay's atomic commit.

Includes a small bundled commit: `docs: Add comment standards to contributing guide` (one-line CONTRIBUTING.md reference to CLAUDE.md's Comment Standards).

## Test plan
- [ ] `npm test` (1240 tests) — already green locally
- [ ] `npm run build` + `npm run check` — already green locally
- [ ] **macOS WKWebView smoke test** (`cargo tauri dev`):
  - [ ] Switch to a 5000+ event session — no freeze, see most recent 100 entries
  - [ ] Scroll up to the top sentinel — older entries load, viewport stays anchored on the entry under cursor (no jump-on-prepend)
  - [ ] Search anchor jump (`scrollToMessage`) — works for `ts` / `anchorId` / `cliUuid` / `id` inputs; DOM lookup uses `match.anchorId`
  - [ ] Tool-card jump (`scrollToTool`) under an active `toolFilter` — clears filter, expands `renderLimit`, target lands centered
  - [ ] Tool inside a collapsed burst — `ensureBurstExpandedFor` flips `manualOverrides`, target renders
  - [ ] HTML export still produces a full transcript (preserved `handleExportHtml` save/restore path)
  - [ ] State residual: search → anchor jump → switch session — new session resets to 100 entries + `loadingMore=false` + `loadMoreArmed=true`
  - [ ] Quickly switch between two large sessions — DevTools console shows `applyEventBatch:async … wall` and the older load aborts cleanly (no `_wsSubscribeAfterLoad` for the abandoned run, no `_lastProcessedSeq` pollution)
  - [ ] Resume / fork paths remain functional, including mid-replay overlay dismissal (`_resumeGuard.isMounted = false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)