### PR TITLE
feat(prompt): add Chinese dun (、) trigger for slash commands

### DIFF
--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -28,6 +28,7 @@
     getQuickActions,
     classifyCloseReason,
     groupSlashCommands,
+    extractSlashQuery,
     VIRTUAL_COMMANDS,
   } from "$lib/utils/slash-commands";
   import type { SlashCommandGroups } from "$lib/utils/slash-commands";
@@ -400,8 +401,7 @@
 
   let slashQuery = $derived.by(() => {
     if (!slashMenuOpen || slashPhase !== "commands") return null;
-    const m = inputText.match(/^\/([a-zA-Z0-9_-]*)$/);
-    return m?.[1] ?? "";
+    return extractSlashQuery(inputText) ?? "";
   });
 
   let filteredCommands = $derived.by(() => {
@@ -612,30 +612,29 @@
     const interaction = getCommandInteraction(cmd);
     dbg("slash", `select:${interaction}:${trigger}`, { name: cmd.name });
 
-    // Use slash prefix (handles both / and 、 triggers)
-    const prefix = "/";
-
+    // Both / and 、 triggers normalize to / when filling inputText below,
+    // so the backend always sees the standard slash form.
     switch (interaction) {
       case "immediate":
         if (trigger === "enter") {
-          inputText = `${prefix}${cmd.name}`;
+          inputText = `/${cmd.name}`;
           closeSlashMenu("execute");
           handleSend();
         } else {
           // Tab: fill only, don't execute
           closeSlashMenu("fill");
-          inputText = `${prefix}${cmd.name} `;
+          inputText = `/${cmd.name} `;
           moveCursorToEnd();
         }
         break;
       case "free-text":
         closeSlashMenu("fill");
-        inputText = `${prefix}${cmd.name} `;
+        inputText = `/${cmd.name} `;
         moveCursorToEnd();
         break;
       case "enum":
         activeSlashCmd = cmd;
-        inputText = `${prefix}${cmd.name} `;
+        inputText = `/${cmd.name} `;
         if (cmd.name === "fast") {
           slashPhase = "sub-fast";
           slashSubSelectedIndex = fastModeState === "on" ? 1 : 0;
@@ -762,21 +761,24 @@
 
   function handleCompositionEnd() {
     isComposing = false;
-    // Re-check input after IME completes (e.g., user typed顿号)
+    // Re-check input after IME completes (e.g., the dun trigger char "、")
     handleInput();
   }
 
   function handleInput() {
     autoResize();
 
-    // Skip processing during IME composition
-    if (isComposing) return;
-
-    // Exit history mode if user edits the recalled text
+    // Exit history mode if user edits the recalled text — runs regardless of IME
     if (histState.index >= 0 && inputText !== userHistory[histState.index]) {
       dbg("prompt-history", "exit: user edited", { index: histState.index });
       resetHistory(histState);
     }
+
+    // Skip menu detection (slash menu + @-mention menu) during IME composition
+    // to avoid flicker. History exit above runs regardless — only menu logic is
+    // deferred. Intentional: menus update once after composition completes
+    // (e.g., pinyin → 你好), not on every intermediate pinyin keystroke.
+    if (isComposing) return;
 
     // @-mention detection: runs BEFORE slashEnabled guard so it works pre-session
     const cursorPos = textareaEl?.selectionStart ?? inputText.length;
@@ -796,13 +798,11 @@
     }
 
     // Commands phase: support both slash (/) and Chinese dun (、) triggers
-    const match = inputText.match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    if (match) {
-      const triggerChar = match[1] as "/" | "、";
-      const query = match[2];
+    const query = extractSlashQuery(inputText);
+    if (query !== null) {
       slashSelectedIndex = 0;
       if (!slashMenuOpen) {
-        dbg("slash", "open", { query, trigger: triggerChar });
+        dbg("slash", "open", { query });
         if (modeDropdownOpen) modeDropdownOpen = false;
         slashMenuOpen = true;
         slashPhase = "commands";

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -391,6 +391,9 @@
   let slashBtnEl: HTMLButtonElement | undefined = $state();
   let savedInputForSlash = $state("");
 
+  // ── Chinese IME support ──
+  let isComposing = $state(false);
+
   let allCommands = $derived(mergeWithVirtual(cliCommands ?? []));
   let quickActions = $derived(getQuickActions(allCommands));
   let skillNameSet = $derived(new Set(availableSkills));
@@ -609,27 +612,30 @@
     const interaction = getCommandInteraction(cmd);
     dbg("slash", `select:${interaction}:${trigger}`, { name: cmd.name });
 
+    // Use slash prefix (handles both / and 、 triggers)
+    const prefix = "/";
+
     switch (interaction) {
       case "immediate":
         if (trigger === "enter") {
-          inputText = `/${cmd.name}`;
+          inputText = `${prefix}${cmd.name}`;
           closeSlashMenu("execute");
           handleSend();
         } else {
           // Tab: fill only, don't execute
           closeSlashMenu("fill");
-          inputText = `/${cmd.name} `;
+          inputText = `${prefix}${cmd.name} `;
           moveCursorToEnd();
         }
         break;
       case "free-text":
         closeSlashMenu("fill");
-        inputText = `/${cmd.name} `;
+        inputText = `${prefix}${cmd.name} `;
         moveCursorToEnd();
         break;
       case "enum":
         activeSlashCmd = cmd;
-        inputText = `/${cmd.name} `;
+        inputText = `${prefix}${cmd.name} `;
         if (cmd.name === "fast") {
           slashPhase = "sub-fast";
           slashSubSelectedIndex = fastModeState === "on" ? 1 : 0;
@@ -749,8 +755,22 @@
     onSend(`/${cmd.name}`, []);
   }
 
+  // ── IME composition event handlers ──
+  function handleCompositionStart() {
+    isComposing = true;
+  }
+
+  function handleCompositionEnd() {
+    isComposing = false;
+    // Re-check input after IME completes (e.g., user typed顿号)
+    handleInput();
+  }
+
   function handleInput() {
     autoResize();
+
+    // Skip processing during IME composition
+    if (isComposing) return;
 
     // Exit history mode if user edits the recalled text
     if (histState.index >= 0 && inputText !== userHistory[histState.index]) {
@@ -775,12 +795,14 @@
       return;
     }
 
-    // Commands phase
-    const match = inputText.match(/^\/([a-zA-Z0-9_-]*)$/);
+    // Commands phase: support both slash (/) and Chinese dun (、) triggers
+    const match = inputText.match(/^([/、])([a-zA-Z0-9_-]*)$/);
     if (match) {
+      const triggerChar = match[1] as "/" | "、";
+      const query = match[2];
       slashSelectedIndex = 0;
       if (!slashMenuOpen) {
-        dbg("slash", "open", { query: match[1] });
+        dbg("slash", "open", { query, trigger: triggerChar });
         if (modeDropdownOpen) modeDropdownOpen = false;
         slashMenuOpen = true;
         slashPhase = "commands";
@@ -1987,6 +2009,8 @@
       onkeydown={handleKeydown}
       oninput={handleInput}
       onpaste={handlePaste}
+      oncompositionstart={handleCompositionStart}
+      oncompositionend={handleCompositionEnd}
       placeholder={effectivePlaceholder}
       rows={1}
       {disabled}

--- a/src/lib/utils/__tests__/slash-commands.test.ts
+++ b/src/lib/utils/__tests__/slash-commands.test.ts
@@ -1135,3 +1135,100 @@ describe("/loop command", () => {
     expect(getCommandCategory("loop")).toBe("session");
   });
 });
+
+// ── Chinese Dun (、) Trigger Support ──
+
+describe("Chinese dun (、) trigger", () => {
+  it("matches slash command with / prefix", () => {
+    const match = "/compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("/");
+    expect(match![2]).toBe("compact");
+  });
+
+  it("matches slash command with 、 prefix", () => {
+    const match = "、compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("、");
+    expect(match![2]).toBe("compact");
+  });
+
+  it("matches empty command with / prefix", () => {
+    const match = "/".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("/");
+    expect(match![2]).toBe("");
+  });
+
+  it("matches empty command with 、 prefix", () => {
+    const match = "、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("、");
+    expect(match![2]).toBe("");
+  });
+
+  it("matches command with hyphen using 、 prefix", () => {
+    const match = "、allowed-tools".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toBe("、");
+    expect(match![2]).toBe("allowed-tools");
+  });
+
+  it("does not match text without prefix", () => {
+    const match = "compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).toBeNull();
+  });
+
+  it("does not match text with other prefix", () => {
+    const match = "#compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).toBeNull();
+  });
+
+  it("does not match when text follows by space", () => {
+    const match = "、compact test".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).toBeNull();
+  });
+
+  it("preserves filterSlashCommands compatibility with dun trigger", () => {
+    // The filterSlashCommands function should work the same regardless of trigger char
+    const commands: CliCommand[] = [
+      { name: "compact", description: "Compact", aliases: ["c"] },
+      { name: "config", description: "Config", aliases: [] },
+      { name: "model", description: "Model", aliases: ["m"] },
+    ];
+
+    // Query extracted from both / and 、 should produce same results
+    const queryFromSlash = "co";
+    const queryFromDun = "co";
+
+    const resultSlash = filterSlashCommands(commands, queryFromSlash);
+    const resultDun = filterSlashCommands(commands, queryFromDun);
+
+    expect(resultSlash).toEqual(resultDun);
+    expect(resultSlash.map((c) => c.name)).toEqual(["compact", "config"]);
+  });
+
+  it("handles IME composition scenario - should not match during composition", () => {
+    // This test documents the expected behavior:
+    // During IME composition (isComposing = true), handleInput() returns early
+    // The regex itself doesn't know about IME state, but the component logic
+    // checks isComposing before applying the regex
+
+    // Simulate what happens after IME completes:
+    // User types "nihao" in Chinese IME, IME produces "你好"
+    // Then user types "、" (dun), IME completes
+    // The input becomes "你好、"
+    // This should NOT match because there's text before the dun
+
+    const match = "你好、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(match).toBeNull();
+
+    // But "、" alone should match
+    const matchDunOnly = "、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(matchDunOnly).not.toBeNull();
+
+    // And "、compact" should match
+    const matchWithCmd = "、compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
+    expect(matchWithCmd).not.toBeNull();
+  });
+});

--- a/src/lib/utils/__tests__/slash-commands.test.ts
+++ b/src/lib/utils/__tests__/slash-commands.test.ts
@@ -13,6 +13,7 @@ import {
   classifyCloseReason,
   getCommandCategory,
   groupSlashCommands,
+  extractSlashQuery,
   VIRTUAL_COMMANDS,
   QUICK_ACTION_NAMES,
   CONTEXT_CLEARED_MARKER,
@@ -1138,97 +1139,79 @@ describe("/loop command", () => {
 
 // ── Chinese Dun (、) Trigger Support ──
 
-describe("Chinese dun (、) trigger", () => {
-  it("matches slash command with / prefix", () => {
-    const match = "/compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe("/");
-    expect(match![2]).toBe("compact");
+describe("extractSlashQuery", () => {
+  it("extracts query from / prefix", () => {
+    expect(extractSlashQuery("/compact")).toBe("compact");
   });
 
-  it("matches slash command with 、 prefix", () => {
-    const match = "、compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe("、");
-    expect(match![2]).toBe("compact");
+  it("extracts query from 、 prefix", () => {
+    expect(extractSlashQuery("、compact")).toBe("compact");
   });
 
-  it("matches empty command with / prefix", () => {
-    const match = "/".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe("/");
-    expect(match![2]).toBe("");
+  it("returns empty string for bare trigger", () => {
+    expect(extractSlashQuery("/")).toBe("");
+    expect(extractSlashQuery("、")).toBe("");
   });
 
-  it("matches empty command with 、 prefix", () => {
-    const match = "、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe("、");
-    expect(match![2]).toBe("");
+  it("returns null for non-trigger input", () => {
+    expect(extractSlashQuery("hello")).toBeNull();
+    expect(extractSlashQuery("#compact")).toBeNull();
+    expect(extractSlashQuery("")).toBeNull();
   });
 
-  it("matches command with hyphen using 、 prefix", () => {
-    const match = "、allowed-tools".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).not.toBeNull();
-    expect(match![1]).toBe("、");
-    expect(match![2]).toBe("allowed-tools");
+  it("returns null when text follows by space (breaks match)", () => {
+    expect(extractSlashQuery("、compact arg")).toBeNull();
+    expect(extractSlashQuery("/compact arg")).toBeNull();
   });
 
-  it("does not match text without prefix", () => {
-    const match = "compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).toBeNull();
+  it("returns null when text precedes trigger (IME scenario)", () => {
+    // After IME completes "nihao" → "你好" and user types "、",
+    // input is "你好、" which should NOT open the slash menu.
+    expect(extractSlashQuery("你好、")).toBeNull();
   });
 
-  it("does not match text with other prefix", () => {
-    const match = "#compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).toBeNull();
+  it("supports hyphenated command names", () => {
+    expect(extractSlashQuery("、allowed-tools")).toBe("allowed-tools");
+    expect(extractSlashQuery("/allowed-tools")).toBe("allowed-tools");
+  });
+});
+
+describe("Chinese dun trigger — end-to-end filter path", () => {
+  const commands: CliCommand[] = [
+    { name: "compact", description: "Compact", aliases: ["c"] },
+    { name: "config", description: "Config", aliases: [] },
+    { name: "model", description: "Model", aliases: ["m"] },
+  ];
+
+  it("filters by query extracted from 、co", () => {
+    const query = extractSlashQuery("、co");
+    expect(query).not.toBeNull();
+    expect(filterSlashCommands(commands, query!).map((c) => c.name)).toEqual(["compact", "config"]);
   });
 
-  it("does not match when text follows by space", () => {
-    const match = "、compact test".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).toBeNull();
+  it("produces identical filter results for /co and 、co", () => {
+    const slashQuery = extractSlashQuery("/co")!;
+    const dunQuery = extractSlashQuery("、co")!;
+    expect(filterSlashCommands(commands, slashQuery)).toEqual(
+      filterSlashCommands(commands, dunQuery),
+    );
   });
 
-  it("preserves filterSlashCommands compatibility with dun trigger", () => {
-    // The filterSlashCommands function should work the same regardless of trigger char
-    const commands: CliCommand[] = [
-      { name: "compact", description: "Compact", aliases: ["c"] },
-      { name: "config", description: "Config", aliases: [] },
-      { name: "model", description: "Model", aliases: ["m"] },
-    ];
-
-    // Query extracted from both / and 、 should produce same results
-    const queryFromSlash = "co";
-    const queryFromDun = "co";
-
-    const resultSlash = filterSlashCommands(commands, queryFromSlash);
-    const resultDun = filterSlashCommands(commands, queryFromDun);
-
-    expect(resultSlash).toEqual(resultDun);
-    expect(resultSlash.map((c) => c.name)).toEqual(["compact", "config"]);
+  // null vs empty-string semantics — drives grouped vs flat mode in PromptInput.
+  // null = no trigger → menu closed; "" = bare trigger → grouped view.
+  it("distinguishes null (no trigger) from empty string (bare trigger)", () => {
+    expect(extractSlashQuery("hello")).toBeNull();
+    expect(extractSlashQuery("/")).toBe("");
+    expect(extractSlashQuery("、")).toBe("");
   });
 
-  it("handles IME composition scenario - should not match during composition", () => {
-    // This test documents the expected behavior:
-    // During IME composition (isComposing = true), handleInput() returns early
-    // The regex itself doesn't know about IME state, but the component logic
-    // checks isComposing before applying the regex
-
-    // Simulate what happens after IME completes:
-    // User types "nihao" in Chinese IME, IME produces "你好"
-    // Then user types "、" (dun), IME completes
-    // The input becomes "你好、"
-    // This should NOT match because there's text before the dun
-
-    const match = "你好、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(match).toBeNull();
-
-    // But "、" alone should match
-    const matchDunOnly = "、".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(matchDunOnly).not.toBeNull();
-
-    // And "、compact" should match
-    const matchWithCmd = "、compact".match(/^([/、])([a-zA-Z0-9_-]*)$/);
-    expect(matchWithCmd).not.toBeNull();
+  it("bare 、 yields empty query, driving grouped view (parity with /)", () => {
+    // slashGroups in PromptInput.svelte only builds when slashQuery === "".
+    // Both bare triggers must produce "" (not null) to enter grouped mode.
+    const slashEmpty = extractSlashQuery("/");
+    const dunEmpty = extractSlashQuery("、");
+    expect(slashEmpty).toBe("");
+    expect(dunEmpty).toBe("");
+    expect(slashEmpty).toBe(dunEmpty);
   });
 });

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -428,6 +428,16 @@ export function isSubViewInputValid(inputText: string, activeCmdName: string): b
   return pattern.test(inputText);
 }
 
+/**
+ * Extract the slash-command query from input text.
+ * Supports both ASCII slash (/) and Chinese dun (、) as trigger prefixes.
+ * Returns the query (text after trigger), or null if input doesn't start with a trigger.
+ */
+export function extractSlashQuery(inputText: string): string | null {
+  const m = inputText.match(/^([/、])([a-zA-Z0-9_-]*)$/);
+  return m ? m[2] : null;
+}
+
 // ── Quick action pills (L3) ──
 
 /** Ordered list of command names shown as quick-action pills above the action bar. */


### PR DESCRIPTION
### Summary

- Add Chinese dun character (`、`) trigger for slash command menu, allowing users to open the command palette without switching input methods
- Implement IME (Input Method Editor) protection to prevent accidental triggers during Chinese text input
- Auto-convert dun to standard slash (`/`) when selecting a command, maintaining consistent command format

### Motivation

Chinese users need to switch to English input mode to type `/` for triggering slash commands, which interrupts their workflow. In Chinese input mode, pressing the `/` key produces the dun character `、` instead. This feature allows users to directly use `、` to trigger slash commands, improving the Chinese input experience.

### Key Changes

#### Features
- **Dual Trigger Support**: Modified regex from `/^\/([a-zA-Z0-9_-]*)$/` to `/^([/、])([a-zA-Z0-9_-]*)$/`, supporting both slash and dun
- **IME Protection**: Added `isComposing` state and `compositionstart/compositionend` event listeners to prevent detection during IME composition
- **Auto Conversion**: When selecting a command, both `/` and `、` triggers are converted to standard format (e.g., `/compact `)

#### Code Changes
| File | Changes | Description |
|------|---------|-------------|
| `src/lib/components/PromptInput.svelte` | +31 lines | Add IME state, event listeners, dun detection and conversion logic |
| `src/lib/utils/__tests__/slash-commands.test.ts` | +97 lines | Add 10 unit tests covering dun trigger scenarios |

#### New State Variables
```typescript
let isComposing = $state(false);  // IME composition state flag
```

### Test Plan

- [x] `npm run verify` passes (lint, format, tests, build, rust checks)
- [x] Unit Tests: All 1266 tests pass (10 new dun trigger tests added)
- [x] ESLint: 0 errors, 0 warnings
- [x] Prettier: Code formatting correct


### Screenshots

> This feature is an interaction logic improvement and does not change the UI appearance. No screenshots needed.

### Breaking Changes

**No Breaking Changes**
- Original slash (`/`) trigger remains fully compatible
- Commands are ultimately in standard slash format, no impact on backend processing

### Technical Implementation Details

- **Trigger Detection**: Match dun character in `handleInput()` using regex `/^([/、])([a-zA-Z0-9_-]*)$/`
- **IME Listening**: Bind `oncompositionstart` and `oncompositionend` events on `<textarea>`
- **State Management**: Only use `isComposing` state, no additional trigger character variable needed (always converts to standard slash format)
- **Test Coverage**: 10 test cases covering prefix matching, empty commands, hyphenated commands, no-prefix non-matching, IME scenarios, etc.