### PR TITLE
feat: enhance paste functionality with plain-text shortcut and block …

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -393,6 +393,9 @@
   "prompt_unsupportedFile": "Unsupported file type: .{ext}",
   "prompt_clipboardUnsupported": "File paste is not yet supported on this platform",
   "prompt_conversionFailed": "Failed to convert {name}",
+  "prompt_pasteBlockInsert": "Insert to input",
+  "prompt_pasteToastMac": "Compressed to chip. Use ⌘+Shift+V for plain text paste",
+  "prompt_pasteToastOther": "Compressed to chip. Use Ctrl+Shift+V for plain text paste",
 
   "common_cancel": "Cancel",
   "common_retry": "Retry",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -393,6 +393,9 @@
   "prompt_unsupportedFile": "不支持的文件类型：.{ext}",
   "prompt_clipboardUnsupported": "当前平台暂不支持粘贴文件",
   "prompt_conversionFailed": "转换 {name} 失败",
+  "prompt_pasteBlockInsert": "插入到输入框",
+  "prompt_pasteToastMac": "已压缩为粘贴块，按 ⌘+Shift+V 可直接粘贴为可编辑文本",
+  "prompt_pasteToastOther": "已压缩为粘贴块，按 Ctrl+Shift+V 可直接粘贴为可编辑文本",
 
   "common_cancel": "取消",
   "common_retry": "重试",

--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -373,7 +373,7 @@ return txt as text
             ("xsel", &["--clipboard", "--output"]),
         ];
         for (bin, args) in tools {
-            if let Ok(output) = std::process::Command::new(bin).args(args).output() {
+            if let Ok(output) = std::process::Command::new(bin).args(*args).output() {
                 if output.status.success() {
                     return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
                 }

--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -336,6 +336,89 @@ pub fn read_clipboard_file(path: String, as_text: bool) -> Result<ClipboardFileC
     })
 }
 
+/// Read plain text from the native clipboard.
+///
+/// - macOS: uses NSPasteboard via osascript.
+/// - Linux: probes wl-paste → xclip → xsel.
+/// - Windows: uses Win32 clipboard API.
+#[tauri::command]
+pub fn read_clipboard_text() -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let script = r#"
+use framework "AppKit"
+set pb to current application's NSPasteboard's generalPasteboard()
+set txt to pb's stringForType:(current application's NSPasteboardTypeString)
+if txt is missing value then return ""
+return txt as text
+"#;
+        let output = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(script)
+            .output()
+            .map_err(|e| format!("osascript failed: {}", e))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(format!("osascript error: {}", stderr));
+        }
+        let text = String::from_utf8_lossy(&output.stdout).into_owned();
+        Ok(text)
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let tools: &[(&str, &[&str])] = &[
+            ("wl-paste", &["--no-newline"]),
+            ("xclip", &["-selection", "clipboard", "-o"]),
+            ("xsel", &["--clipboard", "--output"]),
+        ];
+        for (bin, args) in tools {
+            if let Ok(output) = std::process::Command::new(bin).args(args).output() {
+                if output.status.success() {
+                    return Ok(String::from_utf8_lossy(&output.stdout).into_owned());
+                }
+            }
+        }
+        Err("No clipboard tool available (tried wl-paste, xclip, xsel)".into())
+    }
+
+    #[cfg(windows)]
+    {
+        use windows::Win32::System::DataExchange::{
+            CloseClipboard, GetClipboardData, OpenClipboard,
+        };
+        use windows::Win32::System::Ole::CF_UNICODETEXT;
+        unsafe {
+            if OpenClipboard(None).is_err() {
+                return Err("Failed to open clipboard".into());
+            }
+            struct ClipGuard;
+            impl Drop for ClipGuard {
+                fn drop(&mut self) {
+                    unsafe {
+                        let _ = CloseClipboard();
+                    }
+                }
+            }
+            let _guard = ClipGuard;
+            let handle = match GetClipboardData(CF_UNICODETEXT.0 as u32) {
+                Ok(h) if !h.0.is_null() => h,
+                _ => return Ok(String::new()),
+            };
+            let ptr = handle.0 as *const u16;
+            let len = (0..).take_while(|&i| *ptr.add(i) != 0).count();
+            Ok(String::from_utf16_lossy(std::slice::from_raw_parts(
+                ptr, len,
+            )))
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+    {
+        Err("Clipboard text read is not supported on this platform".into())
+    }
+}
+
 /// Save file content to a temp directory, returning the filesystem path.
 /// Used for >20MB PDFs from drag-and-drop/file picker: file is saved to temp,
 /// then its path is injected into the prompt text so CLI handles via pdftoppm.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -245,6 +245,7 @@ pub fn run() {
             commands::agents::delete_agent_file,
             commands::clipboard::get_clipboard_files,
             commands::clipboard::read_clipboard_file,
+            commands::clipboard::read_clipboard_text,
             commands::clipboard::save_temp_attachment,
             commands::mcp::list_configured_mcp_servers,
             commands::mcp::add_mcp_server,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -777,6 +777,11 @@ export async function readClipboardFile(
   return invoke<ClipboardFileContent>("read_clipboard_file", { path, asText });
 }
 
+/** Read plain text from the native clipboard via Tauri IPC. Browsers navigator.clipboard API. */
+export async function readClipboardText(): Promise<string> {
+  return invoke<string>("read_clipboard_text");
+}
+
 /** Save file to temp directory, return filesystem path. For >20MB PDFs from drag-drop/file picker. */
 export async function saveTempAttachment(name: string, contentBase64: string): Promise<string> {
   dbg("api", "saveTempAttachment", { name, len: contentBase64.length });

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -35,7 +35,7 @@
   import { dbg, dbgWarn } from "$lib/utils/debug";
   import { IS_MAC } from "$lib/utils/platform";
   import { t } from "$lib/i18n/index.svelte";
-  import { formatPasteSize } from "$lib/utils/format";
+  import { formatPasteSize, spliceText } from "$lib/utils/format";
   import {
     BINARY_ATTACHMENT_TYPES,
     MAX_ATTACHMENTS,
@@ -348,6 +348,8 @@
   let textareaEl: HTMLTextAreaElement | undefined = $state();
   let lastEscTime = 0;
   let histState: HistoryState = createHistoryState();
+  let hasShownPasteTip = $state(false);
+  let hoveredBlock: string | null = $state(null);
 
   $effect(() => {
     if (checkAndReset(histState, userHistory.length, runId)) {
@@ -371,13 +373,13 @@
   let toastMessage = $state<string | null>(null);
   let toastVariant = $state<"error" | "info">("error");
   let toastTimeout: ReturnType<typeof setTimeout> | null = null;
-  function showFileToast(msg: string, variant: "error" | "info" = "error") {
+  function showFileToast(msg: string, variant: "error" | "info" = "error", duration = 3500) {
     toastMessage = msg;
     toastVariant = variant;
     if (toastTimeout) clearTimeout(toastTimeout);
     toastTimeout = setTimeout(() => {
       toastMessage = null;
-    }, 3500);
+    }, duration);
   }
 
   // ── Slash menu state ──
@@ -850,6 +852,25 @@
   function handleKeydown(e: KeyboardEvent) {
     // Skip during IME composition (e.g., Chinese input confirming with Enter)
     if (e.isComposing || e.keyCode === 229) return;
+
+    // ── Plain-text paste: Cmd+Shift+V / Ctrl+Shift+V ──
+    // Uses Tauri IPC (read_clipboard_text) to read the clipboard natively,
+    // bypassing the browser Clipboard API which is unreliable in WKWebView.
+    if ((e.key === "V" || e.key === "v") && e.shiftKey && (IS_MAC ? e.metaKey : e.ctrlKey)) {
+      e.preventDefault();
+      api
+        .readClipboardText()
+        .then((text) => {
+          if (text) {
+            insertTextAtCursor(text);
+            dbg("prompt", "plain-text-paste", { len: text.length });
+          }
+        })
+        .catch(() => {
+          dbg("prompt", "plain-text-paste clipboard read failed");
+        });
+      return;
+    }
 
     // ── @-mention menu ──
     if (atMenuOpen) {
@@ -1434,6 +1455,11 @@
     ];
 
     dbg("prompt", "paste-compressed", { lineCount, charCount, blocks: pastedBlocks.length });
+
+    if (!hasShownPasteTip) {
+      hasShownPasteTip = true;
+      showFileToast(IS_MAC ? t("prompt_pasteToastMac") : t("prompt_pasteToastOther"), "info", 5000);
+    }
   }
 
   function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
@@ -1610,12 +1636,33 @@
     pastedBlocks = pastedBlocks.filter((b) => b.id !== id);
   }
 
+  function insertBlockToInput(id: string) {
+    const block = pastedBlocks.find((b) => b.id === id);
+    if (!block) return;
+    insertTextAtCursor(block.text);
+    pastedBlocks = pastedBlocks.filter((b) => b.id !== id);
+    dbg("prompt", "insert-block-to-input", { id });
+  }
+
   function handleSkillSelect(skillName: string) {
     dbg("prompt", "skill-select fill", { skillName });
     inputText = `/${skillName} `;
     requestAnimationFrame(() => {
       autoResize();
       textareaEl?.focus();
+    });
+  }
+
+  function insertTextAtCursor(text: string) {
+    const start = textareaEl?.selectionStart ?? inputText.length;
+    const end = textareaEl?.selectionEnd ?? start;
+    const result = spliceText(inputText, text, start, end);
+    inputText = result.text;
+    requestAnimationFrame(() => {
+      if (textareaEl) {
+        textareaEl.selectionStart = textareaEl.selectionEnd = result.cursorPos;
+        autoResize();
+      }
     });
   }
 
@@ -1745,7 +1792,7 @@
   export function restoreSnapshot(snapshot: PromptInputSnapshot): void {
     inputText = snapshot.text;
     pendingAttachments = snapshot.attachments;
-    pastedBlocks = snapshot.pastedBlocks as PastedBlock[];
+    pastedBlocks = snapshot.pastedBlocks;
     pendingPathRefs = snapshot.pathRefs ?? [];
     resetHistory(histState);
     requestAnimationFrame(() => {
@@ -1838,7 +1885,11 @@
       {#each pastedBlocks as block (block.id)}
         {@const isSpreadsheet = block.ext ? isSpreadsheetExt(block.ext) : false}
         <span
+          role="group"
+          aria-label={block.preview}
           class="inline-flex items-center gap-1.5 rounded-md border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-950/50 text-blue-700 dark:text-blue-300 px-2 py-1 text-xs"
+          onmouseenter={() => (hoveredBlock = block.id)}
+          onmouseleave={() => (hoveredBlock = null)}
         >
           {#if isSpreadsheet}
             <!-- Table/spreadsheet icon -->
@@ -1874,23 +1925,42 @@
           <span class="text-blue-400 dark:text-blue-500"
             >{formatPasteSize(block.lineCount, block.charCount)}</span
           >
-          <button
-            onclick={() => removePastedBlock(block.id)}
-            class="ml-0.5 rounded p-0.5 transition-colors hover:bg-blue-200/50 dark:hover:bg-blue-800/50"
-            title={t("prompt_removePaste")}
-          >
-            <svg
-              class="h-3 w-3"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              stroke-linejoin="round"
+          {#if hoveredBlock === block.id}
+            <button
+              onclick={() => insertBlockToInput(block.id)}
+              class="rounded p-0.5 transition-colors hover:bg-blue-200/50 dark:hover:bg-blue-800/50"
+              title={t("prompt_pasteBlockInsert")}
             >
-              <path d="M18 6 6 18" /><path d="m6 6 12 12" />
-            </svg>
-          </button>
+              <svg
+                class="h-3 w-3"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M12 5v14" /><path d="M5 12h14" />
+              </svg>
+            </button>
+            <button
+              onclick={() => removePastedBlock(block.id)}
+              class="rounded p-0.5 transition-colors hover:bg-blue-200/50 dark:hover:bg-blue-800/50"
+              title={t("prompt_removePaste")}
+            >
+              <svg
+                class="h-3 w-3"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+              </svg>
+            </button>
+          {/if}
         </span>
       {/each}
     </div>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1360,6 +1360,7 @@ export interface PromptInputSnapshot {
     lineCount: number;
     charCount: number;
     preview: string;
+    ext?: string;
   }>;
   pathRefs?: Array<{ id: string; name: string; path: string; isDir: boolean }>;
 }

--- a/src/lib/utils/__tests__/paste-utils.test.ts
+++ b/src/lib/utils/__tests__/paste-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { spliceText, formatPasteSize } from "../format";
+
+describe("spliceText", () => {
+  it("inserts text at cursor position in empty string", () => {
+    const result = spliceText("", "hello", 0);
+    expect(result.text).toBe("hello");
+    expect(result.cursorPos).toBe(5);
+  });
+
+  it("inserts text at cursor position in the middle", () => {
+    const result = spliceText("Hello World", "Beautiful ", 6);
+    expect(result.text).toBe("Hello Beautiful World");
+    expect(result.cursorPos).toBe(16);
+  });
+
+  it("inserts text at the beginning", () => {
+    const result = spliceText("World", "Hello ", 0);
+    expect(result.text).toBe("Hello World");
+    expect(result.cursorPos).toBe(6);
+  });
+
+  it("inserts text at the end", () => {
+    const result = spliceText("Hello", " World", 5);
+    expect(result.text).toBe("Hello World");
+    expect(result.cursorPos).toBe(11);
+  });
+
+  it("replaces selected text", () => {
+    // "Hello [World]" with "World" selected → replaced with "Beautiful"
+    const result = spliceText("Hello World", "Beautiful", 6, 11);
+    expect(result.text).toBe("Hello Beautiful");
+    expect(result.cursorPos).toBe(15);
+  });
+
+  it("replaces entire content", () => {
+    const result = spliceText("old text", "new text", 0, 8);
+    expect(result.text).toBe("new text");
+    expect(result.cursorPos).toBe(8);
+  });
+
+  it("handles multibyte characters", () => {
+    // Select positions 2–4 ("世界") → replace with "美丽的"
+    const result = spliceText("你好世界", "美丽的", 2, 4);
+    expect(result.text).toBe("你好美丽的");
+    expect(result.cursorPos).toBe(5);
+  });
+
+  it("defaults selectionEnd to selectionStart when omitted (no selection)", () => {
+    const result = spliceText("abc", "X", 1);
+    expect(result.text).toBe("aXbc");
+    expect(result.cursorPos).toBe(2);
+  });
+
+  it("inserts multiline text at cursor", () => {
+    const multiline = "line1\nline2\nline3";
+    const result = spliceText("before  after", multiline, 7);
+    expect(result.text).toBe("before line1\nline2\nline3 after");
+    expect(result.cursorPos).toBe(7 + multiline.length);
+  });
+
+  it("replaces selection with multiline text", () => {
+    const replacement = "a\nb\nc";
+    // "start [REPLACE] end" — select positions 6–15 ("[REPLACE]")
+    const result = spliceText("start [REPLACE] end", replacement, 6, 15);
+    expect(result.text).toBe("start a\nb\nc end");
+    expect(result.cursorPos).toBe(6 + replacement.length);
+  });
+
+  it("inserts empty string (no-op)", () => {
+    const result = spliceText("hello", "", 3);
+    expect(result.text).toBe("hello");
+    expect(result.cursorPos).toBe(3);
+  });
+
+  it("handles zero-length selection at position 0", () => {
+    const result = spliceText("abc", "X", 0, 0);
+    expect(result.text).toBe("Xabc");
+    expect(result.cursorPos).toBe(1);
+  });
+});
+
+describe("formatPasteSize", () => {
+  it("shows chars for single line", () => {
+    expect(formatPasteSize(1, 42)).toBe("42 chars");
+  });
+
+  it("shows lines for multi-line", () => {
+    expect(formatPasteSize(5, 200)).toBe("5 lines");
+  });
+
+  it("shows k lines for large counts", () => {
+    expect(formatPasteSize(1500, 50000)).toBe("1.5k lines");
+  });
+
+  it("shows 1k lines at exactly 1000", () => {
+    expect(formatPasteSize(1000, 30000)).toBe("1.0k lines");
+  });
+
+  it("shows chars for single line with zero chars", () => {
+    expect(formatPasteSize(1, 0)).toBe("0 chars");
+  });
+
+  it("shows lines at 999 (below k threshold)", () => {
+    expect(formatPasteSize(999, 50000)).toBe("999 lines");
+  });
+
+  it("shows k lines at 1001", () => {
+    expect(formatPasteSize(1001, 50000)).toBe("1.0k lines");
+  });
+});

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -67,6 +67,24 @@ export function formatPasteSize(lines: number, chars: number): string {
   return `${chars} chars`;
 }
 
+/**
+ * Splice text into a string at a selection range, replacing any selected text.
+ * Returns `{ text, cursorPos }` where cursorPos is the position after the inserted text.
+ *
+ * Used by insertTextAtCursor and insertBlockToInput in PromptInput.
+ */
+export function spliceText(
+  source: string,
+  insertion: string,
+  selectionStart: number,
+  selectionEnd: number = selectionStart,
+): { text: string; cursorPos: number } {
+  const before = source.slice(0, selectionStart);
+  const after = source.slice(selectionEnd);
+  const text = before + insertion + after;
+  return { text, cursorPos: selectionStart + insertion.length };
+}
+
 /** Split a file path by both / and \ separators (cross-platform). */
 export function splitPath(p: string): string[] {
   return p.split(/[/\\]/);


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 bullet points. -->

- Add Cmd+Shift+V / Ctrl+Shift+V keyboard shortcut for plain-text paste, bypassing intelligent paste logic and inserting editable text directly at cursor position
- Add hover action buttons on pasted blocks, allowing users to insert compressed block content back into the input for editing
- Show toast notification on first paste compression to guide users about the shortcut, and display keyboard hint when input is empty

## Test Plan

<!-- How did you verify the changes? -->

- [X] `npm run verify` passes (lint, format, tests, build, rust checks)
- [X] Manual testing:
  - Press Cmd+Shift+V in the input to paste long text (>5 lines), verify text is inserted directly into input instead of being compressed into a pasted block
  - Verify shortcut correctly inserts text at cursor position in the middle of existing content
  - Hover over a pasted block, verify ⬇️ insert button and ❌ delete button appear correctly
  - Click insert button, verify block content is inserted into input and block is removed from the list
  - On first long paste, verify toast notification displays correctly (auto-dismisses after 5 seconds)
  - Verify existing Cmd+V intelligent paste logic is not broken
  - Verify binary file paste (images/PDFs) still works correctly


## Screenshots

<img width="1414" height="331" alt="image" src="https://github.com/user-attachments/assets/54b1b796-1f83-458b-9eb3-12e94ad20eeb" />

### Keyboard Shortcut Hint
- When input is empty, displays "⌘+Shift+V for plain text" (macOS) or "Ctrl+Shift+V for plain text" (Windows/Linux) at the bottom

### Pasted Block Hover Buttons
- ⬇️ insert button and ❌ delete button appear on hover

### Toast Notification Guide
- Shows notification on first intelligent paste compression, informing users about the plain-text paste shortcut

---

## Background & Motivation

### Problem Statement

The current paste functionality has a significant UX issue: when users paste long text (≥5 lines or ≥500 characters), the system automatically compresses it into an immutable pasted block, causing users to lose control over their pasted content.

**Core Pain Points**:
1. **Not Editable**: Pasted block content cannot be modified, forcing users to re-copy and re-paste
2. **Fixed Order**: Content is sent in a fixed order (pasted blocks first, then manual input), with no flexibility to adjust
3. **Lack of Control**: Users cannot choose paste mode and must passively accept the intelligent detection result

While the original intention was to prevent the input box from becoming too bulky, the actual effect sacrificed users' core needs—the ability to edit and maintain control over their text.

### Solution

Build on top of the existing intelligent paste logic by adding user-controlled options:

1. **Plain-Text Paste Shortcut** (Cmd+Shift+V / Ctrl+Shift+V)
   - Industry-standard shortcut (used by Google Docs, Notion, VS Code, Slack)
   - Zero learning curve for users
   - Forces clipboard content to be inserted as plain text, bypassing intelligent detection

2. **Pasted Block Rollback Mechanism**
   - Hover to reveal action buttons
   - One-click conversion of pasted block back to editable text
   - Keeps interface clean (buttons only visible on hover)

3. **Progressive User Guidance**
   - Toast notification on first use
   - Persistent keyboard hint in input box
   - Improves feature discoverability and reduces learning curve

### Design Principles

- **Backward Compatible**: Existing Cmd+V intelligent paste logic remains unchanged
- **User Choice**: Provide multiple paste modes for users to actively choose from
- **Progressive Enhancement**: New users enjoy automatic compression convenience, power users gain full control
- **No Breaking Changes**: All existing functionality remains intact