### PR TITLE
fix: 6 security + stability fixes from max-effort code review

### DIFF
--- a/src-tauri/src/agent/claude_protocol.rs
+++ b/src-tauri/src/agent/claude_protocol.rs
@@ -1188,15 +1188,17 @@ impl ProtocolState {
                         subtype,
                         &error_msg[..error_msg.len().min(200)]
                     );
+                    // HC#1: result event = turn complete (→ idle), NOT session end.
+                    // CLI process is still alive; the session can accept another turn.
+                    // The error is surfaced via the `error` field, and finalize_meta on
+                    // EOF reads meta.result_subtype to decide the terminal status.
                     events.push(BusEvent::RunState {
                         run_id: run_id.to_string(),
-                        state: "failed".to_string(),
+                        state: "idle".to_string(),
                         exit_code: None,
                         error: Some(error_msg),
                     });
                 } else {
-                    // "idle" = turn complete, waiting for next user input.
-                    // The actual "completed" state is emitted on process EOF (read_stdout cleanup).
                     events.push(BusEvent::RunState {
                         run_id: run_id.to_string(),
                         state: "idle".to_string(),
@@ -2102,7 +2104,9 @@ mod tests {
             "usage": {"input_tokens": 100, "output_tokens": 50}
         });
         let events = ps.map_event(RUN, &raw);
-        // UsageUpdate + RunState(failed)
+        // UsageUpdate + RunState(idle, error) — HC#1: result event = turn complete (→ idle).
+        // Terminal failed/completed is decided in session_actor::finalize_meta on EOF
+        // using meta.result_subtype.
         assert!(events.len() >= 2);
         let run_state = events
             .iter()
@@ -2110,7 +2114,7 @@ mod tests {
             .unwrap();
         match run_state {
             BusEvent::RunState { state, error, .. } => {
-                assert_eq!(state, "failed");
+                assert_eq!(state, "idle");
                 assert_eq!(error.as_deref(), Some("Max turns reached"));
             }
             _ => unreachable!(),

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -879,7 +879,9 @@ impl SessionActor {
     }
 
     /// Ralph state transition on turn end. Uses action-first pattern to avoid borrow conflicts.
-    fn ralph_on_turn_end(&mut self, turn: &ActiveTurn, state: &str) {
+    /// `turn_failed`: caller's classification of the just-ended turn (true for error results
+    /// or process-level failures, false for clean idle).
+    fn ralph_on_turn_end(&mut self, turn: &ActiveTurn, turn_failed: bool) {
         if self.ralph_loop.is_none() {
             return;
         }
@@ -900,7 +902,7 @@ impl SessionActor {
                 TurnOrigin::Ralph => {
                     let is_cancel_pending = ralph.phase == RalphPhase::CancelPending;
 
-                    if state == "failed" {
+                    if turn_failed {
                         if is_cancel_pending {
                             RalphAction::Complete(RalphCompleteReason::Cancelled)
                         } else {
@@ -1542,30 +1544,51 @@ impl SessionActor {
                     error,
                     ..
                 } => {
-                    // Handle interrupt: CLI emits result(error) but session is alive.
+                    // HC#1: parser emits idle on both success and error result events
+                    // (CLI is still alive). On user interrupt, the result is just the
+                    // cancel ack — suppress error and clear protocol error tracking so
+                    // finalize_meta on EOF does not mark the run as Failed.
                     let (emit_state, emit_error) =
                         if self.pending_interrupt && (state == "idle" || state == "failed") {
                             self.pending_interrupt = false;
-                            if state == "failed" {
-                                self.protocol.got_result_event = false;
-                                self.protocol.result_subtype = None;
-                                log::debug!("[actor] interrupt result → converted failed to idle");
-                                (String::from("idle"), None)
-                            } else {
-                                (state.clone(), error.clone())
-                            }
+                            self.protocol.got_result_event = false;
+                            self.protocol.result_subtype = None;
+                            log::debug!("[actor] interrupt result → idle, error tracking cleared");
+                            (String::from("idle"), None)
                         } else {
                             (state.clone(), error.clone())
                         };
 
                     self.emit_state(&emit_state, *exit_code, emit_error.clone(), false);
 
-                    // Persist idle status to meta (uses normalized emit_state, not raw state)
                     if emit_state == "idle" {
                         self.persist_idle_running(RunStatus::Idle);
+                        // If the result event indicated an error, persist subtype+message
+                        // to meta so finalize_meta on EOF can mark the run Failed.
+                        let had_result_error = self
+                            .protocol
+                            .result_subtype
+                            .as_deref()
+                            .map(|s| s.starts_with("error"))
+                            .unwrap_or(false);
+                        if had_result_error {
+                            log::debug!(
+                                "[actor] persisting idle-with-error: subtype={:?}, error={:?}",
+                                self.protocol.result_subtype,
+                                emit_error
+                            );
+                            if let Err(e) = storage::runs::persist_result_error(
+                                &self.run_id,
+                                emit_error.clone(),
+                                self.protocol.result_subtype.clone(),
+                            ) {
+                                log::warn!("[actor] failed to persist result error: {}", e);
+                            }
+                        }
                     }
 
-                    // Persist result error on failed
+                    // Defensive: handle_eof emits failed directly (not via process_event),
+                    // but keep this branch in case any other emitter routes failed here.
                     if emit_state == "failed" {
                         log::debug!(
                             "[actor] persisting result error: subtype={:?}, error={:?}",
@@ -1574,7 +1597,7 @@ impl SessionActor {
                         );
                         if let Err(e) = storage::runs::persist_result_error(
                             &self.run_id,
-                            emit_error,
+                            emit_error.clone(),
                             self.protocol.result_subtype.clone(),
                         ) {
                             log::warn!("[actor] failed to persist result error: {}", e);
@@ -1590,8 +1613,13 @@ impl SessionActor {
                         self.active_extractor = None;
                         self.protocol.set_pending_slash_command(None);
 
-                        // Ralph loop: state transition on turn end
-                        self.ralph_on_turn_end(&turn, &emit_state);
+                        // Ralph loop: classify turn outcome.
+                        // emit_state is now "idle" on both success and error result events,
+                        // so use the presence of emit_error (cleared above on interrupt) to
+                        // distinguish a failed turn from a successful one.
+                        let turn_failed = emit_state == "failed"
+                            || (emit_state == "idle" && emit_error.is_some());
+                        self.ralph_on_turn_end(&turn, turn_failed);
 
                         self.try_dispatch().await;
                     }

--- a/src-tauri/src/agent/stream.rs
+++ b/src-tauri/src/agent/stream.rs
@@ -16,6 +16,61 @@ pub fn new_process_map() -> ProcessMap {
     Arc::new(Mutex::new(HashMap::new()))
 }
 
+/// Emit a chunk of Claude stdout: append to assistant_text + persist + Tauri emit.
+fn emit_claude_stdout(run_id: &str, app: &AppHandle, assistant: &mut String, text: String) {
+    assistant.push_str(&text);
+    if let Err(e) = storage::events::append_event(
+        run_id,
+        RunEventType::Stdout,
+        serde_json::json!({ "text": text.clone(), "source": "ui_chat" }),
+    ) {
+        log::warn!("[stream] stdout append failed: {}", e);
+    }
+    let _ = app.emit(
+        "run-event",
+        serde_json::json!({ "run_id": run_id, "type": "stdout", "text": text.clone() }),
+    );
+    let _ = app.emit("chat-delta", ChatDelta { text });
+}
+
+/// Streaming UTF-8 decoder for chunk-boundary correctness.
+///
+/// Concatenates `leftover` (previous incomplete trailing bytes) with `chunk`,
+/// returns the longest valid-UTF-8 prefix as a `String` plus any trailing
+/// partial multibyte sequence to defer to the next chunk. A naive
+/// `String::from_utf8_lossy(&chunk[..n])` per read would emit U+FFFD on every
+/// multibyte character that straddles the read boundary (common for CJK /
+/// emoji output from `claude --print`).
+///
+/// On genuinely invalid UTF-8 (a byte error mid-buffer, not just an incomplete
+/// tail), the whole combined buffer is lossy-decoded so the stream can make
+/// progress instead of accumulating bad bytes forever.
+fn decode_utf8_chunk(leftover: Vec<u8>, chunk: &[u8]) -> (String, Vec<u8>) {
+    let mut combined = leftover;
+    combined.extend_from_slice(chunk);
+    match std::str::from_utf8(&combined) {
+        Ok(s) => (s.to_string(), Vec::new()),
+        Err(e) => {
+            let valid_up_to = e.valid_up_to();
+            match e.error_len() {
+                None => {
+                    // Incomplete trailing char — defer to next read.
+                    let text = std::str::from_utf8(&combined[..valid_up_to])
+                        .expect("valid_up_to bytes form valid UTF-8")
+                        .to_string();
+                    let tail = combined[valid_up_to..].to_vec();
+                    (text, tail)
+                }
+                Some(_) => {
+                    // Truly invalid bytes mid-buffer (corrupted source). Fall
+                    // back to lossy decode so we don't get stuck.
+                    (String::from_utf8_lossy(&combined).into_owned(), Vec::new())
+                }
+            }
+        }
+    }
+}
+
 pub async fn run_agent(
     app: AppHandle,
     process_map: ProcessMap,
@@ -157,31 +212,33 @@ pub async fn run_agent(
                 }
             }
         } else {
-            // Claude: stdout is the response text
+            // Claude: stdout is the response text. Decode UTF-8 across read
+            // boundaries — multibyte characters can straddle a single read(),
+            // so leftover trailing bytes are deferred to the next chunk to
+            // avoid emitting U+FFFD for valid (just-split) input.
             let mut reader = BufReader::new(stdout);
             let mut buf = vec![0u8; 8192];
+            let mut leftover: Vec<u8> = Vec::new();
             loop {
                 match reader.read(&mut buf).await {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        let text = String::from_utf8_lossy(&buf[..n]).to_string();
-                        assistant_text.push_str(&text);
-                        if let Err(e) = storage::events::append_event(
-                            &run_id_out,
-                            RunEventType::Stdout,
-                            serde_json::json!({ "text": text, "source": "ui_chat" }),
-                        ) {
-                            log::warn!("[stream] stdout append failed: {}", e);
+                    Ok(0) => {
+                        // Flush any trailing incomplete bytes at EOF (lossy —
+                        // CLI should always end on a char boundary, but a
+                        // truncated last char shouldn't be silently dropped).
+                        if !leftover.is_empty() {
+                            let text = String::from_utf8_lossy(&leftover).into_owned();
+                            leftover.clear();
+                            emit_claude_stdout(&run_id_out, &app_out, &mut assistant_text, text);
                         }
-                        let _ = app_out.emit(
-                            "run-event",
-                            serde_json::json!({
-                                "run_id": run_id_out,
-                                "type": "stdout",
-                                "text": text
-                            }),
-                        );
-                        let _ = app_out.emit("chat-delta", ChatDelta { text });
+                        break;
+                    }
+                    Ok(n) => {
+                        let (text, new_leftover) =
+                            decode_utf8_chunk(std::mem::take(&mut leftover), &buf[..n]);
+                        leftover = new_leftover;
+                        if !text.is_empty() {
+                            emit_claude_stdout(&run_id_out, &app_out, &mut assistant_text, text);
+                        }
                     }
                     Err(_) => break,
                 }
@@ -298,6 +355,91 @@ pub async fn run_agent(
     );
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_ascii_only_no_leftover() {
+        let (text, leftover) = decode_utf8_chunk(Vec::new(), b"hello world");
+        assert_eq!(text, "hello world");
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn decode_complete_multibyte_no_leftover() {
+        // "你好" = 0xE4 0xBD 0xA0 0xE5 0xA5 0xBD (6 bytes)
+        let (text, leftover) = decode_utf8_chunk(Vec::new(), "你好".as_bytes());
+        assert_eq!(text, "你好");
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn decode_split_multibyte_defers_tail() {
+        // "你好" split at byte 4: first chunk has "你" (3 bytes) + 1 byte of "好"
+        let bytes = "你好".as_bytes();
+        let (text, leftover) = decode_utf8_chunk(Vec::new(), &bytes[..4]);
+        assert_eq!(text, "你", "valid prefix emitted");
+        assert_eq!(leftover, vec![bytes[3]], "incomplete tail deferred");
+
+        // Next read brings the remaining 2 bytes of "好"
+        let (text2, leftover2) = decode_utf8_chunk(leftover, &bytes[4..]);
+        assert_eq!(text2, "好");
+        assert!(leftover2.is_empty());
+    }
+
+    #[test]
+    fn decode_split_at_first_byte_of_multibyte() {
+        // First read ends exactly at the start byte of "你"
+        let bytes = "ab你cd".as_bytes(); // 2 ASCII + 3 multibyte + 2 ASCII
+        let (text, leftover) = decode_utf8_chunk(Vec::new(), &bytes[..3]); // "ab" + first byte of 你
+        assert_eq!(text, "ab");
+        assert_eq!(leftover, vec![bytes[2]]);
+
+        let (text2, leftover2) = decode_utf8_chunk(leftover, &bytes[3..]);
+        assert_eq!(text2, "你cd");
+        assert!(leftover2.is_empty());
+    }
+
+    #[test]
+    fn decode_emoji_split_across_reads() {
+        // "🦀" = 0xF0 0x9F 0xA6 0x80 (4 bytes)
+        let bytes = "🦀".as_bytes();
+        let (text1, leftover1) = decode_utf8_chunk(Vec::new(), &bytes[..2]);
+        assert_eq!(text1, "");
+        assert_eq!(leftover1, bytes[..2].to_vec());
+
+        let (text2, leftover2) = decode_utf8_chunk(leftover1, &bytes[2..3]);
+        assert_eq!(text2, "");
+        assert_eq!(leftover2, bytes[..3].to_vec());
+
+        let (text3, leftover3) = decode_utf8_chunk(leftover2, &bytes[3..]);
+        assert_eq!(text3, "🦀");
+        assert!(leftover3.is_empty());
+    }
+
+    #[test]
+    fn decode_invalid_bytes_falls_back_to_lossy() {
+        // 0xFF is never valid in UTF-8 — error_len is Some, not None.
+        let (text, leftover) = decode_utf8_chunk(Vec::new(), &[b'a', 0xFF, b'b']);
+        // Lossy decode replaces 0xFF with U+FFFD and consumes the whole buffer.
+        assert!(text.contains('a'));
+        assert!(text.contains('b'));
+        assert!(text.contains('\u{FFFD}'));
+        assert!(leftover.is_empty(), "lossy fallback clears leftover");
+    }
+
+    #[test]
+    fn decode_carries_leftover_from_prior_chunk() {
+        // Caller has already stashed the first byte of "你"; this chunk has the rest.
+        let bytes = "你".as_bytes();
+        let leftover_in = vec![bytes[0]];
+        let (text, leftover_out) = decode_utf8_chunk(leftover_in, &bytes[1..]);
+        assert_eq!(text, "你");
+        assert!(leftover_out.is_empty());
+    }
 }
 
 pub async fn stop_process(process_map: &ProcessMap, run_id: &str) -> bool {

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -74,21 +74,13 @@ pub fn check_is_directory(path: String) -> bool {
 /// Shared by chat drag-drop and Explorer image preview.
 const MAX_BASE64_FILE_SIZE: u64 = 100 * 1024 * 1024;
 
-/// Read a file as base64 with MIME detection.
-///
-/// **Path validation**: only enforced when `cwd` is `Some` (Explorer context).
-/// When `cwd` is `None` (chat drag-drop), any absolute path is accepted because
-/// the user explicitly initiated the drop. New call sites that browse the
-/// filesystem MUST pass `cwd` to get boundary enforcement.
+/// Read a file as base64 with MIME detection. `cwd` is required and is passed
+/// to validate_file_path as the caller-provided allowed dir, in addition to
+/// the always-allowed `~/.opencovibe` / `~/.claude` / settings.working_directory.
 #[tauri::command]
-pub fn read_file_base64(path: String, cwd: Option<String>) -> Result<(String, String), String> {
-    log::debug!("[fs] read_file_base64: path={path}, cwd={cwd:?}");
-    let validated = if cwd.is_some() {
-        super::files::validate_file_path(&path, cwd.as_deref())?
-    } else {
-        log::debug!("[fs] read_file_base64: no cwd, skipping path boundary check");
-        std::path::PathBuf::from(&path)
-    };
+pub fn read_file_base64(path: String, cwd: String) -> Result<(String, String), String> {
+    log::debug!("[fs] read_file_base64: path={path}, cwd={cwd}");
+    let validated = super::files::validate_file_path(&path, Some(cwd.as_str()))?;
     let p = validated.as_path();
     let meta = p
         .metadata()
@@ -158,9 +150,28 @@ mod tests {
     use super::*;
     use std::io::Write;
 
-    /// cwd=None (drag-drop): any absolute path should succeed without boundary check.
+    /// Path outside the allowed cwd should be rejected.
     #[test]
-    fn read_file_base64_no_cwd_allows_any_path() {
+    fn read_file_base64_rejects_outside_cwd() {
+        let allowed_dir = tempfile::tempdir().unwrap();
+        let outside_dir = tempfile::tempdir().unwrap();
+        let outside_file = outside_dir.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").unwrap();
+
+        let result = read_file_base64(
+            outside_file.to_string_lossy().into(),
+            allowed_dir.path().to_string_lossy().into(),
+        );
+        assert!(
+            result.is_err(),
+            "path outside cwd should be rejected, got: {:?}",
+            result
+        );
+    }
+
+    /// Path inside the allowed cwd should succeed.
+    #[test]
+    fn read_file_base64_allows_inside_cwd() {
         let dir = tempfile::tempdir().unwrap();
         let img = dir.path().join("test.png");
         // Minimal 1x1 PNG
@@ -179,48 +190,29 @@ mod tests {
             .write_all(png_bytes)
             .unwrap();
 
-        let result = read_file_base64(img.to_string_lossy().into(), None);
-        assert!(result.is_ok(), "cwd=None should allow any path");
+        let result = read_file_base64(
+            img.to_string_lossy().into(),
+            dir.path().to_string_lossy().into(),
+        );
+        assert!(result.is_ok(), "path inside cwd should succeed");
         let (base64, mime) = result.unwrap();
         assert!(!base64.is_empty());
         assert_eq!(mime, "image/png");
     }
 
-    /// cwd=Some: path outside the allowed directory should be rejected.
+    /// Empty cwd should reject any absolute path (cannot canonicalize "" against
+    /// validate_file_path's allowed roots).
     #[test]
-    fn read_file_base64_with_cwd_rejects_outside_path() {
-        let allowed_dir = tempfile::tempdir().unwrap();
-        let outside_dir = tempfile::tempdir().unwrap();
-        let outside_file = outside_dir.path().join("secret.txt");
-        std::fs::write(&outside_file, b"secret").unwrap();
-
-        let result = read_file_base64(
-            outside_file.to_string_lossy().into(),
-            Some(allowed_dir.path().to_string_lossy().into()),
-        );
-        assert!(
-            result.is_err(),
-            "cwd=Some should reject path outside allowed dir"
-        );
-    }
-
-    /// cwd=Some: path inside the allowed directory should succeed.
-    #[test]
-    fn read_file_base64_with_cwd_allows_inside_path() {
+    fn read_file_base64_rejects_empty_cwd() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("hello.txt");
         std::fs::write(&file, b"hello").unwrap();
 
-        let result = read_file_base64(
-            file.to_string_lossy().into(),
-            Some(dir.path().to_string_lossy().into()),
-        );
+        let result = read_file_base64(file.to_string_lossy().into(), String::new());
         assert!(
-            result.is_ok(),
-            "cwd=Some should allow path inside allowed dir"
+            result.is_err(),
+            "empty cwd should not bypass validation, got: {:?}",
+            result
         );
-        let (base64, mime) = result.unwrap();
-        assert!(!base64.is_empty());
-        assert!(mime.contains("text"), "expected text mime, got {}", mime);
     }
 }

--- a/src-tauri/src/storage/plugins.rs
+++ b/src-tauri/src/storage/plugins.rs
@@ -253,12 +253,16 @@ fn collect_md_stems_recursive(
 
     for entry in entries.flatten() {
         let path = entry.path();
-        // Use the entry's file_type to avoid following symlinks into cycles.
-        let file_type = match entry.file_type() {
-            Ok(t) => t,
-            Err(_) => continue,
+        // Resolve metadata via the path (which follows symlinks) rather than
+        // entry.file_type() or entry.metadata() (both report symlink-itself).
+        // Users commonly symlink shared .md files or whole subdirectories from
+        // a dotfiles repo into ~/.claude/commands/ — those must surface in the
+        // slash menu. Cycles are bounded by MAX_COMMAND_DEPTH.
+        let metadata = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue, // broken symlink or unreadable — skip silently
         };
-        if file_type.is_dir() {
+        if metadata.is_dir() {
             if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
                 let new_prefix = if prefix.is_empty() {
                     dir_name.to_string()
@@ -267,7 +271,7 @@ fn collect_md_stems_recursive(
                 };
                 collect_md_stems_recursive(&path, &new_prefix, depth + 1, stems);
             }
-        } else if file_type.is_file() && path.extension().map(|ext| ext == "md").unwrap_or(false) {
+        } else if metadata.is_file() && path.extension().map(|ext| ext == "md").unwrap_or(false) {
             if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                 let command_name = if prefix.is_empty() {
                     stem.to_string()
@@ -892,6 +896,75 @@ mod tests {
         assert_eq!(commands[0].name, "opsx:apply");
         assert_eq!(commands[0].description, "Apply an opsx change");
         assert!(seen.contains("opsx:apply"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_md_stems_follows_symlinked_file() {
+        use std::os::unix::fs::symlink;
+        // A common pattern: shared command files in a dotfiles repo, symlinked
+        // into ~/.claude/commands/ so they show up in the slash menu.
+        let real_dir = tempdir().unwrap();
+        let link_dir = tempdir().unwrap();
+        let target = real_dir.path().join("review.md");
+        fs::write(&target, "---\nname: review\n---").unwrap();
+        symlink(&target, link_dir.path().join("review.md")).unwrap();
+
+        let stems = list_md_stems(link_dir.path());
+        let names = names(&stems);
+        assert_eq!(stems.len(), 1, "symlinked .md must be discovered");
+        assert!(names.contains(&"review"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_md_stems_follows_symlinked_dir() {
+        use std::os::unix::fs::symlink;
+        // Whole-directory symlink (e.g. `commands/team -> ~/dotfiles/team-commands/`).
+        // Nested entries must surface with the symlink name as the prefix.
+        let real_dir = tempdir().unwrap();
+        let link_dir = tempdir().unwrap();
+        fs::create_dir_all(real_dir.path().join("nested")).unwrap();
+        fs::write(real_dir.path().join("nested").join("apply.md"), "x").unwrap();
+        fs::write(real_dir.path().join("plain.md"), "x").unwrap();
+
+        symlink(real_dir.path(), link_dir.path().join("team")).unwrap();
+
+        let stems = list_md_stems(link_dir.path());
+        let names = names(&stems);
+        assert!(
+            names.contains(&"team:plain"),
+            "flat .md under symlinked dir missing; got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"team:nested:apply"),
+            "nested .md under symlinked dir missing; got: {:?}",
+            names
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn list_md_stems_terminates_on_symlink_cycle() {
+        use std::os::unix::fs::symlink;
+        // a/loop -> .. (creates a cycle a/loop/loop/loop/...). MAX_COMMAND_DEPTH
+        // must bound the recursion regardless of follow-symlinks behaviour.
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("a")).unwrap();
+        fs::write(dir.path().join("a").join("real.md"), "x").unwrap();
+        symlink(dir.path().join("a"), dir.path().join("a").join("loop")).unwrap();
+
+        // Should return without hanging. We don't assert an exact count — the
+        // depth cap may duplicate the real.md entry along each loop level — but
+        // we DO require at least one occurrence of "a:real" or "real".
+        let stems = list_md_stems(dir.path());
+        let names = names(&stems);
+        assert!(
+            names.iter().any(|n| n.ends_with("real") || *n == "real"),
+            "expected real.md to appear despite the cycle; got: {:?}",
+            names
+        );
     }
 
     #[test]

--- a/src-tauri/src/storage/settings.rs
+++ b/src-tauri/src/storage/settings.rs
@@ -376,26 +376,68 @@ fn migrate_platform_credentials(settings: &mut AllSettings) -> bool {
     changed
 }
 
-pub fn save(settings: &AllSettings) -> Result<(), String> {
-    log::debug!("[storage/settings] saving settings");
-    let path = settings_path();
-    super::ensure_dir(path.parent().unwrap()).map_err(|e| e.to_string())?;
-    let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
-    fs::write(&path, &json).map_err(|e| e.to_string())?;
+/// Atomic JSON-to-file write with 0600 perms. Mirrors storage::runs::save_meta:
+/// write to a unique tmp file, lock perms, rename. Used by save() to avoid
+/// leaving settings.json truncated on crash (API keys must not be lost).
+fn write_atomic_0600(path: &std::path::Path, json: &str) -> Result<(), String> {
+    let dir = path
+        .parent()
+        .ok_or_else(|| "path has no parent".to_string())?;
+    let file_name = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .ok_or_else(|| "path has no filename".to_string())?;
+    let tmp = dir.join(format!(
+        "{}.{}.{}.tmp",
+        file_name,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+    ));
+    fs::write(&tmp, json).map_err(|e| format!("write tmp: {e}"))?;
 
-    // Restrict file permissions — settings may contain API keys
+    // Restrict perms on the tmp file BEFORE rename so the destination is never
+    // briefly world-readable.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        if let Err(e) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+        if let Err(e) = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600)) {
             log::warn!(
-                "[storage/settings] failed to set permissions on settings.json: {}",
+                "[storage/settings] failed to set 0600 perms on tmp settings.json: {}",
                 e
             );
         }
     }
 
-    Ok(())
+    // Rename with PermissionDenied retry (Windows AV may briefly lock the target).
+    for attempt in 0..3u8 {
+        match fs::rename(&tmp, path) {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied && attempt < 2 => {
+                log::debug!(
+                    "[storage/settings] save rename PermissionDenied, retry {}",
+                    attempt + 1
+                );
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => {
+                let _ = fs::remove_file(&tmp);
+                return Err(format!("rename: {e}"));
+            }
+        }
+    }
+    let _ = fs::remove_file(&tmp);
+    Err("rename: PermissionDenied after 3 retries".to_string())
+}
+
+pub fn save(settings: &AllSettings) -> Result<(), String> {
+    log::debug!("[storage/settings] saving settings");
+    let path = settings_path();
+    super::ensure_dir(path.parent().unwrap()).map_err(|e| e.to_string())?;
+    let json = serde_json::to_string_pretty(settings).map_err(|e| e.to_string())?;
+    write_atomic_0600(&path, &json)
 }
 
 pub fn get_user_settings() -> UserSettings {
@@ -791,5 +833,65 @@ mod tests {
         assert!(is_key_optional_platform("ollama"));
         assert!(!is_key_optional_platform("deepseek"));
         assert!(!is_key_optional_platform("unknown-platform"));
+    }
+
+    #[test]
+    fn write_atomic_writes_content_and_replaces_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+
+        // First write to a fresh path
+        write_atomic_0600(&path, "{\"a\":1}").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{\"a\":1}");
+
+        // Overwrite — must replace cleanly with no leftover tmp file
+        write_atomic_0600(&path, "{\"a\":2,\"b\":3}").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{\"a\":2,\"b\":3}");
+
+        // No stray .tmp files left behind in the dir
+        let leftover_tmps: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            leftover_tmps.is_empty(),
+            "no .tmp files should remain after successful writes, found: {:?}",
+            leftover_tmps
+                .iter()
+                .map(|e| e.file_name())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_atomic_sets_0600_perms() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        write_atomic_0600(&path, "{\"secret\":\"value\"}").unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "destination must be owner-only readable/writable"
+        );
+    }
+
+    #[test]
+    fn write_atomic_preserves_existing_file_when_serialize_path_fails() {
+        // Sanity: if the rename fails (e.g. dir does not exist), the original
+        // file (if any) is untouched. We simulate this by pointing at a path
+        // whose parent does not exist.
+        let dir = tempfile::tempdir().unwrap();
+        let good_path = dir.path().join("settings.json");
+        write_atomic_0600(&good_path, "original").unwrap();
+
+        let bad_path = dir.path().join("missing-subdir").join("settings.json");
+        let result = write_atomic_0600(&bad_path, "new");
+        assert!(result.is_err(), "write to nonexistent dir should fail");
+
+        // Original untouched
+        assert_eq!(fs::read_to_string(&good_path).unwrap(), "original");
     }
 }

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -259,7 +259,7 @@ pub async fn dispatch_command(
         }
         "read_file_base64" => {
             let path = extract_str(&params, "path")?;
-            let cwd = params.get("cwd").and_then(|v| v.as_str()).map(String::from);
+            let cwd = extract_str(&params, "cwd")?;
             let result = crate::commands::fs::read_file_base64(path, cwd)?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -268,10 +268,10 @@ export async function resolveRemoteHome(hostName: string): Promise<string> {
   return invoke<string>("resolve_remote_home", { hostName });
 }
 
-export async function readFileBase64(path: string, cwd?: string): Promise<[string, string]> {
+export async function readFileBase64(path: string, cwd: string): Promise<[string, string]> {
   return perfMarkAsync(
     "ipc-readFileBase64",
-    () => invoke<[string, string]>("read_file_base64", { path, cwd: cwd ?? null }),
+    () => invoke<[string, string]>("read_file_base64", { path, cwd }),
     { path },
   );
 }

--- a/src/lib/components/MarkdownContent.svelte
+++ b/src/lib/components/MarkdownContent.svelte
@@ -156,7 +156,7 @@
       const abs = basePath.replace(/\\/g, "/") + "/" + src.replace(/\\/g, "/");
       dbg("markdown", "resolve-img", { src, abs });
 
-      readFileBase64(abs)
+      readFileBase64(abs, basePath)
         .then(([base64, mime]) => {
           img.src = `data:${mime};base64,${base64}`;
         })

--- a/src/lib/stores/__fixtures__/result-error-max-turns.json
+++ b/src/lib/stores/__fixtures__/result-error-max-turns.json
@@ -31,7 +31,7 @@
   {
     "type": "run_state",
     "run_id": "run-err-1",
-    "state": "failed",
+    "state": "idle",
     "error": "Max turns reached",
     "exit_code": null
   }

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -1144,12 +1144,14 @@ describe("SessionStore reducer", () => {
   // ── result_subtype error flows ──
 
   describe("result_subtype", () => {
-    it("error flows through to phase and error state", () => {
+    it("error flows through to error state but phase stays non-terminal (HC#1)", () => {
       store.run = makeRun("run-err-1");
       store.phase = "running";
       store.applyEventBatch(resultErrorMaxTurnsEvents as BusEvent[]);
 
-      expect(store.phase).toBe("failed");
+      // HC#1: result event = turn complete (→ idle), NOT session end.
+      // Terminal failed/completed is decided in the backend on EOF.
+      expect(store.phase).toBe("idle");
       expect(store.error).toBe("Max turns reached");
       expect(store.timeline).toHaveLength(2); // user + assistant
     });

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -784,6 +784,22 @@
     } finally {
       loadingMore = false;
     }
+
+    // IntersectionObserver only refires on state changes. If anchor compensation
+    // produced ~zero delta (collapsed/unmeasured entries above the viewport, or
+    // a stable layout where the prepended content all sits within rootMargin),
+    // the sentinel stays "still intersecting" with no new state to deliver — and
+    // the user-scroll re-arm path (handleChatScroll) never fires either because
+    // a same-value scrollTop write may dispatch no scroll event. Re-observing
+    // forces a fresh callback delivery: if the sentinel exited the viewport,
+    // the callback returns early; if still intersecting, it kicks off another
+    // batch, naturally terminating once `filteredTimeline.length <= renderLimit`
+    // or the sentinel exits.
+    if (_topObserver && topSentinel && filteredTimeline.length > renderLimit) {
+      loadMoreArmed = true;
+      _topObserver.unobserve(topSentinel);
+      _topObserver.observe(topSentinel);
+    }
   }
 
   /**
@@ -3203,11 +3219,16 @@
         }
       }
 
-      // Phase 2: parallel file read (concurrency=2 to limit memory)
+      // Phase 2: parallel file read (concurrency=2 to limit memory).
+      // Pass project cwd to read_file_base64 so the backend can validate the
+      // path is inside an allowed root. Files outside the project will reject
+      // — the existing "rejected → path ref" fallback below handles that
+      // gracefully so the user still gets the attachment as a path reference.
+      const dropCwd = store.sessionCwd || store.run?.cwd || "";
       const fileResults = await mapSettled(
         fileEntries,
         async ({ p, name }) => {
-          const [base64, mime] = await api.readFileBase64(p);
+          const [base64, mime] = await api.readFileBase64(p, dropCwd);
           const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
           return { file: new File([bytes], name, { type: mime }), name, mime, size: bytes.length };
         },


### PR DESCRIPTION
## Summary

Six issues surfaced by a max-effort code review and verified by parallel verifier agents. Each fix is described inline with the failing scenario it closes; no Codex-related changes — those are sequestered for a separate worktree (see internal notes).

## Fixes

### 1. `read_file_base64` path traversal (security)
`commands/fs.rs:84` accepted any absolute path when `cwd` was `None`. Reachable from chat drag-drop, MarkdownContent images, web_server dispatch, or any IPC caller — could read `~/.ssh/id_rsa`, `~/.opencovibe/settings.json` (API keys), etc.

`cwd` is now required. Both callers pass the session/basePath; web_server dispatch rejects missing `cwd`. Existing path-validation in `files::validate_file_path` enforces the boundary.

**UX trade-off**: drag-dropping a file from outside the project cwd now degrades to a path-ref attachment (existing fallback) instead of inline content. A follow-up could restore the inline path via a session-scoped drag-drop allowlist.

### 2. Error result no longer terminates the session (HC#1)
`agent/claude_protocol.rs:1191` emitted `state: "failed"` (terminal) on error result events like `error_max_turns` / `error_rate_limit`. CLAUDE.md HC#1 explicitly says result events are turn boundaries (→ idle), not session ends — only EOF terminates.

Parser now emits `idle` with the error string. Actor's idle branch persists `result_subtype` so `finalize_meta` on EOF still marks the run `Failed` correctly. Users hitting recoverable mid-turn errors stay interactive.

### 3. UTF-8 chunk-boundary corruption in pipe-exec Claude stream
`agent/stream.rs:167` decoded each 8 KiB read with `from_utf8_lossy`, inserting `U+FFFD` on every multibyte char that happened to straddle a read boundary (common for CJK / emoji from `claude --print`).

Added `decode_utf8_chunk` helper that maintains a leftover-bytes buffer across reads, splits the combined buffer at the last valid UTF-8 boundary, and defers any incomplete trailing sequence to the next chunk.

### 4. `storage/settings.rs` non-atomic write
`fs::write` directly on `~/.opencovibe/settings.json` — power loss / kill -9 / disk-full could truncate the file holding API keys and auth tokens. Mirrors `runs::save_meta` now: tmp + rename, with 0600 perms set on the tmp file **before** rename (no transient world-readable window).

### 5. Symlinked command files dropped from the slash menu
`storage/plugins.rs:257` regression from #124: `entry.file_type()` reports the symlink itself, so `is_dir()`/`is_file()` both returned false for any symlinked `.md` file or subdir under `.claude/commands/`. Switched to `std::fs::metadata(&path)`, which follows the link. Cycle protection retained via `MAX_COMMAND_DEPTH`.

### 6. Timeline progressive-load permanent latch
`routes/chat/+page.svelte` `loadMoreEarlier` cleared `loadMoreArmed` and relied on `handleChatScroll` to re-arm. If anchor compensation produced ~zero delta (collapsed / unmeasured prepended items), the same-value `scrollTop` write dispatched no scroll event → re-arm path never ran → `IntersectionObserver` already reported "still intersecting" so no new firing → timeline stuck mid-load.

Fix: re-observe the sentinel at the end of `loadMoreEarlier`. `IntersectionObserver.observe()` redelivers the current intersection state. If sentinel exited the viewport (normal case), the callback returns early. If still intersecting (zero-delta), it kicks off the next batch — naturally terminating when sentinel exits or `renderLimit >= filteredTimeline.length`.

## Test plan

- [x] `cargo test --lib` — 437 passed (+12 new across fs.rs / stream.rs / settings.rs / plugins.rs)
- [x] `cargo clippy --lib` — 0 warnings
- [x] `cargo fmt` — clean
- [x] `npm test` — 1256 passed
- [x] `npm run check` (svelte-check) — 0 errors
- [x] `npm run format:check` — clean
- [ ] Manual: drop a file from outside project cwd → should appear as path-ref (degraded gracefully)
- [ ] Manual: trigger `error_max_turns` in a chat → chat stays interactive (no "session ended")
- [ ] Manual: claude `--print` with long CJK response → no U+FFFD glyphs in output
- [ ] Manual: open run with 1000+ entries, scroll to top → progressive load continues without manual wiggle
- [ ] Manual: symlink a .md from dotfiles into `~/.claude/commands/` → appears in slash menu