### PR TITLE
fix(session): surface clear error when SessionActor session is dead

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -1879,7 +1879,9 @@ export class SessionStore {
           this._startResponseTimeout(run.id);
         }
       } else {
-        // Codex pipe mode
+        // PipeExec path (Codex): useStreamSession is false iff the freshly
+        // created run has execution_path=pipe_exec, so sendChatMessage is the
+        // correct IPC. SessionActor runs always go through the branch above.
         this._setPhase("running");
         await api.sendChatMessage(run.id, prompt, attachments.length > 0 ? attachments : undefined);
       }
@@ -1900,7 +1902,15 @@ export class SessionStore {
     snapshotCache.deleteSnapshot(this.run.id).catch(() => {});
 
     try {
-      if (this.useStreamSession && this.sessionAlive) {
+      if (this.useStreamSession) {
+        // SessionActor (Claude stream-json): requires a live CLI process.
+        // Why-not fallback: sendChatMessage targets pipe_exec runs only; the
+        // backend rejects it for session_actor runs (commands/chat.rs). When
+        // the process has died, surface a clear error instead of routing to
+        // an IPC that is guaranteed to fail.
+        if (!this.sessionAlive) {
+          throw new Error("Session ended — start a new session to continue.");
+        }
         // Optimistic user message — matches the pattern in startSession().
         // Content-based dedup in _reduce(user_message) prevents double display
         // when the backend's UserMessage bus event arrives.
@@ -1912,6 +1922,7 @@ export class SessionStore {
           this._startResponseTimeout(this.run.id);
         }
       } else {
+        // PipeExec (Codex): one-shot process per message, no liveness concept.
         this._setPhase("running");
         await api.sendChatMessage(
           this.run.id,

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -591,6 +591,42 @@ describe("SessionStore reducer", () => {
     });
   });
 
+  // ── sendMessage dispatch by execution_path ──
+
+  describe("sendMessage dispatch", () => {
+    beforeEach(() => {
+      vi.mocked(api.sendSessionMessage).mockClear();
+      vi.mocked(api.sendChatMessage).mockClear();
+    });
+
+    it("SessionActor + alive routes to sendSessionMessage", async () => {
+      store.run = makeRun("run-sa-alive", { execution_path: "session_actor" });
+      store.phase = "idle";
+      vi.mocked(api.sendSessionMessage).mockResolvedValueOnce(undefined);
+      await store.sendMessage("hello", []);
+      expect(api.sendSessionMessage).toHaveBeenCalledWith("run-sa-alive", "hello", undefined);
+      expect(api.sendChatMessage).not.toHaveBeenCalled();
+    });
+
+    it("SessionActor + dead throws a clear error (no IPC call)", async () => {
+      store.run = makeRun("run-sa-dead", { execution_path: "session_actor" });
+      store.phase = "completed";
+      await expect(store.sendMessage("hello", [])).rejects.toThrow(/Session ended/);
+      expect(api.sendChatMessage).not.toHaveBeenCalled();
+      expect(api.sendSessionMessage).not.toHaveBeenCalled();
+      expect(store.error).toMatch(/Session ended/);
+    });
+
+    it("PipeExec routes to sendChatMessage regardless of phase", async () => {
+      store.run = makeRun("run-pe", { execution_path: "pipe_exec", agent: "codex" });
+      store.phase = "idle";
+      vi.mocked(api.sendChatMessage).mockResolvedValueOnce(undefined);
+      await store.sendMessage("hello", []);
+      expect(api.sendChatMessage).toHaveBeenCalledWith("run-pe", "hello", undefined);
+      expect(api.sendSessionMessage).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Terminal run ask_pending resolution ──
 
   describe("terminal run ask_pending cleanup", () => {


### PR DESCRIPTION
## Summary

- `sendMessage` previously routed any non-alive session to `send_chat_message`. For a SessionActor (Claude stream-json) run, that backend IPC is rejected with `send_chat_message requires execution_path=pipe_exec, got SessionActor` (commands/chat.rs:80), so when the Claude CLI process died, the user saw a cryptic internal error instead of a clear "session ended" message.
- Split the dispatch by `execution_path` instead of collapsing it under `useStreamSession && sessionAlive`:
  - **SessionActor + alive** → `sendSessionMessage` (unchanged)
  - **SessionActor + dead** → throw `"Session ended — start a new session to continue."` (no IPC call)
  - **PipeExec (Codex)** → `sendChatMessage` (unchanged)
- Added a clarifying comment to the `startSession` else-branch to make explicit that it is only reached for fresh `pipe_exec` runs.
- Added 3 tests under `describe("sendMessage dispatch")` covering each branch.

Refs #131. The underlying upstream issue (why the Claude CLI v2.1.150 process appears to die for some users) still needs runtime debug logs to confirm — but this fix removes the structurally-doomed fallback so users get an actionable error instead of a confusing one regardless of what the CLI does.

## Test plan

- [x] `npm test` — all 1270 tests pass (3 new tests in `sendMessage dispatch`)
- [x] `npm run lint:fix` — 0 errors
- [x] `npm run format:check` — clean
- [x] `npm run check` — 0 errors (73 pre-existing a11y warnings unchanged)
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)