### PR TITLE
fix: reduce first-token streaming latency via idle-aware flush

### DIFF
--- a/src/lib/stores/event-middleware.test.ts
+++ b/src/lib/stores/event-middleware.test.ts
@@ -600,4 +600,56 @@ describe("EventMiddleware", () => {
       expect(mockTransport.unsubscribeRun).toHaveBeenCalledWith("run-1");
     });
   });
+
+  // ── Idle-aware flush ──
+  //
+  // Under fake timers: performance.now() starts at 0 and advances with
+  // advanceTimersByTime; requestAnimationFrame is undefined, so the
+  // non-idle branch falls through to setTimeout(_BATCH_INTERVAL).
+  describe("idle-aware flush", () => {
+    it("flushes the first token after an idle gap via microtask (no timer wait)", async () => {
+      await mw.start();
+      const store = mockStore();
+      mw.subscribeCurrent("run-1", store as any);
+
+      // Prime: flush an initial event so _lastFlushTime is recorded.
+      fireBusEvent(makeBusEvent("run-1", "message_complete", { message_id: "m0", text: "a" }));
+      vi.advanceTimersByTime(16);
+      expect(store.applyEvent).toHaveBeenCalledTimes(1);
+
+      // Idle for >_IDLE_GAP_MS, then a new burst arrives.
+      vi.advanceTimersByTime(150);
+      fireBusEvent(makeBusEvent("run-1", "message_complete", { message_id: "m1", text: "b" }));
+
+      // Microtask path: resolves without advancing timers (no rAF/setTimeout wait).
+      await Promise.resolve();
+      expect(store.applyEvent).toHaveBeenCalledTimes(2);
+    });
+
+    it("batches consecutive tokens within the idle gap (timer path, not microtask)", async () => {
+      await mw.start();
+      const store = mockStore();
+      mw.subscribeCurrent("run-1", store as any);
+
+      // Prime a flush to set _lastFlushTime.
+      fireBusEvent(makeBusEvent("run-1", "message_complete", { message_id: "m0", text: "a" }));
+      vi.advanceTimersByTime(16);
+      store.applyEvent.mockClear();
+      store.applyEventBatch.mockClear();
+
+      // Two tokens arrive <_IDLE_GAP_MS after the last flush → non-idle branch.
+      vi.advanceTimersByTime(10);
+      fireBusEvent(makeBusEvent("run-1", "message_complete", { message_id: "m1", text: "b" }));
+      fireBusEvent(makeBusEvent("run-1", "message_complete", { message_id: "m2", text: "c" }));
+
+      // Microtask alone must NOT flush (proves it took the timer path).
+      await Promise.resolve();
+      expect(store.applyEvent).not.toHaveBeenCalled();
+      expect(store.applyEventBatch).not.toHaveBeenCalled();
+
+      // Timer fires → batched flush.
+      vi.advanceTimersByTime(16);
+      expect(store.applyEventBatch).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/lib/stores/event-middleware.ts
+++ b/src/lib/stores/event-middleware.ts
@@ -41,6 +41,7 @@ export class EventMiddleware {
   private _BATCH_INTERVAL = 16; // ~1 frame
   private _MAX_BUFFER_SIZE = 500; // per-run overflow threshold
   private _lastFlushTime = 0; // track last flush for idle detection
+  private _IDLE_GAP_MS = 100; // gap above which the next token starts a fresh burst
 
   // Idempotent start guard
   private _started = false;
@@ -311,9 +312,9 @@ export class EventMiddleware {
     const now = performance.now();
     const idleGap = now - this._lastFlushTime;
 
-    // If idle for >100ms, this is the first token of a new burst — flush
+    // If idle for >_IDLE_GAP_MS, this is the first token of a new burst — flush
     // immediately via microtask so the user sees output without a ~16ms gap.
-    if (idleGap > 100) {
+    if (idleGap > this._IDLE_GAP_MS) {
       queueMicrotask(() => this._flush());
     } else if (typeof requestAnimationFrame !== "undefined") {
       requestAnimationFrame(() => this._flush());

--- a/src/lib/stores/event-middleware.ts
+++ b/src/lib/stores/event-middleware.ts
@@ -40,6 +40,7 @@ export class EventMiddleware {
   private _flushScheduled = false;
   private _BATCH_INTERVAL = 16; // ~1 frame
   private _MAX_BUFFER_SIZE = 500; // per-run overflow threshold
+  private _lastFlushTime = 0; // track last flush for idle detection
 
   // Idempotent start guard
   private _started = false;
@@ -306,7 +307,15 @@ export class EventMiddleware {
   private _scheduleFlush(): void {
     if (this._flushScheduled) return;
     this._flushScheduled = true;
-    if (typeof requestAnimationFrame !== "undefined") {
+
+    const now = performance.now();
+    const idleGap = now - this._lastFlushTime;
+
+    // If idle for >100ms, this is the first token of a new burst — flush
+    // immediately via microtask so the user sees output without a ~16ms gap.
+    if (idleGap > 100) {
+      queueMicrotask(() => this._flush());
+    } else if (typeof requestAnimationFrame !== "undefined") {
       requestAnimationFrame(() => this._flush());
     } else {
       setTimeout(() => this._flush(), this._BATCH_INTERVAL);
@@ -315,6 +324,7 @@ export class EventMiddleware {
 
   private _flush(): void {
     this._flushScheduled = false;
+    this._lastFlushTime = performance.now();
     for (const [runId, events] of this._batchBuffer) {
       const store = this._subscriptions.get(runId);
       if (!store) continue;


### PR DESCRIPTION
## Summary
- When idle for >100ms (start of a new output burst), flush immediately via `queueMicrotask` instead of waiting for `requestAnimationFrame` (~16ms)
- Preserves rAF batching for subsequent high-frequency tokens to avoid excessive rendering

## Problem
The first line of streaming output visibly lags because `_scheduleFlush()` always waits for the next animation frame (~16ms). During this wait, subsequent tokens accumulate in the buffer and appear as a burst when the frame fires.

## Fix
Track `_lastFlushTime` and detect idle gaps >100ms. On first token after idle, use `queueMicrotask()` for near-instant flush. Continuous streaming tokens still use `requestAnimationFrame` for efficient batching.

## Test plan
- [x] `svelte-check` passes with 0 errors
- [x] Prettier + ESLint pass
- [x] Windows x64 build succeeds via CI
- [ ] Manual test: observe streaming output for reduced first-token delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)