### PR TITLE
feat: sync CLI 2.1.152–2.1.154 slash commands + MessageDisplay hook

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1157,7 +1157,8 @@ export type HookEventType =
   | "TaskCreated"
   | "CwdChanged"
   | "FileChanged"
-  | "PermissionDenied";
+  | "PermissionDenied"
+  | "MessageDisplay";
 
 export interface HookHandler {
   type: "command" | "prompt" | "http" | "mcp_tool";

--- a/src/lib/utils/__tests__/hook-helpers.test.ts
+++ b/src/lib/utils/__tests__/hook-helpers.test.ts
@@ -15,6 +15,9 @@ describe("HOOK_EVENT_TYPES", () => {
     expect(HOOK_EVENT_TYPES).toContain("Notification");
     expect(HOOK_EVENT_TYPES).toContain("Stop");
   });
+  it("contains MessageDisplay (CLI 2.1.152)", () => {
+    expect(HOOK_EVENT_TYPES).toContain("MessageDisplay");
+  });
 });
 
 describe("ensureHooksObject", () => {

--- a/src/lib/utils/__tests__/slash-commands.test.ts
+++ b/src/lib/utils/__tests__/slash-commands.test.ts
@@ -301,6 +301,18 @@ describe("mergeWithVirtual", () => {
     expect(merged[0].description).toBe("Custom desc");
   });
 
+  it("fills description for /simplify (CLI 2.1.154 re-add)", () => {
+    const cli: CliCommand[] = [{ name: "simplify", description: "", aliases: [] }];
+    const merged = mergeWithVirtual(cli);
+    expect(merged.find((c) => c.name === "simplify")?.description).toBeTruthy();
+  });
+
+  it("fills description for /reload-skills (CLI 2.1.152)", () => {
+    const cli: CliCommand[] = [{ name: "reload-skills", description: "", aliases: [] }];
+    const merged = mergeWithVirtual(cli);
+    expect(merged.find((c) => c.name === "reload-skills")?.description).toBeTruthy();
+  });
+
   it("leaves unknown commands without description unchanged", () => {
     const cli: CliCommand[] = [{ name: "my-custom-skill", description: "", aliases: [] }];
     const merged = mergeWithVirtual(cli);
@@ -458,12 +470,14 @@ describe("getCommandCategory", () => {
     expect(getCommandCategory("model")).toBe("coding");
     expect(getCommandCategory("review")).toBe("coding");
     expect(getCommandCategory("plan")).toBe("coding");
+    expect(getCommandCategory("simplify")).toBe("coding"); // CLI 2.1.154 re-add
   });
 
   it('returns "config" for known config commands', () => {
     expect(getCommandCategory("config")).toBe("config");
     expect(getCommandCategory("mcp")).toBe("config");
     expect(getCommandCategory("vim")).toBe("config");
+    expect(getCommandCategory("reload-skills")).toBe("config"); // CLI 2.1.152
   });
 
   it('returns "help" for known help commands', () => {

--- a/src/lib/utils/hook-helpers.ts
+++ b/src/lib/utils/hook-helpers.ts
@@ -36,6 +36,7 @@ export const HOOK_EVENT_TYPES: readonly HookEventType[] = [
   "CwdChanged",
   "FileChanged",
   "PermissionDenied",
+  "MessageDisplay",
 ] satisfies readonly HookEventType[];
 
 export type { HookEventType };

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -35,10 +35,12 @@ const KNOWN_COMMAND_DESCRIPTIONS: Record<string, string> = {
   plan: "Enable plan mode or view the current session plan",
   "pr-comments": "View pull request comments",
   "release-notes": "View release notes",
+  "reload-skills": "Re-scan skill directories without restarting the session",
   rename: "Rename the current conversation",
   resume: "Resume a previous conversation",
   review: "Review a pull request",
   "security-review": "Review code for security issues",
+  simplify: "Review code for cleanup (reuse, simplification, efficiency) and apply fixes",
   skills: "List available skills",
   status: "Show Claude Code status and version info",
   theme: "Change the theme",
@@ -492,6 +494,7 @@ const COMMAND_CATEGORY_MAP: Record<string, SlashCategory> = {
   review: "coding",
   "security-review": "coding",
   "code-review": "coding",
+  simplify: "coding",
   plan: "coding",
   init: "coding",
   "pr-comments": "coding",
@@ -516,6 +519,7 @@ const COMMAND_CATEGORY_MAP: Record<string, SlashCategory> = {
   plugin: "config",
   ide: "config",
   "add-dir": "config",
+  "reload-skills": "config",
   // Coding (continued)
   "team-onboarding": "coding",
   // Help


### PR DESCRIPTION
## What

Syncs OpenCovibe's local command/hook catalog with Claude CLI 2.1.152–2.1.154.

The CLI sends only command **names** via `system/init.slash_commands[]`; the app fills
descriptions/categories and the hook-event list locally. These drifted in 2.1.152–154.

## Changes

- **`MessageDisplay` hook event** (CLI 2.1.152) — added to `HookEventType` union
  (`types.ts`) and `HOOK_EVENT_TYPES` (`hook-helpers.ts`). HookManager renders the list
  directly, so the editor dropdown picks it up automatically (no UI/i18n change).
- **`/simplify`** (CLI 2.1.154, repurposed as cleanup-only review) — re-added to
  `KNOWN_COMMAND_DESCRIPTIONS` + `COMMAND_CATEGORY_MAP` (coding). It had been removed at
  2.1.147 when renamed → `/code-review`, but 2.1.154 brings the name back.
- **`/reload-skills`** (CLI 2.1.152) — added to both slash tables (config).
- **Regression tests** for all three.

## Verification

- Verified against a live `system/init.slash_commands` capture (local CLI **2.1.156**):
  `simplify`, `reload-skills`, `code-review` all present; **`workflows` absent** → it's
  TUI-only (background runs viewer), so it is **not** added.
- `npm run lint:fix && npm run format:check && npm run check && npm test && npm run build` — all pass (1270 tests).
- No `models.rs` change → serde-sync not required; `HookEventType` is not a serde-renamed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)