### PR TITLE
chore: update fallback Opus model description to 4.8 (CLI 2.1.154)

### DIFF
--- a/src-tauri/src/agent/control.rs
+++ b/src-tauri/src/agent/control.rs
@@ -297,7 +297,7 @@ pub fn fallback_cli_info() -> CliInfo {
             CliModelInfo {
                 value: "opus".to_string(),
                 display_name: "Opus".to_string(),
-                description: "Opus 4.7".to_string(),
+                description: "Opus 4.8".to_string(),
                 supports_effort: Some(true),
                 supported_effort_levels: Some(vec![
                     "low".into(),


### PR DESCRIPTION
## What

Updates the hardcoded fallback Claude model description in
`src-tauri/src/agent/control.rs` from "Opus 4.7" → "Opus 4.8" (CLI 2.1.154 default model).

## Why

The live `/model` list is fetched from the CLI control protocol (`get models`), so the new
model already surfaces correctly. Only the **offline fallback** (`fallback_cli_info()`, used
when the CLI is unreachable) was stale. `xhigh` effort is already present in the fallback.

Cosmetic; visible only when the CLI cannot be reached.

## Verification

- `cargo fmt` + `cargo clippy` — clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)