### PR TITLE
fix(statusbar): stabilize top-bar context %, turn count and token figure (#135)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -321,6 +321,7 @@
   "statusbar_toggleSidebar": "Toggle sidebar (Ctrl+B)",
   "statusbar_contextTitle": "Context usage for the latest turn ({pct}% of {tokens} tokens). The CLI automatically compacts context when approaching the limit.",
   "statusbar_ctx": "ctx {pct}%",
+  "statusbar_ctxLabel": "Context",
   "statusbar_compacted": "compacted",
   "statusbar_rewindTitle": "Rewind: undo file changes from this session",
   "statusbar_rewind": "Rewind",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -321,6 +321,7 @@
   "statusbar_toggleSidebar": "切换侧边栏 (Ctrl+B)",
   "statusbar_contextTitle": "最新轮次的上下文使用量（{pct}%，共 {tokens} 个 token）。接近限制时 CLI 会自动压缩上下文。",
   "statusbar_ctx": "上下文 {pct}%",
+  "statusbar_ctxLabel": "上下文",
   "statusbar_compacted": "已压缩",
   "statusbar_rewindTitle": "回退：撤销本会话中的文件更改",
   "statusbar_rewind": "回退",

--- a/src/lib/components/SessionStatusBar.svelte
+++ b/src/lib/components/SessionStatusBar.svelte
@@ -31,6 +31,7 @@
     permissionMode,
     fastModeState,
     numTurns,
+    contextTokens = 0,
     durationMs,
     persistedFiles,
     onRewind,
@@ -81,6 +82,7 @@
     permissionMode?: string;
     fastModeState?: string;
     numTurns?: number;
+    contextTokens?: number;
     durationMs?: number;
     persistedFiles?: unknown[];
     onRewind?: () => void;
@@ -742,12 +744,12 @@
           <span class="shrink-0">{formatCost(cost)}</span>
         {/if}
 
-        {#if inputTokens > 0 || outputTokens > 0}
+        {#if contextTokens > 0}
           <span class="text-foreground/30 shrink-0">&middot;</span>
           <span
             class="shrink-0"
-            title={`${t("statusbar_inputLabel")}: ${fmtNumber(inputTokens)} / ${t("statusbar_outputLabel")}: ${fmtNumber(outputTokens)}${cacheReadTokens ? `\n${t("statusbar_cacheReadLabel")}: ${fmtNumber(cacheReadTokens)}` : ""}${cacheWriteTokens ? `\n${t("statusbar_cacheWriteLabel")}: ${fmtNumber(cacheWriteTokens)}` : ""}`}
-            >{formatTokenCount(inputTokens)} / {formatTokenCount(outputTokens)}
+            title={`${t("statusbar_ctxLabel")}: ${fmtNumber(contextTokens)}\n${t("statusbar_inputLabel")}: ${fmtNumber(inputTokens)} / ${t("statusbar_outputLabel")}: ${fmtNumber(outputTokens)}${cacheReadTokens ? `\n${t("statusbar_cacheReadLabel")}: ${fmtNumber(cacheReadTokens)}` : ""}${cacheWriteTokens ? `\n${t("statusbar_cacheWriteLabel")}: ${fmtNumber(cacheWriteTokens)}` : ""}`}
+            >{formatTokenCount(contextTokens)}
             {t("statusbar_tok")}</span
           >
           {#if cacheReadTokens > 0 || cacheWriteTokens > 0}

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -123,6 +123,9 @@ interface ReduceCtx {
   isStream: boolean;
   /** Per-turn usage snapshots. */
   turnUsages: TurnUsage[];
+  /** High-water context tokens / window since last compaction (drives contextUtilization). */
+  contextHwTokens: number;
+  contextHwWindow: number;
   /** tool_use_id → tl[] index (only tool entries, first-match semantics). */
   toolTlIndex: Map<string, number>;
   /** tool_use_id → he[] index (only HookEvent entries with tool_use_id). */
@@ -312,6 +315,13 @@ export class SessionStore {
   strictMode = false;
   /** Per-turn usage snapshots (append-only, one per usage_update event). */
   turnUsages: TurnUsage[] = $state([]);
+  /** High-water mark of current-context tokens (input+cacheRead+cacheWrite) since the last
+   *  compaction. contextUtilization reads this instead of the latest raw usage so that a
+   *  resumed / partial / cross-process usage_update reporting a smaller snapshot can't crater
+   *  the gauge (Issue #135). Reset on compact_boundary. contextHwWindow remembers the matching
+   *  window so a dip event without modelUsage doesn't zero the denominator. */
+  contextHwTokens: number = $state(0);
+  contextHwWindow: number = $state(0);
   /** Timestamp of the most recent compact_boundary event (0 = never). */
   lastCompactedAt: number = $state(0);
   /** Number of full compaction events in this session. */
@@ -587,25 +597,38 @@ export class SessionStore {
   }
 
   get contextWindow(): number {
-    if (!this.usage.modelUsage) return 0;
-    const entries = Object.values(this.usage.modelUsage);
-    let max = 0;
-    for (const e of entries) {
-      if (e.context_window && e.context_window > max) max = e.context_window;
+    // Prefer the latest event's window; fall back to the high-water window so a dip
+    // event without modelUsage (resume/synth) doesn't zero the denominator. #135
+    if (this.usage.modelUsage) {
+      let max = 0;
+      for (const e of Object.values(this.usage.modelUsage)) {
+        if (e.context_window && e.context_window > max) max = e.context_window;
+      }
+      if (max > 0) return max;
     }
-    return max;
+    return this.contextHwWindow;
   }
 
   get contextUtilization(): number {
-    // Total tokens sent to the model in the latest API call:
-    //   input_tokens (new non-cached) + cache_read (from cache) + cache_write (first-time cached)
-    // All three are part of the context window. Divide by contextWindow for fill %.
-    // These are per-turn values (usage_update replaces, not accumulates).
+    // Fill % = current-context tokens (input + cache_read + cache_write of the latest main
+    // turn) / context window. We read the high-water mark since last compaction, NOT the
+    // latest raw usage: a resumed/partial/cross-process usage_update can report a much smaller
+    // snapshot (different process, cold cache, error result) that must not crater the gauge. #135
     const cw = this.contextWindow;
-    if (cw <= 0) return 0;
-    const used = this.usage.inputTokens + this.usage.cacheReadTokens + this.usage.cacheWriteTokens;
-    if (used <= 0) return 0;
-    return Math.min(used / cw, 1);
+    if (cw <= 0 || this.contextHwTokens <= 0) return 0;
+    return Math.min(this.contextHwTokens / cw, 1);
+  }
+
+  /** Conversation turn count = user messages in the timeline. This is the user-facing turn
+   *  number; it matches the conversation list. Distinct from CLI `num_turns`, which counts
+   *  per-prompt internal API steps and resets across process re-invocations (Issue #135). */
+  get userTurnCount(): number {
+    return this.timeline.filter((e) => e.kind === "user").length;
+  }
+
+  /** Current context size in tokens (high-water since last compaction). */
+  get contextTokens(): number {
+    return this.contextHwTokens;
   }
 
   get contextWarningLevel(): "none" | "moderate" | "high" | "critical" {
@@ -1082,6 +1105,8 @@ export class SessionStore {
       sessionId: null,
       isStream: this.useStreamSession,
       turnUsages: [...this.turnUsages],
+      contextHwTokens: this.contextHwTokens,
+      contextHwWindow: this.contextHwWindow,
       toolTlIndex: batchTlIndex,
       toolHeIndex: batchHeIndex,
       toolInputByUseId: new Map<string, Record<string, unknown>>(),
@@ -1127,6 +1152,8 @@ export class SessionStore {
     this.model = ctx.model;
     this.usage = ctx.usage;
     this.turnUsages = ctx.turnUsages;
+    this.contextHwTokens = ctx.contextHwTokens;
+    this.contextHwWindow = ctx.contextHwWindow;
     this._seenMessageIds = ctx.seenMessageIds;
     this._seenToolIds = ctx.seenToolIds;
     this._toolTlIndex = ctx.toolTlIndex;
@@ -1332,6 +1359,8 @@ export class SessionStore {
     this.numTurns = 0;
     this.durationMs = 0;
     this.turnUsages = [];
+    this.contextHwTokens = 0;
+    this.contextHwWindow = 0;
     this.lastCompactedAt = 0;
     this.compactCount = 0;
     this.microcompactCount = 0;
@@ -1393,6 +1422,8 @@ export class SessionStore {
       model: this.model,
       usage: this.usage,
       turnUsages: this.turnUsages,
+      contextHwTokens: this.contextHwTokens,
+      contextHwWindow: this.contextHwWindow,
       _seenMessageIds: [...this._seenMessageIds],
       _seenToolIds: [...this._seenToolIds],
       // B group (direct fields)
@@ -1461,6 +1492,8 @@ export class SessionStore {
       this.model = (obj.model as string) ?? "";
       this.usage = obj.usage as UsageState;
       this.turnUsages = (obj.turnUsages ?? []) as TurnUsage[];
+      this.contextHwTokens = (obj.contextHwTokens as number) ?? 0;
+      this.contextHwWindow = (obj.contextHwWindow as number) ?? 0;
       this._seenMessageIds = new Set((obj._seenMessageIds ?? []) as string[]);
       this._seenToolIds = new Set((obj._seenToolIds ?? []) as string[]);
 
@@ -3225,6 +3258,25 @@ export class SessionStore {
         } else {
           this.turnUsages = [...this.turnUsages, turnSnap];
         }
+
+        // Update context high-water (drives contextUtilization). Use this event's own
+        // window; clamp tokens to it so an over-counted snapshot can't exceed 100%. Only
+        // raise tokens, but always adopt the latest non-zero window (200k↔1m can switch). #135
+        if (hasTokens) {
+          const evUsed = u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens;
+          let evWin = 0;
+          if (u.modelUsage) {
+            for (const e of Object.values(u.modelUsage)) {
+              if (e.context_window && e.context_window > evWin) evWin = e.context_window;
+            }
+          }
+          if (evWin > 0) {
+            const hwTgt = ctx ?? this;
+            const clamped = Math.min(evUsed, evWin);
+            hwTgt.contextHwWindow = evWin;
+            if (clamped > hwTgt.contextHwTokens) hwTgt.contextHwTokens = clamped;
+          }
+        }
         break;
       }
 
@@ -3395,6 +3447,10 @@ export class SessionStore {
           const reset = { ...prev, inputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
           if (ctx) ctx.usage = reset;
           else this.usage = reset;
+          // Reset the context high-water too — the next usage_update re-establishes the
+          // post-compaction peak. Keep the window (denominator unchanged by compaction). #135
+          const hwTgt = ctx ?? this;
+          hwTgt.contextHwTokens = 0;
         }
         // Only set lastCompactedAt during live mode — during replay
         // the timestamp would be meaningless (Date.now() ≠ original event time).

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -540,7 +540,7 @@
       runId: store.run.id,
       runName: store.run.name,
       cwd: store.sessionCwd || store.run.cwd,
-      numTurns: store.numTurns,
+      numTurns: store.userTurnCount,
       status: store.run.status ?? "pending",
       startedAt: store.run.started_at ?? null,
       endedAt: store.run.ended_at ?? null,
@@ -3864,7 +3864,8 @@
       {platformModels}
       fastModeState={store.fastModeState}
       verbose={verboseEnabled}
-      numTurns={store.numTurns}
+      numTurns={store.userTurnCount}
+      contextTokens={store.contextTokens}
       durationMs={store.durationMs}
       persistedFiles={store.persistedFiles}
       onRewind={store.sessionAlive && !store.isRunning ? handleRewind : undefined}


### PR DESCRIPTION
Fixes #135.

## Problem
The top bar derived its three numbers from three inconsistent, last-writer-wins sources, so they jumped and contradicted each other:
- **Turn count** 19 → 1 (right panel showed 4, top bar showed 1)
- **Context %** 77% → 7% with no compaction
- **`26 / 7.7k tok`** — meaning unclear, didn't match the 4-turn content size

## Root causes (confirmed by replaying captured `events.jsonl`)
- **Turn count** mirrored CLI `num_turns`, which is the *per-prompt internal API step count* (1–21 per turn, e.g. `[8,1,1,6,1,1,15,3,21]`) and resets across process re-invocations (resume/recovery) — not the conversation turn count.
- **`contextUtilization`** read the latest raw `usage`, overwritten by every `usage_update`. A resumed/partial/cross-process result with a smaller snapshot cratered the gauge. A clean single-process live session is stable (replay of run `ec3781bf`), proving the formula is correct and the instability comes from overwrite, not math.
- **Token headline** showed new-uncached input / output, hiding the real ~context-sized cache load.

A Phase-0 source check confirmed `result` events are always the main turn (the `UsageUpdate` carries no `parent_tool_use_id`) and subagents do not emit separate `usage_update`s — so a Rust-side "main-turn marker" would do nothing. The real trigger is cross-process resume/recovery, which a frontend high-water mark handles directly.

## Fix (frontend only — no Rust / serde changes)
- **Turn count** and InfoPanel now use a conversation-turn count (timeline user messages), matching the conversation list. `num_turns` is kept for run metadata (history/usage pages).
- **Context %**: added a context high-water mark (tokens + window) since last compaction, mirroring the existing `turnUsages` plumbing (ReduceCtx + state + commit + snapshot/restore + clear). `contextUtilization`/`contextWindow` read the high-water, so a smaller late snapshot can no longer drop the gauge; `compact_boundary` resets it.
- **Token headline** now shows total context tokens; input/output/cache moved to the tooltip. Adds `statusbar_ctxLabel` (en/zh-CN).

## Validation
`lint:fix` ✓ · `format:check` ✓ · `svelte-check` 0 errors · `test` 1267 passed (incl. i18n key parity) · `build` ✓