### PR TITLE
fix(session): prior error result no longer marks a later success run Failed

### DIFF
--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -2205,6 +2205,14 @@ impl SessionActor {
                         e
                     );
                 }
+                // Also reset the in-mem error tracking. The parser sets result_subtype
+                // only on error results and never clears it on success (see claude_protocol
+                // test "success doesn't set got_result_event"). Without this, a stale error
+                // subtype from an earlier turn survives into a later successful turn and
+                // gets re-persisted at that turn's idle (had_result_error), making
+                // finalize_meta on EOF wrongly mark a 0-exit run as Failed. Mirrors the
+                // meta clear above and the interrupt path's reset.
+                self.protocol.result_subtype = None;
             }
 
             // Persist result error details on failed


### PR DESCRIPTION
Found by the agent-teams backend audit (rust-protocol).

## Bug
In a multi-turn Claude session, once any turn ends with an **error result** (`error_max_turns`, `error_input_too_long`, etc. — common), every subsequent successful turn gets the run marked **Failed** on EOF, even with exit code 0. History list status is wrong.

## Root cause
- `claude_protocol` sets `result_subtype` only on error results and never clears it on success (intentional — locked by the "success doesn't set got_result_event" test).
- `session_actor::emit_state` cleared `meta.result_subtype` at turn start (`running`) but left the **in-memory** `self.protocol.result_subtype` stale.
- So at the next turn's idle, `had_result_error` read the stale in-mem subtype → re-persisted it to meta → `finalize_meta` on EOF marked the run Failed.

## Fix
Reset `self.protocol.result_subtype = None` alongside the existing meta clear in the `running` branch — symmetric with the meta clear and the interrupt path's reset. One-line, minimal.

## Test note
`emit_state` has storage side effects and the codebase has no `SessionActor` harness (the struct needs `Arc<BroadcastEmitter>`, session map, etc.), so a full actor unit test is disproportionate. The fix mirrors two existing precedents; the parser invariant is already covered by `claude_protocol` tests. Happy to add an integration harness if wanted.

## Validation
`cargo fmt` clean · `cargo clippy` 0 warnings.