### PR TITLE
fix(store): preserve ralph-loop / rate-limit / compaction / thinking state across idle-snapshot restore

### DIFF
--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -1446,11 +1446,21 @@ export class SessionStore {
       durationMs: this.durationMs,
       compactCount: this.compactCount,
       microcompactCount: this.microcompactCount,
+      lastCompactedAt: this.lastCompactedAt,
       persistedFiles: this.persistedFiles,
       unknownEventCount: this.unknownEventCount,
       rawFallbackCount: this.rawFallbackCount,
       taskNotifications: [...this.taskNotifications.entries()],
       scheduledTasks: this.scheduledTasks,
+      // Reducer-written run state that idle-snapshot restore must preserve (a snapshot-hit
+      // loadRun skips event replay, so anything not serialized here is lost on revisit). #135-class
+      ralphLoop: this.ralphLoop,
+      rateLimitStatus: this.rateLimitStatus,
+      rateLimitType: this.rateLimitType,
+      rateLimitUtilization: this.rateLimitUtilization,
+      rateLimitResetsAt: this.rateLimitResetsAt,
+      thinkingStartMs: this.thinkingStartMs,
+      thinkingEndMs: this.thinkingEndMs,
       _lastProcessedSeq: this._lastProcessedSeq,
     };
     return JSON.stringify(obj);
@@ -1517,9 +1527,18 @@ export class SessionStore {
       this.durationMs = (obj.durationMs as number) ?? 0;
       this.compactCount = (obj.compactCount as number) ?? 0;
       this.microcompactCount = (obj.microcompactCount as number) ?? 0;
+      this.lastCompactedAt = (obj.lastCompactedAt as number) ?? 0;
       this.persistedFiles = (obj.persistedFiles ?? []) as unknown[];
       this.unknownEventCount = (obj.unknownEventCount as number) ?? 0;
       this.rawFallbackCount = (obj.rawFallbackCount as number) ?? 0;
+      // Reducer-written run state (see _buildSnapshot). ?? keeps old snapshots valid.
+      this.ralphLoop = (obj.ralphLoop as typeof this.ralphLoop) ?? null;
+      this.rateLimitStatus = (obj.rateLimitStatus as string) ?? "";
+      this.rateLimitType = (obj.rateLimitType as string) ?? "";
+      this.rateLimitUtilization = (obj.rateLimitUtilization as number | null) ?? null;
+      this.rateLimitResetsAt = (obj.rateLimitResetsAt as number | null) ?? null;
+      this.thinkingStartMs = (obj.thinkingStartMs as number) ?? 0;
+      this.thinkingEndMs = (obj.thinkingEndMs as number) ?? 0;
       this.taskNotifications = new Map(
         (obj.taskNotifications ?? []) as Array<[string, TaskNotificationItem]>,
       );

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -2064,6 +2064,46 @@ describe("SessionStore reducer", () => {
     });
   });
 
+  describe("snapshot round-trip (reducer-written run state)", () => {
+    // Regression for the #135-class snapshot-omission bug: an idle-snapshot loadRun
+    // skips event replay, so any reducer-written field not serialized is lost on revisit.
+    it("preserves ralphLoop / rate-limit / lastCompactedAt / thinking timers across build→restore", () => {
+      store.run = makeRun("run-snap");
+      store.ralphLoop = {
+        active: true,
+        prompt: "Build an API",
+        iteration: 3,
+        maxIterations: 10,
+        completionPromise: "DONE",
+        startedAt: "2026-06-01T00:00:00Z",
+        reason: null,
+      };
+      store.rateLimitStatus = "allowed_warning";
+      store.rateLimitType = "five_hour";
+      store.rateLimitUtilization = 0.82;
+      store.rateLimitResetsAt = 1780000000000;
+      store.lastCompactedAt = 1779999999999;
+      store.thinkingStartMs = 111;
+      store.thinkingEndMs = 222;
+
+      const snap = (store as unknown as { _buildSnapshot(): string })._buildSnapshot();
+      const restored = new SessionStore();
+      const ok = (
+        restored as unknown as { _tryApplySnapshot(b: string): boolean }
+      )._tryApplySnapshot(snap);
+
+      expect(ok).toBe(true);
+      expect(restored.ralphLoop).toEqual(store.ralphLoop);
+      expect(restored.rateLimitStatus).toBe("allowed_warning");
+      expect(restored.rateLimitType).toBe("five_hour");
+      expect(restored.rateLimitUtilization).toBe(0.82);
+      expect(restored.rateLimitResetsAt).toBe(1780000000000);
+      expect(restored.lastCompactedAt).toBe(1779999999999);
+      expect(restored.thinkingStartMs).toBe(111);
+      expect(restored.thinkingEndMs).toBe(222);
+    });
+  });
+
   describe("ralph_loop events", () => {
     it("ralph_started initializes ralphLoop state", () => {
       store.run = makeRun("run-1");


### PR DESCRIPTION
Found by the agent-teams frontend audit (fe-store). Same class as #135.

## Bug
`_buildSnapshot` omitted several reducer-written run fields. A snapshot-hit `loadRun` (idle/terminal runs) skips event replay, so on navigate-away-and-back these silently reset:
- active/recent **Ralph loop** → restored as `null`
- **rate-limit banner** → disappears
- **compaction recency** (`lastCompactedAt`) and **thinking duration** → lost

## Fix
Serialize + restore in `_buildSnapshot` / `_tryApplySnapshot`:
`ralphLoop`, `rateLimitStatus`, `rateLimitType`, `rateLimitUtilization`, `rateLimitResetsAt`, `lastCompactedAt`, `thinkingStartMs`, `thinkingEndMs`. `?? default` on restore keeps old snapshots valid.

Adds a snapshot round-trip regression test locking these 8 fields.

## Validation
lint · format · svelte-check 0 errors · test 1276 passed (incl. new test) · build.