### PR TITLE
fix(codex): filter out Claude model names before passing --model to Codex CLI

### DIFF
--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -1,5 +1,13 @@
 use crate::agent::adapter::{self, AdapterSettings};
 
+/// True if `model` looks like a Claude model name (opus/sonnet/haiku/claude-*).
+/// Codex CLI rejects these; real Codex models (gpt-*, o3, …) never contain these
+/// substrings, so there are no false positives.
+fn is_claude_model_name(model: &str) -> bool {
+    let m = model.to_ascii_lowercase();
+    m.contains("claude") || m.contains("opus") || m.contains("sonnet") || m.contains("haiku")
+}
+
 /// Build the command + args for a given agent (pipe-exec mode, not stream session)
 pub fn build_agent_command(
     agent: &str,
@@ -33,10 +41,21 @@ pub fn build_agent_command(
                 "--json".to_string(),
                 "--skip-git-repo-check".to_string(),
             ];
+            // Codex CLI rejects Claude model names — they leak in when the user's
+            // default_model is a Claude model and they switch to Codex without picking a
+            // Codex model. Skip --model so Codex uses its own configured default instead of
+            // failing on spawn. (audit #13)
             if let Some(ref m) = settings.model {
                 if !m.is_empty() {
-                    args.push("--model".to_string());
-                    args.push(m.to_string());
+                    if is_claude_model_name(m) {
+                        log::debug!(
+                            "[spawn] codex: skipping Claude model name '{}' (Codex would reject it); using Codex default",
+                            m
+                        );
+                    } else {
+                        args.push("--model".to_string());
+                        args.push(m.to_string());
+                    }
                 }
             }
             if !prompt.is_empty() {
@@ -49,5 +68,31 @@ pub fn build_agent_command(
             "Unsupported agent: {}. Supported: claude, codex",
             agent
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_claude_model_name;
+
+    #[test]
+    fn flags_claude_model_names() {
+        for m in [
+            "opus",
+            "sonnet",
+            "haiku",
+            "claude-opus-4-8",
+            "Claude-Sonnet-4-6",
+            "OPUS",
+        ] {
+            assert!(is_claude_model_name(m), "{m} should be flagged");
+        }
+    }
+
+    #[test]
+    fn allows_codex_model_names() {
+        for m in ["gpt-5-codex", "o3", "gpt-4.1", "o4-mini", "openai"] {
+            assert!(!is_claude_model_name(m), "{m} should be allowed");
+        }
     }
 }


### PR DESCRIPTION
Found by the agent-teams backend audit. Documented in CLAUDE.md as a hard constraint.

## Bug (P2)
`build_agent_command` passed `settings.model` to `codex exec --model` verbatim. When `default_model` is a Claude model (opus/sonnet/haiku/claude-*) and the user switches to the Codex agent without picking a Codex model, Codex spawn fails with a model-rejection error.

## Fix
Add `is_claude_model_name()`: if the model string contains `claude`/`opus`/`sonnet`/`haiku` (case-insensitive) drop the `--model` flag and log a debug line — Codex then uses its own configured default. Real Codex model names (`gpt-*`, `o3`, `o4-mini`) never match these substrings.

## Validation
`cargo fmt` clean · `cargo clippy` 0 warnings · 2 new unit tests pass.