### PR TITLE
fix(config): move $messages alias to kit.alias, drop tsconfig paths

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,6 +6,10 @@ const config = {
     adapter: adapter({
       fallback: "index.html",
     }),
+    // $lib is built-in; $messages aliased here so the generated tsconfig + Vite both pick it up
+    alias: {
+      $messages: "messages",
+    },
     paths: {
       relative: false,
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,6 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "moduleResolution": "bundler",
-    "paths": {
-      "$lib": ["./src/lib"],
-      "$lib/*": ["./src/lib/*"],
-      "$messages/*": ["./messages/*"]
-    }
+    "moduleResolution": "bundler"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,10 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
-import path from "path";
 
 const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig({
   plugins: [sveltekit()],
-  resolve: {
-    alias: {
-      $messages: path.resolve("./messages"),
-    },
-  },
   build: {
     target: ["safari16", "chrome105", "edge105"],
   },


### PR DESCRIPTION
## Problem

On dev start SvelteKit warns:

> You have specified a baseUrl and/or paths in your tsconfig.json which interferes with SvelteKit's auto-generated tsconfig.json. Remove it to avoid problems with intellisense. For path aliases, use `kit.alias` instead.

`tsconfig.json` redefined `$lib`/`$messages` paths that SvelteKit already auto-generates in `.svelte-kit/tsconfig.json`.

## Fix

- **svelte.config.js** — declare the custom alias via `kit.alias: { $messages: "messages" }` (feeds both the generated tsconfig and Vite)
- **tsconfig.json** — remove the manual `paths` block (`$lib` is built-in; `$messages` now comes from kit.alias)
- **vite.config.ts** — drop the now-redundant `resolve.alias` + unused `import path`

## Verify

- `svelte-kit sync` — exits clean, warning gone
- generated `.svelte-kit/tsconfig.json` still maps `$messages` → `../messages` (intellisense preserved)
- `svelte-check` 0 errors, `npm run build` OK