### PR TITLE
fix: context-window over-count + Opus 4.8 mispricing (#149)

### DIFF
--- a/src-tauri/src/agent/claude_protocol.rs
+++ b/src-tauri/src/agent/claude_protocol.rs
@@ -1036,23 +1036,29 @@ impl ProtocolState {
                                     .collect::<HashMap<_, _>>()
                             });
 
-                    // Recalculate cost using our pricing table for accurate third-party model costs.
-                    // CLI uses its own (often Claude-based) pricing, which is wrong for providers
-                    // like DeepSeek, MiniMax, etc.
+                    // Cost source (#149): trust the CLI's reported cost for native Claude/OpenAI
+                    // — it knows its own pricing (incl. $0 for subscription/Max plans) and stays
+                    // correct across model releases without app updates. Only recalculate when a
+                    // third-party provider is present, since the CLI mis-prices those as Claude.
                     let (cost, model_usage) = if let Some(mut mu) = model_usage {
-                        let mut total = 0.0_f64;
-                        for (model_name, entry) in mu.iter_mut() {
-                            let recalculated = crate::pricing::estimate_cost(
-                                model_name,
-                                entry.input_tokens,
-                                entry.output_tokens,
-                                entry.cache_read_tokens,
-                                entry.cache_write_tokens,
-                            );
-                            entry.cost_usd = recalculated;
-                            total += recalculated;
+                        if mu.keys().any(|m| crate::pricing::is_third_party(m)) {
+                            let mut total = 0.0_f64;
+                            for (model_name, entry) in mu.iter_mut() {
+                                let recalculated = crate::pricing::estimate_cost(
+                                    model_name,
+                                    entry.input_tokens,
+                                    entry.output_tokens,
+                                    entry.cache_read_tokens,
+                                    entry.cache_write_tokens,
+                                );
+                                entry.cost_usd = recalculated;
+                                total += recalculated;
+                            }
+                            (total, Some(mu))
+                        } else {
+                            // Native only — keep the CLI's total_cost_usd and per-model costUSD.
+                            (cost, Some(mu))
                         }
-                        (total, Some(mu))
                     } else {
                         (cost, None)
                     };

--- a/src-tauri/src/pricing.rs
+++ b/src-tauri/src/pricing.rs
@@ -10,17 +10,19 @@ pub struct ModelPricing {
 /// and falls back to Sonnet pricing for unknown models.
 pub fn get_pricing(model: &str) -> ModelPricing {
     // ── Claude models ──
-    // Opus 4.5 / 4.6 → $5 / $25
-    if model.contains("opus-4-6")
-        || model.contains("opus-4-5")
-        || model.contains("opus-4.5")
-        || model.contains("opus-4.6")
+    // Legacy Opus 4.0 / 4.1 → $15 / $75. Match these explicitly so newer Opus
+    // (4.5, 4.6, 4.7, 4.8, and future releases) defaults to current $5/$25 pricing
+    // below — otherwise each new Opus version silently inherits legacy pricing (#149).
+    if model.contains("opus-4-0")
+        || model.contains("opus-4-1")
+        || model.contains("opus-4.0")
+        || model.contains("opus-4.1")
     {
-        return claude_pricing(5.0, 25.0);
-    }
-    // Opus 4.0 / 4.1 (legacy)
-    if model.contains("opus") {
         return claude_pricing(15.0, 75.0);
+    }
+    // Opus 4.5+ (current) → $5 / $25
+    if model.contains("opus") {
+        return claude_pricing(5.0, 25.0);
     }
     if model.contains("haiku") {
         return claude_pricing(0.80, 4.0);
@@ -164,6 +166,20 @@ pub fn get_pricing(model: &str) -> ModelPricing {
     claude_pricing(3.0, 15.0)
 }
 
+/// Whether `model` is a known third-party provider model (DeepSeek, Kimi, GLM, Qwen,
+/// DouBao, MiniMax, MiMo). The Claude CLI mis-prices these as Claude, so live cost must
+/// be recalculated from our table; native Claude/OpenAI costs are trusted from the CLI. #149
+pub fn is_third_party(model: &str) -> bool {
+    model.contains("deepseek")
+        || model.contains("kimi")
+        || model.contains("glm")
+        || model.contains("qwen")
+        || model.contains("doubao")
+        || model.contains("minimax")
+        || model.contains("MiniMax")
+        || model.contains("mimo")
+}
+
 /// Standard Claude pricing: cache_read = 10% of input, cache_write = 125% of input.
 fn claude_pricing(input: f64, output: f64) -> ModelPricing {
     ModelPricing {
@@ -188,4 +204,36 @@ pub fn estimate_cost(
         + cache_read_tokens as f64 * p.cache_read
         + cache_write_tokens as f64 * p.cache_write)
         / 1_000_000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opus_4_8_uses_current_pricing() {
+        // Regression for #149: Opus 4.7/4.8 must not inherit legacy $15/$75.
+        for m in ["claude-opus-4-8", "claude-opus-4-8[1m]", "claude-opus-4-7"] {
+            let p = get_pricing(m);
+            assert_eq!(p.input, 5.0, "{m} input");
+            assert_eq!(p.output, 25.0, "{m} output");
+            assert_eq!(p.cache_read, 0.5, "{m} cache_read");
+        }
+    }
+
+    #[test]
+    fn opus_4_5_and_4_6_still_current() {
+        for m in ["claude-opus-4-5", "claude-opus-4-6"] {
+            assert_eq!(get_pricing(m).input, 5.0, "{m}");
+        }
+    }
+
+    #[test]
+    fn legacy_opus_4_0_and_4_1_keep_old_pricing() {
+        for m in ["claude-opus-4-0", "claude-opus-4-1-20250805"] {
+            let p = get_pricing(m);
+            assert_eq!(p.input, 15.0, "{m} input");
+            assert_eq!(p.output, 75.0, "{m} output");
+        }
+    }
 }

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -128,6 +128,8 @@ interface ReduceCtx {
   /** High-water context tokens / window since last compaction (drives contextUtilization). */
   contextHwTokens: number;
   contextHwWindow: number;
+  /** Context tokens of the last request in the current turn (drives context occupancy, #149). */
+  lastReqContextTokens: number;
   /** tool_use_id → tl[] index (only tool entries, first-match semantics). */
   toolTlIndex: Map<string, number>;
   /** tool_use_id → he[] index (only HookEvent entries with tool_use_id). */
@@ -324,6 +326,12 @@ export class SessionStore {
    *  window so a dip event without modelUsage doesn't zero the denominator. */
   contextHwTokens: number = $state(0);
   contextHwWindow: number = $state(0);
+  /** Context tokens of the LAST request in the current turn (input + cache_read +
+   *  cache_creation from the final assistant message_usage). Context occupancy is a
+   *  point-in-time measure, so it must use the last request — NOT the turn-summed
+   *  result usage, which multiplies cache_read by the request count (#149). 0 until
+   *  a message with usage arrives; the result handler falls back to summed usage then. */
+  lastReqContextTokens: number = $state(0);
   /** Timestamp of the most recent compact_boundary event (0 = never). */
   lastCompactedAt: number = $state(0);
   /** Number of full compaction events in this session. */
@@ -1176,6 +1184,7 @@ export class SessionStore {
       turnUsages: [...this.turnUsages],
       contextHwTokens: this.contextHwTokens,
       contextHwWindow: this.contextHwWindow,
+      lastReqContextTokens: this.lastReqContextTokens,
       toolTlIndex: batchTlIndex,
       toolHeIndex: batchHeIndex,
       toolInputByUseId: new Map<string, Record<string, unknown>>(),
@@ -1223,6 +1232,7 @@ export class SessionStore {
     this.turnUsages = ctx.turnUsages;
     this.contextHwTokens = ctx.contextHwTokens;
     this.contextHwWindow = ctx.contextHwWindow;
+    this.lastReqContextTokens = ctx.lastReqContextTokens;
     this._seenMessageIds = ctx.seenMessageIds;
     this._seenToolIds = ctx.seenToolIds;
     this._toolTlIndex = ctx.toolTlIndex;
@@ -1430,6 +1440,7 @@ export class SessionStore {
     this.turnUsages = [];
     this.contextHwTokens = 0;
     this.contextHwWindow = 0;
+    this.lastReqContextTokens = 0;
     this.lastCompactedAt = 0;
     this.compactCount = 0;
     this.microcompactCount = 0;
@@ -1493,6 +1504,7 @@ export class SessionStore {
       turnUsages: this.turnUsages,
       contextHwTokens: this.contextHwTokens,
       contextHwWindow: this.contextHwWindow,
+      lastReqContextTokens: this.lastReqContextTokens,
       _seenMessageIds: [...this._seenMessageIds],
       _seenToolIds: [...this._seenToolIds],
       // B group (direct fields)
@@ -1573,6 +1585,7 @@ export class SessionStore {
       this.turnUsages = (obj.turnUsages ?? []) as TurnUsage[];
       this.contextHwTokens = (obj.contextHwTokens as number) ?? 0;
       this.contextHwWindow = (obj.contextHwWindow as number) ?? 0;
+      this.lastReqContextTokens = (obj.lastReqContextTokens as number) ?? 0;
       this._seenMessageIds = new Set((obj._seenMessageIds ?? []) as string[]);
       this._seenToolIds = new Set((obj._seenToolIds ?? []) as string[]);
 
@@ -2859,6 +2872,24 @@ export class SessionStore {
             len: savedThinking.length,
           });
 
+        // Track this request's context size (input + cache_read + cache_creation). Context
+        // occupancy is point-in-time, so the result handler uses the LAST request's value
+        // instead of the turn-summed result usage, which multiplies cache_read by request
+        // count (#149). Main-session messages only — subagent usage is its own context.
+        if (ev.message_usage) {
+          const mu = ev.message_usage;
+          const num = (k: string) => (typeof mu[k] === "number" ? (mu[k] as number) : 0);
+          const reqCtx =
+            num("input_tokens") +
+            num("cache_read_input_tokens") +
+            num("cache_creation_input_tokens");
+          if (reqCtx > 0) {
+            if (ctx) ctx.lastReqContextTokens = reqCtx;
+            else this.lastReqContextTokens = reqCtx;
+            dbg("store", "lastReqContextTokens", { reqCtx });
+          }
+        }
+
         this._pushTimeline(ctx, entry);
         break;
       }
@@ -3362,7 +3393,12 @@ export class SessionStore {
         // window; clamp tokens to it so an over-counted snapshot can't exceed 100%. Only
         // raise tokens, but always adopt the latest non-zero window (200k↔1m can switch). #135
         if (hasTokens) {
-          const evUsed = u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens;
+          // Context occupancy = the LAST request's tokens, NOT the turn-summed result usage,
+          // which inflates cache_read by the request count (#149). Fall back to the summed
+          // usage for older runs whose message events carry no per-request usage.
+          const lastReq = (ctx ?? this).lastReqContextTokens;
+          const evUsed =
+            lastReq > 0 ? lastReq : u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens;
           let evWin = 0;
           if (u.modelUsage) {
             for (const e of Object.values(u.modelUsage)) {
@@ -3550,6 +3586,7 @@ export class SessionStore {
           // post-compaction peak. Keep the window (denominator unchanged by compaction). #135
           const hwTgt = ctx ?? this;
           hwTgt.contextHwTokens = 0;
+          hwTgt.lastReqContextTokens = 0;
         }
         // Only set lastCompactedAt during live mode — during replay
         // the timestamp would be meaningless (Date.now() ≠ original event time).

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -5494,4 +5494,74 @@ describe("SessionStore reducer", () => {
       expect(store.panelTasks).toEqual([]);
     });
   });
+
+  // ── context occupancy uses last request, not turn-summed usage (#149) ──
+
+  describe("context occupancy (#149)", () => {
+    beforeEach(() => {
+      store.run = makeRun("run-ctx");
+      store.phase = "running";
+    });
+
+    function msg(id: string, input: number, cacheRead: number, cacheCreation: number): BusEvent {
+      return {
+        type: "message_complete",
+        run_id: "run-ctx",
+        message_id: id,
+        text: "ok",
+        message_usage: {
+          input_tokens: input,
+          cache_read_input_tokens: cacheRead,
+          cache_creation_input_tokens: cacheCreation,
+        },
+      } as BusEvent;
+    }
+
+    function result(cacheReadSummed: number, win: number): BusEvent {
+      return {
+        type: "usage_update",
+        run_id: "run-ctx",
+        input_tokens: 3000,
+        output_tokens: 500,
+        cache_read_tokens: cacheReadSummed,
+        cache_write_tokens: 69000,
+        total_cost_usd: 0.4,
+        model_usage: {
+          "claude-opus-4-8": {
+            input_tokens: 3000,
+            output_tokens: 500,
+            cache_read_tokens: cacheReadSummed,
+            cache_write_tokens: 69000,
+            web_search_requests: 0,
+            cost_usd: 0.4,
+            context_window: win,
+          },
+        },
+      } as BusEvent;
+    }
+
+    it("uses the last request's context, not the summed result usage", () => {
+      store.applyEventBatch([
+        { type: "user_message", run_id: "run-ctx", text: "go" },
+        msg("m1", 1000, 0, 30000), // 31k
+        msg("m2", 1000, 30000, 20000), // 51k
+        msg("m3", 1000, 50000, 19000), // 70k ← last request
+        result(80000, 1_000_000), // turn-summed cache_read inflated
+      ] as BusEvent[]);
+      expect(store.lastReqContextTokens).toBe(70000);
+      // 70k, NOT the summed 3000 + 80000 + 69000 = 152000
+      expect(store.contextTokens).toBe(70000);
+    });
+
+    it("falls back to summed usage when messages carry no per-request usage", () => {
+      store.applyEventBatch([
+        { type: "user_message", run_id: "run-ctx", text: "go" },
+        { type: "message_complete", run_id: "run-ctx", message_id: "m1", text: "ok" },
+        result(50000, 200_000),
+      ] as BusEvent[]);
+      expect(store.lastReqContextTokens).toBe(0);
+      // fallback = input 3000 + cache_read 50000 + cache_write 69000
+      expect(store.contextTokens).toBe(122000);
+    });
+  });
 });


### PR DESCRIPTION
Closes #149.

## Bug 1 — context-window occupancy inflated by request count
A turn with N API requests reports `cache_read` **summed** across all N (correct for billing), but **context-window occupancy is point-in-time** and was reading that summed value — inflating it ~Nx (issue example: **230k shown vs ~70k real**, the root cause of the `%` jumps in #135).

**Fix**: track each request's context (`input + cache_read + cache_creation`) from the assistant `message_usage` — already sent to the frontend but unused — and drive the context high-water from the **last** request. Falls back to the summed usage for older runs whose messages carry no per-request usage. Threaded through snapshot/restore/reset/compact.

## Bug 2 — Opus 4.7/4.8 priced as legacy ($15/$75, ~2.6x too high)
The live cost path **recalculated** every model's cost with a hardcoded table that matched only `opus-4-5/4-6`, so 4.7/4.8 fell through to the legacy `$15/$75` branch (issue example: **$1.06 computed vs $0.40 correct**).

**Fix (two layers)**:
- **Trust the CLI for native Claude/OpenAI** — it knows its own pricing, reports `$0` for subscription/Max plans, and stays correct across model releases with no app update. Only **third-party providers** (which the CLI mis-prices as Claude) get recalculated from our table (`pricing::is_third_party`).
- **Invert the Opus table** — only `opus-4-0/4-1` keep legacy pricing; all other Opus default to current `$5/$25`. This keeps historical aggregation (which has no CLI cost to trust) and future versions from recurring the bug.

## Test plan
- [x] `cargo test` (445 passed; +3 pricing regression tests for 4.5/4.6/4.7/4.8/legacy) · `cargo clippy` 0 warnings
- [x] `npm test` (1288 passed; +2 context-occupancy tests: last-request vs summed, and fallback) · `npm run check` 0 errors · build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)