### PR TITLE
fix(chat): clear stuck drag-hover overlay that can freeze the UI

### DIFF
--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -3153,6 +3153,29 @@
   let dragProcessingCount = $state(0);
   let dragProcessing = $derived(dragProcessingCount > 0);
 
+  // Safety net: the native `tauri://drag-leave` / `drag-drop` events can be dropped on some
+  // platforms/webviews, leaving pageDragActive stuck true → the z-50 hover overlay swallows
+  // every click and the whole UI looks frozen. A pointerdown cannot reach the webview while an
+  // OS file-drag is in progress, so receiving one means the drag is over — force-clear the
+  // stale hover. Escape does the same. Does NOT touch dragProcessing (real in-flight work).
+  $effect(() => {
+    function clearStaleHover() {
+      if (pageDragActive) {
+        pageDragActive = false;
+        dbg("chat", "drag-hover safety-net cleared stale pageDragActive");
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") clearStaleHover();
+    }
+    window.addEventListener("pointerdown", clearStaleHover);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", clearStaleHover);
+      window.removeEventListener("keydown", onKey);
+    };
+  });
+
   /** Concurrency-limited parallel map returning PromiseSettledResult for each item. */
   async function handleTauriDrop(payload: { paths: string[] }) {
     pageDragActive = false;


### PR DESCRIPTION
Safety net for a stuck full-screen drag-hover overlay (pageDragActive) that can swallow all clicks and freeze the UI when native tauri://drag-leave / drag-drop events are dropped on some platforms. Clears the stale hover on pointerdown (cannot reach the webview during an OS drag) or Escape; does not touch dragProcessing and does not listen on blur. Defensive hardening — verified: npm run check 0 errors, npm test 1288 passed, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)