### PR TITLE
Codex integration: code-review fixes (security, app-server parity, perf, cleanup)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1620,7 +1620,7 @@
   "chat_addDirFailed": "Failed to add directory: {error}",
   "chat_addDirTitle": "Add directory to workspace",
   "chat_addDirUnsupported": "add-dir is only supported for Claude agent",
-  "chat_addDirNextTurn": "Added {path} — takes effect next message",
+  "chat_addDirNextSession": "Added {path} — takes effect on the next session / new thread (write-enabled modes only)",
   "chat_addDirInvalidPath": "Path contains invalid characters",
 
   "skillSelector_label": "Skills",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1620,7 +1620,7 @@
   "chat_addDirFailed": "添加目录失败：{error}",
   "chat_addDirTitle": "添加目录到工作区",
   "chat_addDirUnsupported": "add-dir 仅支持 Claude agent",
-  "chat_addDirNextTurn": "已添加 {path} — 下条消息生效",
+  "chat_addDirNextSession": "已添加 {path} — 将在下个会话 / 新线程中生效（仅限可写模式）",
   "chat_addDirInvalidPath": "路径包含无效字符",
 
   "skillSelector_label": "技能",

--- a/src-tauri/src/agent/codex_appserver.rs
+++ b/src-tauri/src/agent/codex_appserver.rs
@@ -14,6 +14,7 @@
 //! mode` even over app-server. The spawn (in the actor wiring) MUST pass
 //! `--enable default_mode_request_user_input` to unlock it in normal sessions.
 
+use crate::agent::codex_parser::{codex_normalize_status, CodexToolKind};
 use crate::agent::session_protocol::{
     CodexTurnOverrides, LifecycleSignal, ParsedLine, PendingInteractive, PendingKind,
     SessionProtocol, StartupCtx,
@@ -60,6 +61,18 @@ pub struct CodexAppServer {
     /// When the reply arrives (`parse_line` sees a matching id with no `method`) we resolve the
     /// actor's `control_waiter` for that frontend request_id with the JSON-RPC `result`/`error`.
     client_waiters: HashMap<i64, String>,
+    /// Extra writable directories from settings (`StartupCtx.add_dirs`). `thread/start`'s
+    /// `sandbox` is a bare mode string and can't carry writable roots, so these are injected
+    /// into the `workspaceWrite` `sandboxPolicy` on `turn/start` (persists server-side).
+    add_dirs: Vec<String>,
+    /// Spawn-time model/effort/approval/sandbox defaults. `thread/start` carries model/approval/
+    /// sandbox but NOT effort, and on RESUME `thread/resume` carries none of them — so these are
+    /// (re-)applied on the first `turn/start` after spawn, where Codex persists them for the
+    /// thread. Live `set_model`/`set_effort`/`set_permission_mode` overrides from the actor take
+    /// precedence per turn.
+    startup_overrides: CodexTurnOverrides,
+    /// Cleared after the first `turn/start` — gates the one-shot replay of `startup_overrides`.
+    pending_startup_replay: bool,
 }
 
 impl Default for CodexAppServer {
@@ -71,6 +84,9 @@ impl Default for CodexAppServer {
             next_client_id: 3,
             pending: HashMap::new(),
             client_waiters: HashMap::new(),
+            add_dirs: Vec::new(),
+            startup_overrides: CodexTurnOverrides::default(),
+            pending_startup_replay: true,
         }
     }
 }
@@ -185,14 +201,16 @@ fn req_id_str(raw_id: &Value) -> String {
 /// per-turn override expects (distinct from `thread/start`'s `sandbox: SandboxMode` STRING).
 /// Mode strings come from `codex_sandbox_for` (commands/session.rs): "read-only",
 /// "workspace-write", "danger-full-access". Unknown values fall back to workspace-write.
-fn sandbox_policy_value(mode: &str) -> Value {
+/// `writable_roots` populates the `workspaceWrite` policy's writable dirs (ignored by the other
+/// modes, which have no such field).
+fn sandbox_policy_value(mode: &str, writable_roots: &[String]) -> Value {
     match mode {
         "read-only" => json!({ "type": "readOnly", "networkAccess": false }),
         "danger-full-access" => json!({ "type": "dangerFullAccess" }),
         // "workspace-write" (and any unknown mode) → the standard writable-workspace policy.
         _ => json!({
             "type": "workspaceWrite",
-            "writableRoots": [],
+            "writableRoots": writable_roots,
             "networkAccess": false,
             "excludeTmpdirEnvVar": false,
             "excludeSlashTmp": false,
@@ -202,6 +220,19 @@ fn sandbox_policy_value(mode: &str) -> Value {
 
 impl SessionProtocol for CodexAppServer {
     fn startup_messages(&mut self, ctx: &StartupCtx) -> Vec<Value> {
+        // Remember the writable dirs + spawn-time turn defaults so the first turn/start can
+        // (re-)apply them. `thread/resume` carries none of model/effort/approval/sandbox, and
+        // `thread/start` carries no effort — so this is the only way those reach a resumed
+        // thread or pick up the effort setting.
+        self.add_dirs = ctx.add_dirs.clone();
+        self.startup_overrides = CodexTurnOverrides {
+            approval_policy: ctx.approval_policy.clone(),
+            sandbox: ctx.sandbox.clone(),
+            model: ctx.model.clone(),
+            effort: ctx.effort.clone(),
+        };
+        self.pending_startup_replay = true;
+
         let initialize = json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -275,19 +306,56 @@ impl SessionProtocol for CodexAppServer {
         // turn/start overrides apply "for this turn AND subsequent turns" — they persist
         // server-side, so we only need to inject a given override on the first turn after it
         // changes, but emitting it every turn is harmless and keeps the actor stateless here.
+        //
+        // On the FIRST turn we fall back to the spawn-time defaults (`startup_overrides`) for
+        // any field the actor hasn't overridden. This carries model/effort/approval/sandbox onto
+        // a resumed thread (`thread/resume` sends none of them) and applies the effort setting
+        // (`thread/start` has no effort field). Live actor overrides always win.
+        let first_turn = self.pending_startup_replay;
+        self.pending_startup_replay = false;
+        let pick = |actor: &Option<String>, startup: &Option<String>| -> Option<String> {
+            actor
+                .clone()
+                .or_else(|| if first_turn { startup.clone() } else { None })
+        };
+        let approval_policy = pick(
+            &overrides.approval_policy,
+            &self.startup_overrides.approval_policy,
+        );
+        let sandbox = pick(&overrides.sandbox, &self.startup_overrides.sandbox);
+        let model = pick(&overrides.model, &self.startup_overrides.model);
+        let effort = pick(&overrides.effort, &self.startup_overrides.effort);
+
         let mut params = serde_json::Map::new();
         params.insert("threadId".into(), json!(thread_id));
         params.insert("input".into(), Value::Array(input));
-        if let Some(p) = &overrides.approval_policy {
+        if let Some(p) = &approval_policy {
             params.insert("approvalPolicy".into(), json!(p));
         }
-        if let Some(s) = &overrides.sandbox {
-            params.insert("sandboxPolicy".into(), sandbox_policy_value(s));
+        // Emit a sandboxPolicy when the sandbox is explicitly set, OR (first turn only) when we
+        // have writable dirs to inject — `thread/start`'s bare `sandbox` string can't carry
+        // `writableRoots`, so the workspace-write policy object is the only channel for add_dirs.
+        match &sandbox {
+            Some(s) => {
+                params.insert(
+                    "sandboxPolicy".into(),
+                    sandbox_policy_value(s, &self.add_dirs),
+                );
+            }
+            None if first_turn && !self.add_dirs.is_empty() => {
+                // No explicit mode → the server default is workspace-write; build that policy so
+                // the writable roots take effect.
+                params.insert(
+                    "sandboxPolicy".into(),
+                    sandbox_policy_value("workspace-write", &self.add_dirs),
+                );
+            }
+            None => {}
         }
-        if let Some(m) = &overrides.model {
+        if let Some(m) = &model {
             params.insert("model".into(), json!(m));
         }
-        if let Some(e) = &overrides.effort {
+        if let Some(e) = &effort {
             params.insert("effort".into(), json!(e));
         }
         vec![json!({
@@ -584,13 +652,12 @@ impl CodexAppServer {
                 out.lifecycle = Some(LifecycleSignal::TurnFailed(err));
             }
             "error" => {
-                // A top-level error ends/aborts the active turn — drop the stale turn id so a
-                // later steer doesn't target a turn that's no longer running.
-                self.active_turn_id = None;
                 // ErrorNotification = { error: TurnError, willRetry: bool, threadId, turnId }.
                 // The message lives in `error.message` (a TurnError) — NOT a top-level `message`.
                 // `willRetry: true` is a transient failure Codex auto-retries (e.g. a flaky
-                // upstream connection); the turn recovers, so don't alarm the user — log only.
+                // upstream connection); the SAME turn keeps running, so don't alarm the user
+                // and — crucially — keep `active_turn_id` so a steer issued during the retry
+                // window still targets the live turn.
                 let err = params.get("error");
                 let m = err
                     .and_then(|e| e.get("message"))
@@ -604,6 +671,9 @@ impl CodexAppServer {
                 if will_retry {
                     log::debug!("[codex] transient error (will retry): {m}");
                 } else {
+                    // Terminal error — the turn is over; drop the stale id so a later
+                    // steer doesn't target a turn that's no longer running.
+                    self.active_turn_id = None;
                     out.events.push(BusEvent::CommandOutput {
                         run_id: run_id.to_string(),
                         content: format!("[error] {m}"),
@@ -876,18 +946,24 @@ fn elicitation_prompt(run_id: &str, request_id: &str, params: &Value) -> BusEven
 
 // ── item.* → tool/message BusEvents ──────────────────────────────────────────────────
 
-/// Map an app-server item to (tool_name) for the camelCase item types.
+/// Map an app-server item to its tool name. Classification is shared with the exec parser via
+/// `CodexToolKind`; the `mcpToolCall` name uses this transport's own field defaults (server "mcp",
+/// tool "tool" — the exec transport defaults tool to "unknown").
 fn item_tool_name(item: &Value) -> Option<String> {
-    match item.get("type").and_then(|v| v.as_str())? {
-        "commandExecution" => Some("Bash".to_string()),
-        "fileChange" => Some("Edit".to_string()),
-        "webSearch" => Some("WebSearch".to_string()),
-        "mcpToolCall" => {
+    let item_type = item.get("type").and_then(|v| v.as_str())?;
+    match CodexToolKind::from_item_type(item_type)? {
+        CodexToolKind::McpToolCall => {
             let server = item.get("server").and_then(|v| v.as_str()).unwrap_or("mcp");
             let tool = item.get("tool").and_then(|v| v.as_str()).unwrap_or("tool");
             Some(format!("{server}:{tool}"))
         }
-        _ => None,
+        // `collabToolCall` IS reachable over app-server (multi-agent / spawn_agent sessions), but
+        // this transport's `item_started_event` only copies a `command` field — it has none of the
+        // collab fields (tool/prompt/agents_states), so rendering it would yield an empty Agent
+        // card. The app-server path has never rendered collab items; preserve that (return None)
+        // until the collab fields are properly extracted. The exec parser DOES render them.
+        CodexToolKind::CollabToolCall => None,
+        kind => kind.fixed_tool_name().map(|s| s.to_string()),
     }
 }
 
@@ -947,10 +1023,8 @@ fn item_completed_events(run_id: &str, item: &Value, out: &mut Vec<BusEvent>) {
             .or_else(|| item.get("changes"))
             .cloned()
             .unwrap_or(Value::Null);
-        let status = match item.get("status").and_then(|v| v.as_str()) {
-            Some("failed") | Some("declined") => "error",
-            _ => "success",
-        };
+        let status =
+            codex_normalize_status(item.get("status").and_then(|v| v.as_str()).unwrap_or(""));
         out.push(BusEvent::ToolEnd {
             run_id: run_id.to_string(),
             tool_use_id: id,
@@ -1199,21 +1273,119 @@ mod tests {
     }
 
     #[test]
+    fn first_turn_replays_startup_defaults_only_once() {
+        // A resumed thread (thread/resume carries no model/effort/approval/sandbox) must have
+        // the spawn-time defaults re-applied on the first turn — then NOT re-sent afterwards.
+        let mut s = CodexAppServer::new();
+        s.startup_messages(&StartupCtx {
+            resume_thread_id: Some("th-r".into()),
+            model: Some("gpt-5-codex".into()),
+            approval_policy: Some("on-request".into()),
+            sandbox: Some("workspace-write".into()),
+            effort: Some("high".into()),
+            ..Default::default()
+        });
+        // thread/resume ack readies the session.
+        s.parse_line("r", r#"{"id":2,"result":{}}"#);
+
+        let first = s.frame_user_turn("hi", &[], &no_overrides());
+        let p = &first[0]["params"];
+        assert_eq!(p["model"], "gpt-5-codex");
+        assert_eq!(p["approvalPolicy"], "on-request");
+        assert_eq!(p["effort"], "high");
+        assert_eq!(p["sandboxPolicy"]["type"], "workspaceWrite");
+
+        // Second turn: defaults already persisted server-side → not re-sent.
+        let second = s.frame_user_turn("again", &[], &no_overrides());
+        let p2 = &second[0]["params"];
+        assert!(p2.get("model").is_none());
+        assert!(p2.get("approvalPolicy").is_none());
+        assert!(p2.get("effort").is_none());
+        assert!(p2.get("sandboxPolicy").is_none());
+    }
+
+    #[test]
+    fn actor_override_wins_over_startup_default_on_first_turn() {
+        let mut s = CodexAppServer::new();
+        s.startup_messages(&StartupCtx {
+            resume_thread_id: Some("th-r".into()),
+            model: Some("gpt-5-codex".into()),
+            ..Default::default()
+        });
+        s.parse_line("r", r#"{"id":2,"result":{}}"#);
+        let overrides = CodexTurnOverrides {
+            model: Some("o3".into()),
+            ..Default::default()
+        };
+        let msgs = s.frame_user_turn("hi", &[], &overrides);
+        assert_eq!(msgs[0]["params"]["model"], "o3");
+    }
+
+    #[test]
+    fn add_dirs_populate_writable_roots_on_first_turn() {
+        let mut s = CodexAppServer::new();
+        s.startup_messages(&StartupCtx {
+            cwd: "/work".into(),
+            sandbox: Some("workspace-write".into()),
+            add_dirs: vec!["/extra/a".into(), "/extra/b".into()],
+            ..Default::default()
+        });
+        s.parse_line("r", r#"{"id":2,"result":{"thread":{"id":"th-1"}}}"#);
+        let msgs = s.frame_user_turn("go", &[], &no_overrides());
+        let policy = &msgs[0]["params"]["sandboxPolicy"];
+        assert_eq!(policy["type"], "workspaceWrite");
+        assert_eq!(policy["writableRoots"][0], "/extra/a");
+        assert_eq!(policy["writableRoots"][1], "/extra/b");
+    }
+
+    #[test]
+    fn add_dirs_emit_workspace_policy_when_sandbox_unset() {
+        // No explicit sandbox at spawn → server default is workspace-write. The writable dirs
+        // still need a policy object (the bare thread/start `sandbox` string can't carry them).
+        let mut s = CodexAppServer::new();
+        s.startup_messages(&StartupCtx {
+            cwd: "/work".into(),
+            add_dirs: vec!["/extra".into()],
+            ..Default::default()
+        });
+        s.parse_line("r", r#"{"id":2,"result":{"thread":{"id":"th-1"}}}"#);
+        let msgs = s.frame_user_turn("go", &[], &no_overrides());
+        let policy = &msgs[0]["params"]["sandboxPolicy"];
+        assert_eq!(policy["type"], "workspaceWrite");
+        assert_eq!(policy["writableRoots"][0], "/extra");
+        // No add_dirs and no sandbox → no policy at all.
+        let mut s2 = ready_server();
+        let m2 = s2.frame_user_turn("go", &[], &no_overrides());
+        assert!(m2[0]["params"].get("sandboxPolicy").is_none());
+    }
+
+    #[test]
     fn sandbox_policy_value_mapping() {
-        assert_eq!(sandbox_policy_value("read-only")["type"], "readOnly");
-        assert_eq!(sandbox_policy_value("read-only")["networkAccess"], false);
+        assert_eq!(sandbox_policy_value("read-only", &[])["type"], "readOnly");
         assert_eq!(
-            sandbox_policy_value("danger-full-access")["type"],
+            sandbox_policy_value("read-only", &[])["networkAccess"],
+            false
+        );
+        assert_eq!(
+            sandbox_policy_value("danger-full-access", &[])["type"],
             "dangerFullAccess"
         );
-        let ws = sandbox_policy_value("workspace-write");
+        let ws = sandbox_policy_value("workspace-write", &[]);
         assert_eq!(ws["type"], "workspaceWrite");
         assert_eq!(ws["writableRoots"], json!([]));
         assert_eq!(ws["networkAccess"], false);
         assert_eq!(ws["excludeTmpdirEnvVar"], false);
         assert_eq!(ws["excludeSlashTmp"], false);
         // Unknown mode falls back to workspace-write.
-        assert_eq!(sandbox_policy_value("bogus")["type"], "workspaceWrite");
+        assert_eq!(sandbox_policy_value("bogus", &[])["type"], "workspaceWrite");
+        // Writable roots populate the workspace-write policy (and are ignored elsewhere).
+        let roots = vec!["/extra/a".to_string(), "/extra/b".to_string()];
+        let ws2 = sandbox_policy_value("workspace-write", &roots);
+        assert_eq!(ws2["writableRoots"][0], "/extra/a");
+        assert_eq!(ws2["writableRoots"][1], "/extra/b");
+        assert!(sandbox_policy_value("read-only", &roots)
+            .get("writableRoots")
+            .is_none());
     }
 
     #[test]
@@ -1419,6 +1591,58 @@ mod tests {
                 assert_eq!(status, "success");
             }
             e => panic!("expected ToolEnd, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn collab_tool_call_emits_no_card_over_app_server() {
+        // Regression: app-server has never rendered collabToolCall items (item_started only copies
+        // a `command` field, which collab lacks → an empty Agent card). The shared CodexToolKind
+        // classifier knows collab → Agent, but this transport must keep emitting NOTHING for it
+        // until the collab fields are extracted. (The exec parser DOES render collab — separate.)
+        let mut s = ready_server();
+        let started = s.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"item":{"id":"col_1","type":"collabToolCall","tool":"code_review","prompt":"review"}}}"#,
+        );
+        assert!(
+            started.events.is_empty(),
+            "collabToolCall must emit no ToolStart over app-server, got {:?}",
+            started.events
+        );
+        let completed = s.parse_line(
+            "r",
+            r#"{"method":"item/completed","params":{"item":{"id":"col_1","type":"collabToolCall","status":"completed","agents_states":{}}}}"#,
+        );
+        assert!(
+            completed.events.is_empty(),
+            "collabToolCall must emit no ToolEnd over app-server, got {:?}",
+            completed.events
+        );
+    }
+
+    #[test]
+    fn mcp_tool_name_default_diverges_from_exec_intentionally() {
+        // The two transports use DIFFERENT defaults for a missing `tool` field on an MCP item:
+        // app-server → "tool", exec (pipe_parser) → "unknown". This is intentional; lock it so a
+        // future "cleanup" can't silently unify them. (Pair: pipe_parser::tests covers the exec side.)
+        let mut s = ready_server();
+        let out = s.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"item":{"id":"m_1","type":"mcpToolCall","server":"fs"}}}"#,
+        );
+        match &out.events[0] {
+            BusEvent::ToolStart { tool_name, .. } => assert_eq!(tool_name, "fs:tool"),
+            e => panic!("expected ToolStart, got {e:?}"),
+        }
+        // Both fields present → "{server}:{tool}".
+        let out2 = s.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"item":{"id":"m_2","type":"mcpToolCall","server":"fs","tool":"read"}}}"#,
+        );
+        match &out2.events[0] {
+            BusEvent::ToolStart { tool_name, .. } => assert_eq!(tool_name, "fs:read"),
+            e => panic!("expected ToolStart, got {e:?}"),
         }
     }
 

--- a/src-tauri/src/agent/codex_parser.rs
+++ b/src-tauri/src/agent/codex_parser.rs
@@ -1,5 +1,63 @@
 use serde_json::Value;
 
+/// The tool category a Codex item maps to. Shared by both Codex transports — the one-way `exec`
+/// NDJSON parser ([`crate::agent::pipe_parser`], snake_case item types) and the bidirectional
+/// `app-server` driver ([`crate::agent::codex_appserver`], camelCase item types) — so the
+/// item→tool-name decision lives in exactly one place.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexToolKind {
+    /// `command_execution` / `commandExecution` → "Bash".
+    Command,
+    /// `file_change` / `fileChange` → "Edit".
+    FileChange,
+    /// `web_search` / `webSearch` → "WebSearch".
+    WebSearch,
+    /// `mcp_tool_call` / `mcpToolCall` → "{server}:{tool}" (caller supplies server/tool).
+    McpToolCall,
+    /// `collab_tool_call` / `collabToolCall` → "Agent".
+    CollabToolCall,
+}
+
+impl CodexToolKind {
+    /// Classify a Codex item `type` string, tolerating BOTH the exec snake_case and the
+    /// app-server camelCase spellings. Returns `None` for non-tool items (agent_message,
+    /// reasoning, user_message, todo_list, error, …) which each transport handles separately.
+    pub fn from_item_type(item_type: &str) -> Option<Self> {
+        match item_type {
+            "command_execution" | "commandExecution" => Some(Self::Command),
+            "file_change" | "fileChange" => Some(Self::FileChange),
+            "web_search" | "webSearch" => Some(Self::WebSearch),
+            "mcp_tool_call" | "mcpToolCall" => Some(Self::McpToolCall),
+            "collab_tool_call" | "collabToolCall" => Some(Self::CollabToolCall),
+            _ => None,
+        }
+    }
+
+    /// The fixed tool name for non-MCP kinds. `McpToolCall` returns `None` because its name is
+    /// `"{server}:{tool}"`, which depends on item fields the caller extracts (with its own
+    /// defaults for missing values, which differ slightly between transports).
+    pub fn fixed_tool_name(self) -> Option<&'static str> {
+        match self {
+            Self::Command => Some("Bash"),
+            Self::FileChange => Some("Edit"),
+            Self::WebSearch => Some("WebSearch"),
+            Self::CollabToolCall => Some("Agent"),
+            Self::McpToolCall => None,
+        }
+    }
+}
+
+/// Normalize a Codex item `status` to the app convention ("success" | "error"). Codex emits
+/// `completed` / `failed` / `declined` / `in_progress` (see exec_events.rs); only `failed` and
+/// `declined` are surfaced as errors, everything else (including missing/unknown) is "success".
+/// Shared by both Codex transports so the two parsers can't drift.
+pub fn codex_normalize_status(raw_status: &str) -> &'static str {
+    match raw_status {
+        "failed" | "declined" => "error",
+        _ => "success",
+    }
+}
+
 /// Extract text delta from a Codex NDJSON payload.
 ///
 /// Codex CLI v0.98+ output format (NDJSON):
@@ -193,5 +251,54 @@ mod tests {
     fn test_empty_payload() {
         let payload = json!({});
         assert_eq!(extract_codex_delta(&payload), None);
+    }
+
+    #[test]
+    fn tool_kind_accepts_both_casings() {
+        use CodexToolKind::*;
+        // snake_case (exec) and camelCase (app-server) classify identically.
+        for (snake, camel, kind) in [
+            ("command_execution", "commandExecution", Command),
+            ("file_change", "fileChange", FileChange),
+            ("web_search", "webSearch", WebSearch),
+            ("mcp_tool_call", "mcpToolCall", McpToolCall),
+            ("collab_tool_call", "collabToolCall", CollabToolCall),
+        ] {
+            assert_eq!(CodexToolKind::from_item_type(snake), Some(kind));
+            assert_eq!(CodexToolKind::from_item_type(camel), Some(kind));
+        }
+        // Non-tool item types → None.
+        for t in [
+            "agent_message",
+            "agentMessage",
+            "reasoning",
+            "todo_list",
+            "error",
+            "",
+        ] {
+            assert_eq!(CodexToolKind::from_item_type(t), None);
+        }
+    }
+
+    #[test]
+    fn tool_kind_fixed_names() {
+        use CodexToolKind::*;
+        assert_eq!(Command.fixed_tool_name(), Some("Bash"));
+        assert_eq!(FileChange.fixed_tool_name(), Some("Edit"));
+        assert_eq!(WebSearch.fixed_tool_name(), Some("WebSearch"));
+        assert_eq!(CollabToolCall.fixed_tool_name(), Some("Agent"));
+        // MCP has no fixed name — it's "{server}:{tool}", built by the caller.
+        assert_eq!(McpToolCall.fixed_tool_name(), None);
+    }
+
+    #[test]
+    fn normalize_status_failed_and_declined_are_errors() {
+        assert_eq!(codex_normalize_status("failed"), "error");
+        assert_eq!(codex_normalize_status("declined"), "error");
+        // Everything else (completed / in_progress / unknown / missing) is success.
+        assert_eq!(codex_normalize_status("completed"), "success");
+        assert_eq!(codex_normalize_status("in_progress"), "success");
+        assert_eq!(codex_normalize_status("whatever"), "success");
+        assert_eq!(codex_normalize_status(""), "success");
     }
 }

--- a/src-tauri/src/agent/pipe_parser.rs
+++ b/src-tauri/src/agent/pipe_parser.rs
@@ -1,3 +1,4 @@
+use crate::agent::codex_parser::{codex_normalize_status, CodexToolKind};
 use crate::models::BusEvent;
 use serde_json::Value;
 
@@ -48,8 +49,8 @@ impl CodexStdoutParser {
         let item_id = item.get("id").and_then(|v| v.as_str()).unwrap_or("unknown");
         let tool_use_id = self.scoped_id(item_id);
 
-        match item_type {
-            "command_execution" => {
+        match CodexToolKind::from_item_type(item_type) {
+            Some(CodexToolKind::Command) => {
                 let command = item
                     .get("command")
                     .and_then(|v| v.as_str())
@@ -63,7 +64,7 @@ impl CodexStdoutParser {
                     parent_tool_use_id: None,
                 }]
             }
-            "file_change" => {
+            Some(CodexToolKind::FileChange) => {
                 vec![BusEvent::ToolStart {
                     run_id: run_id.to_string(),
                     tool_use_id,
@@ -72,16 +73,11 @@ impl CodexStdoutParser {
                     parent_tool_use_id: None,
                 }]
             }
-            "mcp_tool_call" => {
-                let server = item.get("server").and_then(|v| v.as_str()).unwrap_or("mcp");
-                let tool = item
-                    .get("tool")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
+            Some(CodexToolKind::McpToolCall) => {
                 vec![BusEvent::ToolStart {
                     run_id: run_id.to_string(),
                     tool_use_id,
-                    tool_name: format!("{}:{}", server, tool),
+                    tool_name: mcp_tool_name(item),
                     input: item
                         .get("arguments")
                         .cloned()
@@ -89,7 +85,7 @@ impl CodexStdoutParser {
                     parent_tool_use_id: None,
                 }]
             }
-            "web_search" => {
+            Some(CodexToolKind::WebSearch) => {
                 let query = item
                     .get("query")
                     .and_then(|v| v.as_str())
@@ -108,7 +104,7 @@ impl CodexStdoutParser {
                     parent_tool_use_id: None,
                 }]
             }
-            "collab_tool_call" => {
+            Some(CodexToolKind::CollabToolCall) => {
                 let tool = item
                     .get("tool")
                     .and_then(|v| v.as_str())
@@ -128,18 +124,7 @@ impl CodexStdoutParser {
                 }]
             }
             // agent_message, reasoning: wait for completed
-            _ => vec![],
-        }
-    }
-
-    /// Map Codex item status to app convention: "success" or "error".
-    /// Codex uses: completed/failed/declined/in_progress (see exec_events.rs).
-    fn normalize_status(raw_status: &str) -> String {
-        match raw_status {
-            "completed" => "success".to_string(),
-            "failed" | "declined" => "error".to_string(),
-            // Treat unknown / missing as success (same as "completed")
-            _ => "success".to_string(),
+            None => vec![],
         }
     }
 
@@ -155,7 +140,7 @@ impl CodexStdoutParser {
             .get("status")
             .and_then(|v| v.as_str())
             .unwrap_or("completed");
-        let status = Self::normalize_status(raw_status);
+        let status = codex_normalize_status(raw_status).to_string();
 
         match item_type {
             "agent_message" => {
@@ -210,15 +195,10 @@ impl CodexStdoutParser {
                 }]
             }
             "mcp_tool_call" => {
-                let server = item.get("server").and_then(|v| v.as_str()).unwrap_or("mcp");
-                let tool = item
-                    .get("tool")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
                 vec![BusEvent::ToolEnd {
                     run_id: run_id.to_string(),
                     tool_use_id,
-                    tool_name: format!("{}:{}", server, tool),
+                    tool_name: mcp_tool_name(item),
                     output: item.get("result").cloned().unwrap_or(serde_json::json!({})),
                     status,
                     duration_ms: None,
@@ -411,6 +391,17 @@ fn human_error_message(raw: &str) -> String {
         }
     }
     current
+}
+
+/// `"{server}:{tool}"` name for an exec `mcp_tool_call` item. Defaults: server "mcp", tool
+/// "unknown" (the app-server transport defaults tool to "tool" — kept distinct intentionally).
+fn mcp_tool_name(item: &Value) -> String {
+    let server = item.get("server").and_then(|v| v.as_str()).unwrap_or("mcp");
+    let tool = item
+        .get("tool")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    format!("{}:{}", server, tool)
 }
 
 /// Build Edit ToolStart input from a Codex `file_change` item. Live shape is
@@ -622,6 +613,23 @@ mod tests {
         assert_eq!(events.len(), 1);
         match &events[0] {
             BusEvent::ToolStart { tool_name, .. } => assert_eq!(tool_name, "fs:read"),
+            other => panic!("expected ToolStart, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn mcp_tool_call_missing_tool_defaults_to_unknown() {
+        // Exec parser defaults a missing `tool` field to "unknown" — INTENTIONALLY different from
+        // the app-server transport, which defaults to "tool". Lock it so a future "cleanup" can't
+        // silently unify them. (Pair: codex_appserver::tests covers the app-server "tool" default.)
+        let mut p = parser();
+        let raw = json!({
+            "type": "item.started",
+            "item": {"id": "mcp_1", "type": "mcp_tool_call", "server": "fs"}
+        });
+        let events = p.parse_line("run-1", &raw);
+        match &events[0] {
+            BusEvent::ToolStart { tool_name, .. } => assert_eq!(tool_name, "fs:unknown"),
             other => panic!("expected ToolStart, got {:?}", other),
         }
     }

--- a/src-tauri/src/agent/session_protocol.rs
+++ b/src-tauri/src/agent/session_protocol.rs
@@ -25,6 +25,12 @@ pub struct StartupCtx {
     pub approval_policy: Option<String>,
     /// Codex `sandbox` mode (e.g. "read-only", "workspace-write", "danger-full-access").
     pub sandbox: Option<String>,
+    /// Codex `ReasoningEffort` ("minimal" | "low" | "medium" | "high"). `thread/start` has no
+    /// effort field, so this is applied on the first `turn/start` (and persists server-side).
+    pub effort: Option<String>,
+    /// Extra directories the workspace-write sandbox may write to, beyond `cwd`. Mapped into
+    /// the `workspaceWrite` policy's `writableRoots` at `thread/start` (empty = cwd-only).
+    pub add_dirs: Vec<String>,
 }
 
 /// Live per-turn overrides for a Codex `app-server` session. These are injected into the next

--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -1,4 +1,47 @@
 use crate::agent::adapter::{self, AdapterSettings};
+use crate::models::CodexProviderCredential;
+
+/// Build the `-c model_providers.*` config overrides for a Codex third-party provider
+/// (OpenAI Responses API gateway). Accepted on `codex exec`, `codex exec resume`, and
+/// `codex app-server`. The API key is supplied separately via [`codex_provider_env`].
+/// `requires_openai_auth=false` is required for non-OpenAI gateways, otherwise Codex ignores
+/// `env_key` and falls back to ChatGPT login. `wire_api` is always "responses" (no "chat").
+/// Does NOT include `--model` — callers handle the model arg differently (the exec path lets the
+/// provider model win over the generic model, the side-question path inherits the run's model).
+pub fn codex_provider_config_args(p: &CodexProviderCredential) -> Vec<String> {
+    let id = &p.id;
+    let mut args = vec![
+        "-c".to_string(),
+        format!("model_provider=\"{}\"", id),
+        "-c".to_string(),
+        format!("model_providers.{}.name=\"{}\"", id, p.name),
+        "-c".to_string(),
+        format!("model_providers.{}.base_url=\"{}\"", id, p.base_url),
+    ];
+    if !p.env_key.is_empty() {
+        args.push("-c".to_string());
+        args.push(format!("model_providers.{}.env_key=\"{}\"", id, p.env_key));
+    }
+    args.push("-c".to_string());
+    args.push(format!(
+        "model_providers.{}.wire_api=\"{}\"",
+        id, p.wire_api
+    ));
+    args.push("-c".to_string());
+    args.push(format!("model_providers.{}.requires_openai_auth=false", id));
+    args
+}
+
+/// The env var entry (`env_key` → `api_key`) Codex reads the provider API key from, if both are
+/// set. Returned as `(name, value)` so callers can inject it onto the child process. `None` when
+/// the provider has no key or no `env_key` (e.g. a ChatGPT-login provider).
+pub fn codex_provider_env(p: &CodexProviderCredential) -> Option<(String, String)> {
+    let key = p.api_key.as_ref().filter(|k| !k.is_empty())?;
+    if p.env_key.is_empty() {
+        return None;
+    }
+    Some((p.env_key.clone(), key.clone()))
+}
 
 /// Build the command + args for a given agent (pipe-exec mode, not stream session)
 pub fn build_agent_command(
@@ -47,33 +90,12 @@ pub fn build_agent_command(
             args.push("--skip-git-repo-check".to_string());
 
             // Codex third-party provider (OpenAI Responses API) → inject as `-c model_providers.*`
-            // overrides. Accepted on both `codex exec` and `exec resume` (no resume gating). The
-            // API key is supplied separately via the env var named by `env_key`, set on the child
-            // process at spawn time (see run_agent extra_env). `requires_openai_auth=false` is
-            // required for non-OpenAI gateways, otherwise Codex ignores env_key and falls back to
-            // ChatGPT login. `wire_api` is always "responses" (Codex removed "chat").
+            // overrides (shared with the app-server + side-question paths). Accepted on both
+            // `codex exec` and `exec resume` (no resume gating). The API key is supplied separately
+            // via the env var named by `env_key`, set on the child process at spawn time (see
+            // run_agent extra_env). Here we additionally pin the provider-side `--model`.
             if let Some(p) = &settings.codex_provider {
-                let id = &p.id;
-                args.push("-c".to_string());
-                args.push(format!("model_provider=\"{}\"", id));
-                args.push("-c".to_string());
-                args.push(format!("model_providers.{}.name=\"{}\"", id, p.name));
-                args.push("-c".to_string());
-                args.push(format!(
-                    "model_providers.{}.base_url=\"{}\"",
-                    id, p.base_url
-                ));
-                if !p.env_key.is_empty() {
-                    args.push("-c".to_string());
-                    args.push(format!("model_providers.{}.env_key=\"{}\"", id, p.env_key));
-                }
-                args.push("-c".to_string());
-                args.push(format!(
-                    "model_providers.{}.wire_api=\"{}\"",
-                    id, p.wire_api
-                ));
-                args.push("-c".to_string());
-                args.push(format!("model_providers.{}.requires_openai_auth=false", id));
+                args.extend(codex_provider_config_args(p));
                 if !p.model.is_empty() {
                     args.push("--model".to_string());
                     args.push(p.model.clone());
@@ -445,6 +467,48 @@ mod tests {
         s.codex_provider = None;
         let (_, na) = build_agent_command("codex", "q", &s, false, None, &[]).unwrap();
         assert!(!na.join(" ").contains("model_provider="));
+    }
+
+    #[test]
+    fn codex_provider_helper_shapes() {
+        use crate::models::CodexProviderCredential;
+        let p = CodexProviderCredential {
+            id: "vercel".into(),
+            name: "Vercel AI Gateway".into(),
+            base_url: "https://ai-gateway.vercel.sh/v1".into(),
+            env_key: "AI_GATEWAY_API_KEY".into(),
+            wire_api: "responses".into(),
+            model: "openai/gpt-5.5".into(),
+            api_key: Some("sk-secret".into()),
+        };
+        // Config args: the -c overrides, NOT --model, and never the api key.
+        let args = codex_provider_config_args(&p);
+        let joined = args.join(" ");
+        assert!(joined.contains("model_provider=\"vercel\""));
+        assert!(
+            joined.contains("model_providers.vercel.base_url=\"https://ai-gateway.vercel.sh/v1\"")
+        );
+        assert!(joined.contains("model_providers.vercel.env_key=\"AI_GATEWAY_API_KEY\""));
+        assert!(joined.contains("model_providers.vercel.wire_api=\"responses\""));
+        assert!(joined.contains("model_providers.vercel.requires_openai_auth=false"));
+        assert!(!args.iter().any(|a| a == "--model"));
+        assert!(!joined.contains("sk-secret"));
+        // Env: env_key → api_key.
+        assert_eq!(
+            codex_provider_env(&p),
+            Some(("AI_GATEWAY_API_KEY".into(), "sk-secret".into()))
+        );
+        // No api key → no env entry.
+        let mut no_key = p.clone();
+        no_key.api_key = None;
+        assert_eq!(codex_provider_env(&no_key), None);
+        // No env_key → no env entry (ChatGPT-login style provider).
+        let mut no_env = p.clone();
+        no_env.env_key = String::new();
+        assert_eq!(codex_provider_env(&no_env), None);
+        // env_key with empty config still omits the env_key override line.
+        let args2 = codex_provider_config_args(&no_env);
+        assert!(!args2.join(" ").contains(".env_key="));
     }
 
     #[test]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -270,10 +270,8 @@ pub async fn send_chat_message(
     // (the -c model_providers.*.env_key override was already added in build_agent_command).
     let mut extra_env: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     if let Some(p) = &adapter_settings.codex_provider {
-        if let Some(key) = p.api_key.as_ref().filter(|k| !k.is_empty()) {
-            if !p.env_key.is_empty() {
-                extra_env.insert(p.env_key.clone(), key.clone());
-            }
+        if let Some((k, v)) = crate::agent::spawn::codex_provider_env(p) {
+            extra_env.insert(k, v);
         }
     }
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -147,17 +147,27 @@ pub(crate) fn validate_file_path(
                 log::debug!("[files] path allowed (extra dir): {}", canonical.display());
                 return Ok(canonical);
             }
-            // Also allow git repo root (for ancestor AGENTS.md files)
-            for ancestor in extra_canonical.ancestors().skip(1) {
-                if ancestor.join(".git").exists() {
-                    if canonical.starts_with(ancestor) {
-                        log::debug!(
-                            "[files] path allowed (git root of cwd): {}",
-                            canonical.display()
-                        );
-                        return Ok(canonical);
+            // Also allow ancestor agent-memory files (e.g. an AGENTS.md / CLAUDE.md at
+            // the repo root when cwd is a subdir). Restricted to those filenames: an
+            // unrestricted git-root allowance would let a caller write e.g.
+            // `<repo>/.git/hooks/pre-commit` and gain code execution on the next commit.
+            let is_agent_memory = canonical
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.eq_ignore_ascii_case("AGENTS.md") || n.eq_ignore_ascii_case("CLAUDE.md"))
+                .unwrap_or(false);
+            if is_agent_memory {
+                for ancestor in extra_canonical.ancestors().skip(1) {
+                    if ancestor.join(".git").exists() {
+                        if canonical.starts_with(ancestor) {
+                            log::debug!(
+                                "[files] path allowed (agent-memory file at git root): {}",
+                                canonical.display()
+                            );
+                            return Ok(canonical);
+                        }
+                        break;
                     }
-                    break;
                 }
             }
         }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -663,13 +663,18 @@ pub(crate) async fn start_session_impl(
                 .codex_provider
                 .as_ref()
                 .map(|p| p.id.clone()),
-            // `on-request`: the recommended interactive-approval policy (what Codex's own TUI
-            // uses); Codex surfaces an approval card when a command needs to escape the sandbox.
-            // (Previously `on-failure`, but Codex 0.136 deprecated it and warned on every turn.)
-            approval_policy: Some("on-request".to_string()),
+            // Approval policy derived from permission_mode (mirrors the sandbox mapping):
+            // bypassPermissions/dontAsk → "never" (no prompts, matches danger-full-access),
+            // everything else → "on-request" (the interactive policy Codex's own TUI uses;
+            // surfaces an approval card when a command needs to escape the sandbox).
+            approval_policy: Some(codex_approval_for(
+                adapter_settings.permission_mode.as_deref(),
+            )),
             sandbox: Some(codex_sandbox_for(
                 adapter_settings.permission_mode.as_deref(),
             )),
+            effort: adapter_settings.effort.clone().filter(|e| !e.is_empty()),
+            add_dirs: adapter_settings.add_dirs.clone(),
         };
         let startup = driver.startup_messages(&ctx);
         (c, si, so, se, Some(driver), startup)
@@ -1955,29 +1960,10 @@ async fn spawn_codex_appserver_process(
         "suppress_unstable_features_warning=true".into(),
     ];
 
-    // Third-party provider overrides (mirror spawn.rs exec path).
+    // Third-party provider overrides (shared with the exec + side-question paths). The provider
+    // API key is injected as an env var (env_key=api_key) below, mirroring chat.rs's run_agent.
     if let Some(p) = &settings.codex_provider {
-        let id = &p.id;
-        args.push("-c".into());
-        args.push(format!("model_provider=\"{}\"", id));
-        args.push("-c".into());
-        args.push(format!("model_providers.{}.name=\"{}\"", id, p.name));
-        args.push("-c".into());
-        args.push(format!(
-            "model_providers.{}.base_url=\"{}\"",
-            id, p.base_url
-        ));
-        if !p.env_key.is_empty() {
-            args.push("-c".into());
-            args.push(format!("model_providers.{}.env_key=\"{}\"", id, p.env_key));
-        }
-        args.push("-c".into());
-        args.push(format!(
-            "model_providers.{}.wire_api=\"{}\"",
-            id, p.wire_api
-        ));
-        args.push("-c".into());
-        args.push(format!("model_providers.{}.requires_openai_auth=false", id));
+        args.extend(crate::agent::spawn::codex_provider_config_args(p));
     }
 
     let mut cmd = Command::new(&codex_bin);
@@ -1997,6 +1983,13 @@ async fn spawn_codex_appserver_process(
         .kill_on_drop(true);
     if let Some(env) = extra_env {
         for (k, v) in env {
+            cmd.env(k, v);
+        }
+    }
+    // Provider API key (env_key=api_key) — the exec path sets this in chat.rs's run_agent, but
+    // the app-server actor path has no such hook, so inject it here.
+    if let Some(p) = &settings.codex_provider {
+        if let Some((k, v)) = crate::agent::spawn::codex_provider_env(p) {
             cmd.env(k, v);
         }
     }
@@ -2607,13 +2600,33 @@ async fn codex_side_question(
         "--skip-git-repo-check".into(),
     ];
 
-    // Inherit model from source run (skip Claude model names that Codex rejects)
-    if let Some(ref m) = source.model {
-        let is_claude_model = m.is_empty()
-            || m.contains("claude")
-            || m.contains("opus")
-            || m.contains("sonnet")
-            || m.contains("haiku");
+    // Resolve the configured Codex provider so the side question routes to the same gateway as
+    // the main run (otherwise a custom/gateway provider would be ignored → wrong provider or an
+    // auth error). Mirrors the normal run path: `-c model_providers.*` overrides + env_key=api_key.
+    let user_settings = storage::settings::get_user_settings();
+    let agent_settings = storage::settings::get_agent_settings(&source.agent);
+    let adapter = adapter::build_adapter_settings(&agent_settings, &user_settings, None);
+    let codex_provider = adapter.codex_provider.clone();
+    if let Some(ref p) = codex_provider {
+        codex_args.extend(crate::agent::spawn::codex_provider_config_args(p));
+    }
+
+    // Model: a provider-pinned model wins; otherwise inherit the source run's model (skipping
+    // Claude model names that Codex rejects).
+    let provider_model = codex_provider
+        .as_ref()
+        .map(|p| p.model.clone())
+        .filter(|m| !m.is_empty());
+    if let Some(m) = provider_model {
+        codex_args.push("--model".into());
+        codex_args.push(m);
+    } else if let Some(ref m) = source.model {
+        let lm = m.to_lowercase();
+        let is_claude_model = lm.is_empty()
+            || lm.contains("claude")
+            || lm.contains("opus")
+            || lm.contains("sonnet")
+            || lm.contains("haiku");
         if !is_claude_model {
             codex_args.push("--model".into());
             codex_args.push(m.clone());
@@ -2626,10 +2639,11 @@ async fn codex_side_question(
     let effective_cwd = &source.cwd;
 
     log::debug!(
-        "[btw] codex_side_question: btw_id={}, cwd={}, args_len={}",
+        "[btw] codex_side_question: btw_id={}, cwd={}, args_len={}, provider={:?}",
         btw_id,
         effective_cwd,
-        codex_args.len()
+        codex_args.len(),
+        codex_provider.as_ref().map(|p| &p.id)
     );
 
     let mut cmd = Command::new(&codex_bin);
@@ -2643,6 +2657,12 @@ async fn codex_side_question(
         .stderr(std::process::Stdio::piped())
         .hide_console()
         .kill_on_drop(true);
+    // Provider API key (env_key=api_key), same as the main run path.
+    if let Some(ref p) = codex_provider {
+        if let Some((k, v)) = crate::agent::spawn::codex_provider_env(p) {
+            cmd.env(k, v);
+        }
+    }
 
     let mut child = cmd
         .spawn()

--- a/src-tauri/src/storage/cli_sessions_common.rs
+++ b/src-tauri/src/storage/cli_sessions_common.rs
@@ -5,9 +5,11 @@
 //! the two implementations stay in sync.
 
 use crate::models::ImportWatermark;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 // ── Shared types ────────────────────────────────────────────────────
 
@@ -90,6 +92,85 @@ pub fn sha256_short(s: &str) -> String {
 /// Generate an event-level key from line_key + event type + index.
 pub fn event_key(lk: &str, event_type: &str, n: usize) -> String {
     format!("v1:{}#{}#{}", lk, event_type, n)
+}
+
+// ── Generic per-file scan cache ─────────────────────────────────────
+
+/// Disk-backed scan cache keyed by file path + (mtime_ns, size). A cached entry
+/// is reused only when both the modification time and size match, so any edit to
+/// a rollout file invalidates its entry. `T` is the per-file scan result.
+///
+/// Shared by `codex_usage` (token aggregation) and `codex_sessions` (discovery
+/// summaries) so unchanged rollout files are never re-parsed.
+#[derive(Serialize, Deserialize)]
+pub struct DiskScanCache<T> {
+    pub version: u32,
+    /// path → cached scan of that file.
+    pub manifest: HashMap<String, CachedFile<T>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CachedFile<T> {
+    pub mtime_ns: u128,
+    pub size: u64,
+    pub data: T,
+}
+
+impl<T> DiskScanCache<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// Read and validate a cache file; `None` on missing/corrupt/version mismatch.
+    pub fn read(path: &Path, version: u32) -> Option<Self> {
+        let raw = std::fs::read_to_string(path).ok()?;
+        let cache: Self = serde_json::from_str(&raw).ok()?;
+        if cache.version != version {
+            return None;
+        }
+        Some(cache)
+    }
+
+    /// Atomically write the cache (write tmp + rename). Best-effort: errors ignored.
+    pub fn write(&self, path: &Path) {
+        if let Some(parent) = path.parent() {
+            let _ = crate::storage::ensure_dir(parent);
+        }
+        let Ok(json) = serde_json::to_string(self) else {
+            return;
+        };
+        let tmp = path.with_extension("json.tmp");
+        if std::fs::write(&tmp, &json).is_ok() {
+            let _ = std::fs::rename(&tmp, path);
+        }
+    }
+
+    /// Take the cached scan for `key` if its (mtime_ns, size) still match, removing
+    /// it from the old manifest. `None` means the file is new or changed and must
+    /// be re-scanned.
+    pub fn take_if_fresh(&mut self, key: &str, mtime_ns: u128, size: u64) -> Option<T> {
+        match self.manifest.remove(key) {
+            Some(cf) if cf.mtime_ns == mtime_ns && cf.size == size => Some(cf.data),
+            _ => None,
+        }
+    }
+}
+
+/// Convenience: a fresh empty manifest of the given version.
+pub fn empty_scan_cache<T>(version: u32) -> DiskScanCache<T> {
+    DiskScanCache {
+        version,
+        manifest: HashMap::new(),
+    }
+}
+
+/// Stable string key for a path, used as the cache manifest key.
+pub fn cache_key(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}
+
+/// Where per-scan caches live (under the app data dir).
+pub fn scan_cache_path(filename: &str) -> PathBuf {
+    crate::storage::data_dir().join(filename)
 }
 
 /// Load `source_key` set from an import-index file for crash-recovery dedup.

--- a/src-tauri/src/storage/codex_sessions.rs
+++ b/src-tauri/src/storage/codex_sessions.rs
@@ -16,11 +16,12 @@ use crate::storage::cli_sessions::{
     build_imported_index, build_imported_index_cached, invalidate_imported_cache,
 };
 use crate::storage::cli_sessions_common::{
-    event_key, load_import_skip_set, sha256_short, CliSessionSummary, DiscoverResult, ImportResult,
-    SyncResult,
+    cache_key, event_key, load_import_skip_set, scan_cache_path, sha256_short, CachedFile,
+    CliSessionSummary, DiscoverResult, DiskScanCache, ImportResult, SyncResult,
 };
 use crate::storage::events::{is_replayable, EventWriter};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
@@ -33,6 +34,26 @@ use std::time::{Duration, SystemTime};
 
 const MAX_DISCOVER_CANDIDATES: usize = 500;
 const SCAN_HEAD_LINES_FOR_FIRST_PROMPT: usize = 100;
+const SUMMARY_CACHE_VERSION: u32 = 1;
+
+fn summary_cache_path() -> PathBuf {
+    scan_cache_path("codex-summary-scan-cache.json")
+}
+
+/// Cacheable per-rollout-file scan used to build discovery summaries. Aggregating
+/// these across a thread's files (mtime asc) reproduces the old single-pass
+/// `build_summary` result, but unchanged files are skipped via the disk cache.
+#[derive(Clone, Default, Serialize, Deserialize)]
+struct SummaryFileScan {
+    /// Count of `event_msg/task_complete` records in this file.
+    task_complete_count: u32,
+    /// Last `timestamp` field seen in the file (for last_activity_at).
+    last_ts: Option<String>,
+    /// First `user_message` text within the head window (truncated for the prompt preview).
+    first_user_message: Option<String>,
+    /// Last `turn_context.payload.model` seen in the file (real model name).
+    last_model: Option<String>,
+}
 
 // ── Paths ────────────────────────────────────────────────────────────
 
@@ -223,14 +244,17 @@ pub fn discover_sessions(target_cwd: &str) -> Result<DiscoverResult, String> {
         }
     };
     let imported = build_imported_index_cached(Duration::from_secs(30));
-    discover_sessions_in_root(&root, target_cwd, &imported)
+    discover_sessions_in_root(&root, target_cwd, &imported, &summary_cache_path())
 }
 
-/// Testable inner: discovery against an explicit root + imported-index.
+/// Testable inner: discovery against an explicit root + imported-index. The
+/// summary scan cache lives at `cache_path` (a parameter so tests give each run
+/// its own file — no shared global cache state).
 fn discover_sessions_in_root(
     root: &Path,
     target_cwd: &str,
     imported: &crate::storage::cli_sessions::ImportedIndex,
+    cache_path: &Path,
 ) -> Result<DiscoverResult, String> {
     let start = std::time::Instant::now();
     if !root.exists() {
@@ -270,6 +294,11 @@ fn discover_sessions_in_root(
         })
         .collect();
 
+    // Scan each rollout's body once, reusing unchanged files from the disk cache
+    // (key = path + mtime_ns + size). This is the expensive part of discovery —
+    // it used to be a single-threaded per-thread re-parse on every call.
+    let scans = scan_summary_files(&parsed, cache_path);
+
     // Group by thread_id
     let mut groups: HashMap<String, Vec<RolloutFileInfo>> = HashMap::new();
     for fi in parsed {
@@ -289,7 +318,7 @@ fn discover_sessions_in_root(
             if !show_all && latest.meta.cwd != target_cwd {
                 return None;
             }
-            build_summary(&thread_id, &files, imported)
+            build_summary(&thread_id, &files, &scans, imported)
         })
         .collect();
 
@@ -309,9 +338,129 @@ fn discover_sessions_in_root(
     })
 }
 
+/// Scan one rollout's body into a cacheable `SummaryFileScan`.
+///
+/// Mirrors the per-file pass the old `build_summary` did inline: counts
+/// `task_complete`, tracks the last timestamp, the first head-window
+/// `user_message`, and the last `turn_context` model.
+fn scan_summary_file(path: &Path) -> SummaryFileScan {
+    let mut scan = SummaryFileScan::default();
+    let Ok(file) = File::open(path) else {
+        return scan;
+    };
+    let mut head_seen = 0usize;
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(json) = serde_json::from_str::<Value>(trimmed) else {
+            continue;
+        };
+        if let Some(ts) = json.get("timestamp").and_then(|v| v.as_str()) {
+            scan.last_ts = Some(ts.to_string());
+        }
+        let outer_type = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if outer_type == "event_msg" {
+            let inner = json
+                .get("payload")
+                .and_then(|p| p.get("type"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if inner == "task_complete" {
+                scan.task_complete_count = scan.task_complete_count.saturating_add(1);
+            }
+            if scan.first_user_message.is_none()
+                && inner == "user_message"
+                && head_seen < SCAN_HEAD_LINES_FOR_FIRST_PROMPT
+            {
+                if let Some(text) = json
+                    .get("payload")
+                    .and_then(|p| p.get("message"))
+                    .and_then(|v| v.as_str())
+                {
+                    scan.first_user_message = Some(truncate_prompt(text));
+                }
+            }
+        } else if outer_type == "turn_context" {
+            if let Some(m) = json
+                .get("payload")
+                .and_then(|p| p.get("model"))
+                .and_then(|v| v.as_str())
+            {
+                scan.last_model = Some(m.to_string());
+            }
+        }
+        head_seen += 1;
+    }
+    scan
+}
+
+/// Scan all discovered rollout files into a `path → SummaryFileScan` map, reusing
+/// unchanged files from the disk cache at `cache_path` and re-scanning only
+/// new/modified ones in parallel. The refreshed cache is written back
+/// (best-effort). `cache_path` is a parameter (not a global) so tests can point
+/// each invocation at its own file with no shared mutable state.
+fn scan_summary_files(
+    files: &[RolloutFileInfo],
+    cache_path: &Path,
+) -> HashMap<String, SummaryFileScan> {
+    let mut old_cache = DiskScanCache::<SummaryFileScan>::read(cache_path, SUMMARY_CACHE_VERSION)
+        .unwrap_or_else(|| {
+            crate::storage::cli_sessions_common::empty_scan_cache(SUMMARY_CACHE_VERSION)
+        });
+
+    // Split into cache hits (reused as-is) and misses (need a fresh scan). Pull
+    // hits out of the old cache first so the parallel scan only touches misses.
+    let mut result: HashMap<String, SummaryFileScan> = HashMap::new();
+    let mut misses: Vec<&RolloutFileInfo> = Vec::new();
+    for f in files {
+        let key = cache_key(&f.path);
+        match old_cache.take_if_fresh(&key, f.mtime_ns, f.size) {
+            Some(data) => {
+                result.insert(key, data);
+            }
+            None => misses.push(f),
+        }
+    }
+
+    let scanned: Vec<(String, SummaryFileScan)> = misses
+        .par_iter()
+        .map(|f| (cache_key(&f.path), scan_summary_file(&f.path)))
+        .collect();
+    result.extend(scanned);
+
+    // Rebuild the manifest from exactly the files we just discovered so stale
+    // entries (deleted rollouts) are dropped, then persist.
+    let manifest: HashMap<String, CachedFile<SummaryFileScan>> = files
+        .iter()
+        .filter_map(|f| {
+            let key = cache_key(&f.path);
+            result.get(&key).map(|data| {
+                (
+                    key,
+                    CachedFile {
+                        mtime_ns: f.mtime_ns,
+                        size: f.size,
+                        data: data.clone(),
+                    },
+                )
+            })
+        })
+        .collect();
+    DiskScanCache {
+        version: SUMMARY_CACHE_VERSION,
+        manifest,
+    }
+    .write(cache_path);
+
+    result
+}
+
 fn build_summary(
     thread_id: &str,
     files_asc: &[RolloutFileInfo],
+    scans: &HashMap<String, SummaryFileScan>,
     imported: &crate::storage::cli_sessions::ImportedIndex,
 ) -> Option<CliSessionSummary> {
     let earliest = files_asc.first()?;
@@ -326,62 +475,23 @@ fn build_summary(
     // the latest-rollout-authoritative rule used for cwd/cli_version/provider below.
     let mut model: Option<String> = None;
 
+    // Merge per-file scans (files in mtime-asc order) to reproduce the old
+    // single-pass result: sum task_complete; first head-window prompt wins;
+    // latest non-empty last_ts and model win.
     for f in files_asc {
         total_size = total_size.saturating_add(f.size);
-        // Scan file for task_complete count + last_ts + first_prompt
-        if let Ok(file) = File::open(&f.path) {
-            let mut head_seen = 0usize;
-            for line in BufReader::new(file).lines().map_while(Result::ok) {
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                let Ok(json) = serde_json::from_str::<Value>(trimmed) else {
-                    continue;
-                };
-                if let Some(ts) = json.get("timestamp").and_then(|v| v.as_str()) {
-                    last_activity_ts = Some(ts.to_string());
-                }
-                let outer_type = json.get("type").and_then(|v| v.as_str()).unwrap_or("");
-                if outer_type == "event_msg" {
-                    let inner = json
-                        .get("payload")
-                        .and_then(|p| p.get("type"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    if inner == "task_complete" {
-                        message_count = message_count.saturating_add(1);
-                    }
-                    if first_prompt.is_none()
-                        && inner == "user_message"
-                        && head_seen < SCAN_HEAD_LINES_FOR_FIRST_PROMPT
-                    {
-                        if let Some(text) = json
-                            .get("payload")
-                            .and_then(|p| p.get("message"))
-                            .and_then(|v| v.as_str())
-                        {
-                            first_prompt = Some(truncate_prompt(text));
-                        }
-                    }
-                } else if outer_type == "turn_context" {
-                    if let Some(m) = json
-                        .get("payload")
-                        .and_then(|p| p.get("model"))
-                        .and_then(|v| v.as_str())
-                    {
-                        model = Some(m.to_string());
-                    }
-                }
-                head_seen += 1;
-                if head_seen > SCAN_HEAD_LINES_FOR_FIRST_PROMPT
-                    && first_prompt.is_some()
-                    && message_count > 0
-                {
-                    // Done with head; keep streaming for last_activity_ts
-                    // (cheap: just keeps iterating)
-                }
-            }
+        let Some(scan) = scans.get(&cache_key(&f.path)) else {
+            continue;
+        };
+        message_count = message_count.saturating_add(scan.task_complete_count);
+        if scan.last_ts.is_some() {
+            last_activity_ts = scan.last_ts.clone();
+        }
+        if first_prompt.is_none() {
+            first_prompt = scan.first_user_message.clone();
+        }
+        if scan.last_model.is_some() {
+            model = scan.last_model.clone();
         }
     }
 
@@ -1462,6 +1572,13 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// A summary-scan cache path inside a test's own temp dir. Each test owns its
+    /// own file, so there is zero shared mutable cache state across parallel tests
+    /// (no process-global env var, no shared OnceLock).
+    fn test_cache_path(tmp: &std::path::Path) -> std::path::PathBuf {
+        tmp.join("summary-scan-cache.json")
+    }
+
     fn writer() -> Arc<EventWriter> {
         Arc::new(EventWriter::new())
     }
@@ -1931,7 +2048,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         // Don't create the sessions/ subdir at all — fully nonexistent root path
         let nonexistent = tmp.path().join("does-not-exist");
-        let result = discover_sessions_in_root(&nonexistent, "/", &empty_imported()).unwrap();
+        let result = discover_sessions_in_root(
+            &nonexistent,
+            "/",
+            &empty_imported(),
+            &test_cache_path(tmp.path()),
+        )
+        .unwrap();
         assert_eq!(result.sessions.len(), 0);
         assert!(!result.truncated);
     }
@@ -1979,7 +2102,9 @@ mod tests {
             ],
         );
 
-        let result = discover_sessions_in_root(root, "/", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         assert_eq!(result.sessions.len(), 2, "two distinct threads");
         let t1 = result
             .sessions
@@ -2015,7 +2140,9 @@ mod tests {
                 r#"{"timestamp":"2026-02-10T00:03:00Z","type":"event_msg","payload":{"type":"task_complete"}}"#,
             ],
         );
-        let result = discover_sessions_in_root(root, "/", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         let s = result
             .sessions
             .iter()
@@ -2040,7 +2167,9 @@ mod tests {
             "\n",
         );
         std::fs::write(&path, content).unwrap();
-        let result = discover_sessions_in_root(root, "/", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         let s = result
             .sessions
             .iter()
@@ -2086,7 +2215,9 @@ mod tests {
 
         // Discovery truncates to 500 (mtime desc keeps the 505 "new" files;
         // first 500 of them are kept; "old" files are evicted).
-        let result = discover_sessions_in_root(root, "/", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         assert!(result.truncated);
         assert_eq!(result.total, 510, "truncated total = candidate file count");
         assert!(
@@ -2127,7 +2258,9 @@ mod tests {
             "/proj-b",
             &[],
         );
-        let result = discover_sessions_in_root(root, "/proj-a", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/proj-a", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert_eq!(result.sessions[0].session_id, "thread-a");
     }
@@ -2158,7 +2291,9 @@ mod tests {
             "/proj-new",
             &[],
         );
-        let result = discover_sessions_in_root(root, "/", &empty_imported()).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &empty_imported(), &test_cache_path(root))
+                .unwrap();
         assert_eq!(result.sessions.len(), 1, "single thread despite two cwds");
         assert_eq!(
             result.sessions[0].cwd, "/proj-new",
@@ -2339,12 +2474,81 @@ mod tests {
             "run-existing".to_string(),
         );
 
-        let result = discover_sessions_in_root(root, "/", &imported).unwrap();
+        let result =
+            discover_sessions_in_root(root, "/", &imported, &test_cache_path(root)).unwrap();
         assert_eq!(result.sessions.len(), 1);
         assert!(result.sessions[0].already_imported);
         assert_eq!(
             result.sessions[0].existing_run_id.as_deref(),
             Some("run-existing")
+        );
+    }
+
+    // ── Summary scan cache: hit + invalidation ──
+
+    /// Build a `RolloutFileInfo` from an on-disk path, reading current metadata.
+    fn rollout_info(path: &std::path::Path) -> RolloutFileInfo {
+        let md = std::fs::metadata(path).unwrap();
+        let mtime = md.modified().unwrap();
+        RolloutFileInfo {
+            path: path.to_path_buf(),
+            size: md.len(),
+            mtime,
+            mtime_ns: mtime_ns(&md),
+            meta: RolloutMeta::default(),
+        }
+    }
+
+    #[test]
+    fn summary_scan_cache_serves_hit_and_invalidates_on_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        // This test's own cache file — no shared global state with other tests.
+        let cache = test_cache_path(tmp.path());
+        let path = write_rollout(
+            tmp.path(),
+            "2026",
+            "03",
+            "01",
+            "rollout-cache.jsonl",
+            "thread-cache",
+            "/p",
+            &[
+                r#"{"timestamp":"2026-03-01T00:01:00Z","type":"event_msg","payload":{"type":"task_complete"}}"#,
+            ],
+        );
+
+        // First pass: scans the file, count = 1, and populates the disk cache.
+        let info = rollout_info(&path);
+        let first = scan_summary_files(std::slice::from_ref(&info), &cache);
+        assert_eq!(first[&cache_key(&path)].task_complete_count, 1);
+
+        // Append a second task_complete on disk, but call with the STALE
+        // (mtime_ns,size). The cache key still matches → cached scan reused,
+        // so the new line is NOT seen (count stays 1). Proves a cache hit.
+        let mut content = std::fs::read_to_string(&path).unwrap();
+        content.push_str(
+            "{\"timestamp\":\"2026-03-01T00:02:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\"}}\n",
+        );
+        std::fs::write(&path, &content).unwrap();
+        let stale_hit = scan_summary_files(std::slice::from_ref(&info), &cache);
+        assert_eq!(
+            stale_hit[&cache_key(&path)].task_complete_count,
+            1,
+            "unchanged (mtime,size) key must reuse cached scan"
+        );
+
+        // Now pass the real updated metadata → key differs → re-scan picks up
+        // both task_complete lines. Proves invalidation on file change.
+        let updated = rollout_info(&path);
+        assert!(
+            updated.size != info.size || updated.mtime_ns != info.mtime_ns,
+            "appended bytes should change size/mtime"
+        );
+        let refreshed = scan_summary_files(std::slice::from_ref(&updated), &cache);
+        assert_eq!(
+            refreshed[&cache_key(&path)].task_complete_count,
+            2,
+            "changed file must be re-scanned"
         );
     }
 }

--- a/src-tauri/src/storage/codex_usage.rs
+++ b/src-tauri/src/storage/codex_usage.rs
@@ -15,6 +15,7 @@
 
 use crate::models::{DailyAggregate, ModelAggregate, UsageOverview};
 use crate::pricing;
+use crate::storage::cli_sessions_common::{cache_key, scan_cache_path, CachedFile, DiskScanCache};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -36,20 +37,6 @@ struct FileData {
     daily: HashMap<String, HashMap<String, TokenCounts>>,
     /// dates that had at least one session turn (for activity/streaks)
     dates: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct DiskCache {
-    version: u32,
-    /// path → (mtime_ns, size, FileData)
-    manifest: HashMap<String, CachedFile>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct CachedFile {
-    mtime_ns: u128,
-    size: u64,
-    data: FileData,
 }
 
 fn sessions_dir() -> Option<PathBuf> {
@@ -193,31 +180,7 @@ fn scan_single_rollout(path: &Path) -> FileData {
 }
 
 fn disk_cache_path() -> PathBuf {
-    super::data_dir().join("codex-usage-scan-cache.json")
-}
-
-fn read_disk_cache() -> Option<DiskCache> {
-    let raw = std::fs::read_to_string(disk_cache_path()).ok()?;
-    let cache: DiskCache = serde_json::from_str(&raw).ok()?;
-    if cache.version != DISK_CACHE_VERSION {
-        return None;
-    }
-    Some(cache)
-}
-
-fn write_disk_cache(cache: &DiskCache) {
-    let path = disk_cache_path();
-    if let Some(parent) = path.parent() {
-        let _ = super::ensure_dir(parent);
-    }
-    let json = match serde_json::to_string(cache) {
-        Ok(j) => j,
-        Err(_) => return,
-    };
-    let tmp = path.with_extension("json.tmp");
-    if std::fs::write(&tmp, &json).is_ok() {
-        let _ = std::fs::rename(&tmp, &path);
-    }
+    scan_cache_path("codex-usage-scan-cache.json")
 }
 
 /// Read aggregated global Codex usage. `days` filters the daily window (None = all time).
@@ -229,20 +192,22 @@ pub fn read_global_codex_usage(days: Option<u32>) -> Result<UsageOverview, Strin
     let files = list_rollout_files(&dir);
     log::debug!("[codex_usage] {} rollout files", files.len());
 
-    let mut old_cache = read_disk_cache().map(|c| c.manifest).unwrap_or_default();
-    let mut new_manifest: HashMap<String, CachedFile> = HashMap::new();
+    let mut old_cache = DiskScanCache::<FileData>::read(&disk_cache_path(), DISK_CACHE_VERSION)
+        .unwrap_or_else(|| {
+            crate::storage::cli_sessions_common::empty_scan_cache(DISK_CACHE_VERSION)
+        });
+    let mut new_manifest: HashMap<String, CachedFile<FileData>> = HashMap::new();
 
     // date → model → TokenCounts (merged across all files)
     let mut merged: HashMap<String, HashMap<String, TokenCounts>> = HashMap::new();
     let mut all_dates: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for (path, mtime_ns, size) in files {
-        let key = path.to_string_lossy().to_string();
+        let key = cache_key(&path);
         // Reuse cached scan if unchanged.
-        let data = match old_cache.remove(&key) {
-            Some(cf) if cf.mtime_ns == mtime_ns && cf.size == size => cf.data,
-            _ => scan_single_rollout(&path),
-        };
+        let data = old_cache
+            .take_if_fresh(&key, mtime_ns, size)
+            .unwrap_or_else(|| scan_single_rollout(&path));
         for (date, models) in &data.daily {
             let day = merged.entry(date.clone()).or_default();
             for (model, tc) in models {
@@ -265,10 +230,11 @@ pub fn read_global_codex_usage(days: Option<u32>) -> Result<UsageOverview, Strin
         );
     }
 
-    write_disk_cache(&DiskCache {
+    DiskScanCache {
         version: DISK_CACHE_VERSION,
         manifest: new_manifest,
-    });
+    }
+    .write(&disk_cache_path());
 
     Ok(build_overview(merged, all_dates, days))
 }

--- a/src/lib/components/AgentAuthBadge.svelte
+++ b/src/lib/components/AgentAuthBadge.svelte
@@ -5,6 +5,7 @@
   import { t } from "$lib/i18n/index.svelte";
   import * as api from "$lib/api";
   import { CODEX_PROVIDER_PRESETS } from "$lib/utils/codex-provider-presets";
+  import { computeDropdownStyle, attachDismissHandlers } from "$lib/utils/dropdown";
   import { dbgWarn } from "$lib/utils/debug";
 
   // Unified hero auth badge for both agents. Auth is a simple two-way choice — OAuth (the
@@ -113,13 +114,7 @@
 
   function updateDropdownPosition() {
     if (!buttonEl) return;
-    const rect = buttonEl.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - rect.bottom;
-    if (spaceBelow < 240) {
-      dropdownStyle = `position:fixed; bottom:${window.innerHeight - rect.top + 4}px; left:${rect.left}px; z-index:50;`;
-    } else {
-      dropdownStyle = `position:fixed; top:${rect.bottom + 4}px; left:${rect.left}px; z-index:50;`;
-    }
+    dropdownStyle = computeDropdownStyle(buttonEl, 240);
   }
 
   async function selectOAuth() {
@@ -153,21 +148,17 @@
   onMount(() => {
     // Codex status is loaded by the $effect above (reactive to isCodex); here we only
     // wire the dropdown's outside-click/Escape handlers + the auth-changed refresh.
-    function onDocClick(e: MouseEvent) {
-      if (dropdownOpen && wrapperEl && !wrapperEl.contains(e.target as Node)) dropdownOpen = false;
-    }
-    function onDocKeydown(e: KeyboardEvent) {
-      if (dropdownOpen && e.key === "Escape") dropdownOpen = false;
-    }
+    const detach = attachDismissHandlers({
+      getWrapper: () => wrapperEl,
+      isOpen: () => dropdownOpen,
+      close: () => (dropdownOpen = false),
+    });
     function onCodexAuthChanged() {
       void loadCodexStatus();
     }
-    document.addEventListener("mousedown", onDocClick, true);
-    document.addEventListener("keydown", onDocKeydown);
     window.addEventListener("ocv:codex-auth-changed", onCodexAuthChanged);
     return () => {
-      document.removeEventListener("mousedown", onDocClick, true);
-      document.removeEventListener("keydown", onDocKeydown);
+      detach();
       window.removeEventListener("ocv:codex-auth-changed", onCodexAuthChanged);
     };
   });

--- a/src/lib/components/AuthSourceBadge.svelte
+++ b/src/lib/components/AuthSourceBadge.svelte
@@ -8,6 +8,8 @@
     PRESET_CATEGORIES,
   } from "$lib/utils/platform-presets";
   import { dbg } from "$lib/utils/debug";
+  import { computeDropdownStyle, attachDismissHandlers } from "$lib/utils/dropdown";
+  import { onMount } from "svelte";
 
   let {
     authOverview = null,
@@ -112,13 +114,7 @@
 
   function updateDropdownPosition() {
     if (!buttonEl) return;
-    const rect = buttonEl.getBoundingClientRect();
-    const spaceBelow = window.innerHeight - rect.bottom;
-    if (spaceBelow < 300) {
-      dropdownStyle = `position:fixed; bottom:${window.innerHeight - rect.top + 4}px; left:${rect.left}px; z-index:50;`;
-    } else {
-      dropdownStyle = `position:fixed; top:${rect.bottom + 4}px; left:${rect.left}px; z-index:50;`;
-    }
+    dropdownStyle = computeDropdownStyle(buttonEl, 300);
   }
 
   function selectMode(mode: string) {
@@ -138,26 +134,13 @@
     }
   }
 
-  import { onMount } from "svelte";
-
-  onMount(() => {
-    function onDocClick(e: MouseEvent) {
-      if (dropdownOpen && wrapperEl && !wrapperEl.contains(e.target as Node)) {
-        dropdownOpen = false;
-      }
-    }
-    function onDocKeydown(e: KeyboardEvent) {
-      if (dropdownOpen && e.key === "Escape") {
-        dropdownOpen = false;
-      }
-    }
-    document.addEventListener("mousedown", onDocClick, true);
-    document.addEventListener("keydown", onDocKeydown);
-    return () => {
-      document.removeEventListener("mousedown", onDocClick, true);
-      document.removeEventListener("keydown", onDocKeydown);
-    };
-  });
+  onMount(() =>
+    attachDismissHandlers({
+      getWrapper: () => wrapperEl,
+      isOpen: () => dropdownOpen,
+      close: () => (dropdownOpen = false),
+    }),
+  );
 </script>
 
 {#if hasRun && authSourceLabel}

--- a/src/lib/components/ModelSelector.svelte
+++ b/src/lib/components/ModelSelector.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { getCliModels, getCodexModels } from "$lib/stores/cli-info.svelte";
+  import { getModelsForAgent } from "$lib/stores/cli-info.svelte";
   import { t } from "$lib/i18n/index.svelte";
 
   let {
@@ -16,7 +16,7 @@
   let showCustom = $state(false);
   let customModel = $state("");
 
-  let models = $derived(agent === "codex" ? getCodexModels() : getCliModels());
+  let models = $derived(getModelsForAgent(agent));
 
   let displayValue = $derived.by(() => {
     const found = models.find((mdl) => mdl.value === value);

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -21,6 +21,7 @@
     filterSlashCommands,
     mergeWithVirtual,
     parseVirtualAction,
+    resolveVirtualCommand,
     getCommandInteraction,
     getArgumentHint,
     shouldBackFromSubView,
@@ -29,7 +30,6 @@
     classifyCloseReason,
     groupSlashCommands,
     extractSlashQuery,
-    VIRTUAL_COMMANDS,
   } from "$lib/utils/slash-commands";
   import type { SlashCommandGroups } from "$lib/utils/slash-commands";
   import type { MessageKey } from "$lib/i18n/types";
@@ -740,8 +740,9 @@
       return;
     }
 
-    // immediate: execute directly without touching inputText/pastedBlocks/attachments
-    const vDef = VIRTUAL_COMMANDS.find((v) => v.name === cmd.name);
+    // immediate: execute directly without touching inputText/pastedBlocks/attachments.
+    // Resolve agent-aware so per-agent variants pick the correct _action.
+    const vDef = resolveVirtualCommand(cmd.name, agent) ?? cmd;
     if (vDef) {
       if (typeof vDef["_action"] === "string" && onVirtualCommand) {
         onVirtualCommand(vDef["_action"] as string, "");
@@ -1140,8 +1141,10 @@
           }
           return; // Always consume /model command, even without handler
         }
-        // Navigation virtual commands (e.g. /config → /settings?tab=cli-config)
-        const vDef = VIRTUAL_COMMANDS.find((v) => v.name === virtual.name);
+        // Navigation virtual commands (e.g. /config → /settings?tab=cli-config).
+        // Resolve agent-aware so per-agent variants (Codex /rewind → "codex-rewind")
+        // dispatch the right _action instead of the first same-named entry.
+        const vDef = resolveVirtualCommand(virtual.name, agent);
         if (vDef && typeof vDef["_navigate"] === "string") {
           inputText = "";
           if (textareaEl) textareaEl.style.height = "auto";

--- a/src/lib/components/SessionStatusBar.svelte
+++ b/src/lib/components/SessionStatusBar.svelte
@@ -4,7 +4,7 @@
   import type { TaskRun, McpServerInfo, CliModelInfo } from "$lib/types";
   import type { TurnUsage } from "$lib/stores/types";
   import { dbg } from "$lib/utils/debug";
-  import { getCliModels, getCodexModels } from "$lib/stores/cli-info.svelte";
+  import { getModelsForAgent } from "$lib/stores/cli-info.svelte";
   import { t } from "$lib/i18n/index.svelte";
   import { fmtNumber } from "$lib/i18n/format";
   import { truncate, formatTokenCount, formatDuration, formatCostDisplay } from "$lib/utils/format";
@@ -213,13 +213,7 @@
 
   // ── Model selector dropdown ──
   // Use platform-specific models when a third-party provider is active
-  let models = $derived(
-    agent === "codex"
-      ? getCodexModels()
-      : platformModels.length > 0
-        ? platformModels
-        : getCliModels(),
-  );
+  let models = $derived(getModelsForAgent(agent, { platformModels }));
   let dropdownOpen = $state(false);
   let focusedModelIdx = $state(-1);
   let modelBtnEl: HTMLButtonElement | undefined = $state();
@@ -372,8 +366,7 @@
 
   let modelLabel = $derived.by(() => {
     // Check agent-specific models first, then platform/CLI models
-    const all =
-      agent === "codex" ? getCodexModels() : [...(platformModels ?? []), ...getCliModels()];
+    const all = getModelsForAgent(agent, { platformModels, merge: true });
     const found = all.find((m) => m.value === model);
     if (found) return found.displayName;
     const fuzzy = all.find((m) => model.includes(m.value) && m.value !== "default");

--- a/src/lib/stores/cli-info.svelte.ts
+++ b/src/lib/stores/cli-info.svelte.ts
@@ -57,6 +57,27 @@ export function getCodexDefaultModel(): string | undefined {
   return _codex?.defaultModel ?? undefined;
 }
 
+/**
+ * Resolve the model list to show for an agent, folding in third-party platform models.
+ * Centralizes the `agent === "codex" ? getCodexModels() : …CLI/platform…` branch that
+ * was copy-pasted across ModelSelector, SessionStatusBar, and the chat page.
+ *
+ * - Codex → the live Codex catalog (platform models don't apply).
+ * - Other agents → platform models when present (see `merge`), else the CLI catalog.
+ *   - `merge: false` (default): platform models REPLACE the CLI list when non-empty.
+ *   - `merge: true`: platform models are PREPENDED to the CLI list (used where label
+ *     lookups need to resolve both platform and CLI model values).
+ */
+export function getModelsForAgent(
+  agent: string,
+  opts: { platformModels?: CliModelInfo[]; merge?: boolean } = {},
+): CliModelInfo[] {
+  if (agent === "codex") return getCodexModels();
+  const platform = opts.platformModels ?? [];
+  if (opts.merge) return [...platform, ...getCliModels()];
+  return platform.length > 0 ? platform : getCliModels();
+}
+
 export async function loadCodexModels(force = false): Promise<CodexModelList | null> {
   if (_codexLoaded && !force) return _codex;
   if (_codexLoading) return _codex; // dedupe concurrent calls

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -24,6 +24,7 @@ export {
   updateInstalledVersion,
   getCodexVersion,
   getCodexModels,
+  getModelsForAgent,
   getCodexDefaultModel,
   loadCodexModels,
 } from "./cli-info.svelte";

--- a/src/lib/utils/__tests__/add-dir-action.test.ts
+++ b/src/lib/utils/__tests__/add-dir-action.test.ts
@@ -27,7 +27,11 @@ describe("executeAddDir", () => {
 
   // ── Codex-specific tests ──
 
-  it("codex + sessionAlive saves to settings (does not sendMessage)", async () => {
+  it("codex + sessionAlive saves to settings (does not sendMessage), reports next-session", async () => {
+    // Codex lacks supportsLiveAddDir: it consumes writableRoots once at spawn
+    // (first turn/start), so a mid-session add-dir is persisted and only takes
+    // effect on the next session / new thread — never the current thread. With a
+    // live session we surface the "next session" wording.
     const deps = makeDeps({
       getAgentSettings: vi.fn().mockResolvedValue({ add_dirs: [] }),
     });
@@ -38,10 +42,10 @@ describe("executeAddDir", () => {
       add_dirs: ["/tmp/codex-dir"],
     });
     const call = (deps.appendOutput as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(call).toContain("chat_addDirNextTurn");
+    expect(call).toContain("chat_addDirNextSession");
   });
 
-  it("codex + sessionAlive=false saves to settings", async () => {
+  it("codex + sessionAlive=false is a plain pre-session save", async () => {
     const deps = makeDeps({
       getAgentSettings: vi.fn().mockResolvedValue({ add_dirs: [] }),
     });
@@ -52,7 +56,7 @@ describe("executeAddDir", () => {
       add_dirs: ["/tmp/codex-dir"],
     });
     const call = (deps.appendOutput as ReturnType<typeof vi.fn>).mock.calls[0][0] as string;
-    expect(call).toContain("chat_addDirNextTurn");
+    expect(call).toContain("chat_addDirSaved");
   });
 
   it("user cancels dialog — no further action", async () => {

--- a/src/lib/utils/__tests__/agent-caps.test.ts
+++ b/src/lib/utils/__tests__/agent-caps.test.ts
@@ -8,6 +8,8 @@ describe("getAgentCaps", () => {
     expect(caps.supportsSessionInit).toBe(true);
     expect(caps.supportsPermissions).toBe(true);
     expect(caps.supportsSnapshots).toBe(true);
+    // Claude's `/add-dir` takes effect immediately on the running session.
+    expect(caps.supportsLiveAddDir).toBe(true);
   });
 
   it("returns bus-events-only caps for codex", () => {
@@ -16,6 +18,8 @@ describe("getAgentCaps", () => {
     expect(caps.supportsSessionInit).toBe(false);
     expect(caps.supportsPermissions).toBe(false);
     expect(caps.supportsSnapshots).toBe(false);
+    // Codex reads writableRoots at thread/start, so add-dir is persisted, not live.
+    expect(caps.supportsLiveAddDir).toBe(false);
   });
 
   it("returns minimal caps for unknown agent (never promotes to claude)", () => {
@@ -24,6 +28,7 @@ describe("getAgentCaps", () => {
     expect(caps.supportsSessionInit).toBe(false);
     expect(caps.supportsPermissions).toBe(false);
     expect(caps.supportsSnapshots).toBe(false);
+    expect(caps.supportsLiveAddDir).toBe(false);
   });
 
   it("codex and unknown caps differ (codex has supportsBusEvents)", () => {

--- a/src/lib/utils/__tests__/slash-commands.test.ts
+++ b/src/lib/utils/__tests__/slash-commands.test.ts
@@ -657,20 +657,38 @@ describe("parseVirtualAction", () => {
     });
   });
 
-  it("/side resolves to /btw via alias, preserving args", () => {
-    // Codex CLI's `/side` is OpenCovibe's `/btw` (ephemeral side question).
-    expect(parseVirtualAction("/side what is X")).toEqual({
+  it("/new, /exit, /quit resolve to /clear on Codex only (Codex CLI alias parity)", () => {
+    // GUI parity for Codex: /new starts a new chat (same as /clear); /exit and
+    // /quit don't quit the app — they leave the current chat back to the welcome
+    // page, again identical to /clear semantics. These aliases were added for
+    // Codex CLI parity, so they only fire for Codex.
+    expect(parseVirtualAction("/new", "codex")).toEqual({ name: "clear", args: "" });
+    expect(parseVirtualAction("/exit", "codex")).toEqual({ name: "clear", args: "" });
+    expect(parseVirtualAction("/quit", "codex")).toEqual({ name: "clear", args: "" });
+  });
+
+  it("/new, /exit, /quit fall through on Claude (no silent clear-context override)", () => {
+    // Claude CLI owns /exit and /quit (and has no /new). OpenCovibe must not
+    // intercept these as clear-context — they fall through to CLI passthrough.
+    expect(parseVirtualAction("/new", "claude")).toBeNull();
+    expect(parseVirtualAction("/exit", "claude")).toBeNull();
+    expect(parseVirtualAction("/quit", "claude")).toBeNull();
+    // Default agent is Claude — same fall-through behaviour.
+    expect(parseVirtualAction("/new")).toBeNull();
+    expect(parseVirtualAction("/exit")).toBeNull();
+  });
+
+  it("/side resolves to /btw on Codex only (Codex CLI alias parity)", () => {
+    // Codex CLI's `/side` is OpenCovibe's `/btw`. The alias is Codex-only.
+    expect(parseVirtualAction("/side what is X", "codex")).toEqual({
       name: "btw",
       args: "what is X",
     });
   });
 
-  it("/new and /exit both resolve to /clear via alias", () => {
-    // GUI parity: /new starts a new chat (same as /clear). /exit doesn't
-    // quit the app — it leaves the current chat back to the welcome page,
-    // again identical to /clear semantics.
-    expect(parseVirtualAction("/new")).toEqual({ name: "clear", args: "" });
-    expect(parseVirtualAction("/exit")).toEqual({ name: "clear", args: "" });
+  it("/side falls through on Claude (no silent /btw override)", () => {
+    expect(parseVirtualAction("/side what is X", "claude")).toBeNull();
+    expect(parseVirtualAction("/side what is X")).toBeNull();
   });
 });
 

--- a/src/lib/utils/add-dir.ts
+++ b/src/lib/utils/add-dir.ts
@@ -1,6 +1,7 @@
 import { quoteCliArg, normalizeDirPath, pathsEqual } from "./path-utils";
 import { dbg } from "./debug";
 import { getAgentFeatures } from "./agent-features";
+import { getAgentCaps } from "./agent-caps";
 
 export interface AddDirDeps {
   openDirectoryDialog: (title: string) => Promise<string | null>;
@@ -34,8 +35,13 @@ export async function executeAddDir(ctx: AddDirContext, deps: AddDirDeps): Promi
 
   const dirPath = normalizeDirPath(raw);
 
-  if (ctx.sessionAlive && ctx.agent !== "codex") {
-    // Claude: send /add-dir to CLI (instant effect)
+  // Agents whose CLI honors add-dir live (Claude) push it to the running session;
+  // others (Codex) read writable roots only at thread/start, so we persist to
+  // settings and the dir is picked up on the next spawn / new thread.
+  const liveAddDir = getAgentCaps(ctx.agent).supportsLiveAddDir;
+
+  if (ctx.sessionAlive && liveAddDir) {
+    // Live: send /add-dir to CLI (instant effect)
     const quoted = quoteCliArg(dirPath);
     if (!quoted) {
       deps.appendOutput(deps.t("chat_addDirFailed", { error: deps.t("chat_addDirInvalidPath") }));
@@ -44,16 +50,20 @@ export async function executeAddDir(ctx: AddDirContext, deps: AddDirDeps): Promi
     await deps.sendMessage(`/add-dir ${quoted}`);
     dbg("chat", "add-dir: sent to CLI", { path: dirPath });
   } else {
-    // Codex or no active session: persist to agent settings
+    // No live support, or no active session: persist to agent settings
     const settings = await deps.getAgentSettings(ctx.agent);
     const current = (settings.add_dirs ?? []).map(normalizeDirPath);
     if (!current.some((c) => pathsEqual(c, dirPath))) {
       await deps.updateAgentSettings(ctx.agent, {
         add_dirs: [...(settings.add_dirs ?? []), dirPath],
       });
+      // A running session that can't apply add-dir live consumes its writable roots
+      // once at spawn (first turn/start), so a mid-session add only lands on the next
+      // session / new thread — not the current thread's next turn. Pre-session it's a
+      // plain save (picked up when the session next starts).
       deps.appendOutput(
-        ctx.agent === "codex"
-          ? deps.t("chat_addDirNextTurn", { path: dirPath })
+        ctx.sessionAlive
+          ? deps.t("chat_addDirNextSession", { path: dirPath })
           : deps.t("chat_addDirSaved", { path: dirPath }),
       );
       dbg("chat", "add-dir: saved to settings", { path: dirPath, agent: ctx.agent });

--- a/src/lib/utils/agent-caps.ts
+++ b/src/lib/utils/agent-caps.ts
@@ -1,13 +1,18 @@
 /**
- * Per-agent protocol output capabilities.
- * Only describes what the CLI *emits* — not transport (ExecutionPath),
- * UI feature gates (AgentFeatures), or resume logic (canResumeStructurally).
+ * Per-agent protocol/runtime capabilities.
+ * Describes what the CLI *emits* and which session-runtime operations it honors —
+ * not UI feature gates (AgentFeatures) or resume logic (canResumeStructurally).
  */
 export interface AgentCapabilities {
   supportsBusEvents: boolean; // CLI produces structured bus-events
   supportsSessionInit: boolean; // CLI sends session_init
   supportsPermissions: boolean; // CLI supports can_use_tool
   supportsSnapshots: boolean; // CLI supports snapshot restore
+  // Add-dir applies live to the running session (Claude: `/add-dir` takes effect
+  // immediately). When false, add-dir is persisted to settings and applies later
+  // (Codex: writableRoots are read at thread/start, so a saved dir applies to the
+  // next spawn / new thread rather than the current turn).
+  supportsLiveAddDir: boolean;
 }
 
 const CLAUDE_CAPS: AgentCapabilities = {
@@ -15,6 +20,7 @@ const CLAUDE_CAPS: AgentCapabilities = {
   supportsSessionInit: true,
   supportsPermissions: true,
   supportsSnapshots: true,
+  supportsLiveAddDir: true,
 };
 
 const CODEX_CAPS: AgentCapabilities = {
@@ -22,6 +28,7 @@ const CODEX_CAPS: AgentCapabilities = {
   supportsSessionInit: false,
   supportsPermissions: false,
   supportsSnapshots: false,
+  supportsLiveAddDir: false,
 };
 
 // Minimal capability set — unknown agents should not be silently promoted to Claude
@@ -30,6 +37,7 @@ const MINIMAL_CAPS: AgentCapabilities = {
   supportsSessionInit: false,
   supportsPermissions: false,
   supportsSnapshots: false,
+  supportsLiveAddDir: false,
 };
 
 const CAPS_MAP: Record<string, AgentCapabilities> = {

--- a/src/lib/utils/dropdown.ts
+++ b/src/lib/utils/dropdown.ts
@@ -1,0 +1,43 @@
+// Shared dropdown positioning + dismissal helpers.
+// Both auth badges (and other anchored dropdowns) flip above the trigger when there
+// isn't enough room below, and close on outside-click / Escape. These helpers keep
+// that logic in one place instead of copy-pasting it into each component.
+
+/**
+ * Compute a `position:fixed` inline style for a dropdown anchored to `buttonEl`.
+ * Flips above the trigger when the space below is smaller than `minSpaceBelow`.
+ */
+export function computeDropdownStyle(buttonEl: HTMLElement, minSpaceBelow: number): string {
+  const rect = buttonEl.getBoundingClientRect();
+  const spaceBelow = window.innerHeight - rect.bottom;
+  if (spaceBelow < minSpaceBelow) {
+    return `position:fixed; bottom:${window.innerHeight - rect.top + 4}px; left:${rect.left}px; z-index:50;`;
+  }
+  return `position:fixed; top:${rect.bottom + 4}px; left:${rect.left}px; z-index:50;`;
+}
+
+/**
+ * Wire outside-click (capture-phase mousedown) and Escape to dismiss a dropdown.
+ * `isOpen` is read lazily so the handlers see the current open state; `close` runs
+ * when a dismissal gesture fires while open. Returns a teardown function — call it
+ * from the component's `onMount` cleanup.
+ */
+export function attachDismissHandlers(opts: {
+  getWrapper: () => HTMLElement | undefined;
+  isOpen: () => boolean;
+  close: () => void;
+}): () => void {
+  function onDocClick(e: MouseEvent) {
+    const wrapper = opts.getWrapper();
+    if (opts.isOpen() && wrapper && !wrapper.contains(e.target as Node)) opts.close();
+  }
+  function onDocKeydown(e: KeyboardEvent) {
+    if (opts.isOpen() && e.key === "Escape") opts.close();
+  }
+  document.addEventListener("mousedown", onDocClick, true);
+  document.addEventListener("keydown", onDocKeydown);
+  return () => {
+    document.removeEventListener("mousedown", onDocClick, true);
+    document.removeEventListener("keydown", onDocKeydown);
+  };
+}

--- a/src/lib/utils/slash-commands.ts
+++ b/src/lib/utils/slash-commands.ts
@@ -217,11 +217,22 @@ export const VIRTUAL_COMMANDS: CliCommand[] = [
   },
   {
     name: "clear",
-    description: "Clear conversation history and free up context",
     // Codex parity: `/new`, `/exit`, `/quit` are aliases — all fall through to the
     // same clear-context action. In a GUI app "exit"/"quit" mean leave the current
-    // chat (not quit the app), which matches clear semantics.
+    // chat (not quit the app), which matches clear semantics. Gated to Codex so we
+    // don't silently intercept these names on Claude, whose CLI owns /exit and /quit
+    // (and has no /new) — there they fall through to CLI passthrough.
+    // Listed before the agent-neutral entry so Codex's merged menu surfaces the aliases.
+    description: "Clear conversation history and free up context",
     aliases: ["new", "exit", "quit"],
+    _virtual: true,
+    _action: "clear-context",
+    _excludeAgents: ["claude"],
+  },
+  {
+    name: "clear",
+    description: "Clear conversation history and free up context",
+    aliases: [],
     _virtual: true,
     _action: "clear-context",
     // Codex: navigates to fresh chat (new thread on next message)
@@ -327,9 +338,21 @@ export const VIRTUAL_COMMANDS: CliCommand[] = [
   },
   {
     name: "btw",
+    // Codex parity: Codex CLI names this `/side`. Gated to Codex so the `/side`
+    // alias isn't intercepted on Claude (where it has no native meaning and would
+    // otherwise shadow CLI passthrough). The canonical `/btw` stays on both agents.
+    // Listed before the agent-neutral entry so Codex's merged menu surfaces the alias.
     description: "Ask a side question without interrupting the current task",
-    // Codex CLI names this `/side`; we accept both.
     aliases: ["side"],
+    _virtual: true,
+    _action: "side-question",
+    argumentHint: "<question>",
+    _excludeAgents: ["claude"],
+  },
+  {
+    name: "btw",
+    description: "Ask a side question without interrupting the current task",
+    aliases: [],
     _virtual: true,
     _action: "side-question",
     argumentHint: "<question>",
@@ -419,6 +442,24 @@ export const VIRTUAL_COMMANDS: CliCommand[] = [
 function isExcludedForAgent(cmd: CliCommand, agent: string): boolean {
   const excluded = cmd["_excludeAgents"];
   return Array.isArray(excluded) && excluded.includes(agent);
+}
+
+/**
+ * Resolve a virtual command name/alias to the agent-correct variant.
+ * Some names (rewind, compact, …) have per-agent variants distinguished only by
+ * `_excludeAgents`; this returns the first one NOT excluded for `agent` so callers
+ * dispatch the right `_action` (e.g. Codex /rewind → "codex-rewind", not "rewind").
+ */
+export function resolveVirtualCommand(
+  name: string,
+  agent: string = "claude",
+): CliCommand | undefined {
+  const lname = name.toLowerCase();
+  const candidates = VIRTUAL_COMMANDS.filter(
+    (v) =>
+      v.name.toLowerCase() === lname || (v.aliases ?? []).some((a) => a.toLowerCase() === lname),
+  );
+  return candidates.find((v) => !isExcludedForAgent(v, agent));
 }
 
 /** Known virtual command names+aliases for an agent (for isKnownSlashCommand). */
@@ -519,9 +560,15 @@ export function mergeWithVirtual(
     }
     return merged;
   });
-  // Append virtuals not present in CLI
+  // Append virtuals not present in CLI. Some names have multiple applicable
+  // variants for one agent (e.g. Codex's base `clear` + the alias-carrying
+  // `clear`); append only the first so the menu shows no duplicate entries.
+  const appended = new Set<string>();
   for (const v of applicableVirtuals) {
-    if (!cliMap.has(v.name)) result.push(v);
+    if (!cliMap.has(v.name) && !appended.has(v.name)) {
+      result.push(v);
+      appended.add(v.name);
+    }
   }
   return result;
 }
@@ -541,15 +588,11 @@ export function parseVirtualAction(
   const match = text.match(/^\/(\S+)(?:\s+(.*))?$/);
   if (!match) return null;
   const name = match[1];
-  // Some names (rewind, compact) have per-agent variants — match the first one
+  // Some names (rewind, compact) have per-agent variants — resolve to the variant
   // that ISN'T excluded for this agent so e.g. Codex /rewind resolves to the
   // turn-based variant rather than short-circuiting on the Claude snapshot one.
-  const candidates = VIRTUAL_COMMANDS.filter(
-    (v) => v.name === name || (v.aliases ?? []).includes(name),
-  );
-  if (candidates.length === 0) return null;
-  const virtual = candidates.find((v) => !isExcludedForAgent(v, agent));
-  if (!virtual) return null; // all variants excluded for this agent
+  const virtual = resolveVirtualCommand(name, agent);
+  if (!virtual) return null; // unknown, or all variants excluded for this agent
   return { name: virtual.name, args: (match[2] ?? "").trim() };
 }
 

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -12,7 +12,7 @@
     getCliCurrentModel,
     getCliCommands,
     getCliModels,
-    getCodexModels,
+    getModelsForAgent,
     getCodexDefaultModel,
     loadCodexModels,
     canResumeNow,
@@ -246,7 +246,11 @@
   let goalPanelOpen = $state(false);
 
   // Top-level user messages → selectable turns for the Codex rewind modal.
-  let codexRewindTurns = $derived.by<RewindTurn[]>(() => {
+  // Built lazily (only when the modal opens) rather than on every stream event:
+  // it's the only consumer, and the per-turn regex/slice work is O(turns). The
+  // cheap `store.userTurnCount` gates whether the entry point is shown/enabled.
+  let codexRewindTurns = $state<RewindTurn[]>([]);
+  function buildCodexRewindTurns(): RewindTurn[] {
     const turns: RewindTurn[] = [];
     let idx = 0;
     for (const e of store.timeline) {
@@ -256,7 +260,11 @@
       }
     }
     return turns;
-  });
+  }
+  function openCodexRewind() {
+    codexRewindTurns = buildCodexRewindTurns();
+    codexRewindOpen = true;
+  }
 
   async function runCodexRewind(opts: { dropFromTurnIndex: number; numTurns: number }) {
     if (!store.run || effectiveAgent !== "codex") return;
@@ -724,13 +732,7 @@
     }));
   });
 
-  let effectiveModels = $derived(
-    effectiveAgent === "codex"
-      ? getCodexModels()
-      : platformModels.length > 0
-        ? platformModels
-        : getCliModels(),
-  );
+  let effectiveModels = $derived(getModelsForAgent(effectiveAgent, { platformModels }));
   let currentEffort = $state("");
   let isCodexAgent = $derived(store.agent === "codex");
   let assistantDisplayName = $derived(isCodexAgent ? "Codex" : t("chat_claude"));
@@ -3561,11 +3563,11 @@
         appendCommandOutput(t("codexRewind_busy"));
         return;
       }
-      if (codexRewindTurns.length === 0) {
+      if (store.userTurnCount === 0) {
         appendCommandOutput(t("codexRewind_noTurns"));
         return;
       }
-      codexRewindOpen = true;
+      openCodexRewind();
     } else if (action === "codex-goal") {
       if (effectiveAgent !== "codex") return;
       if (!store.run) {
@@ -4466,8 +4468,8 @@
       onCodexRewind={effectiveAgent === "codex" &&
       store.sessionAlive &&
       !store.isRunning &&
-      codexRewindTurns.length > 0
-        ? () => (codexRewindOpen = true)
+      store.userTurnCount > 0
+        ? openCodexRewind
         : undefined}
       contextUtilization={store.contextUtilization}
       contextWarningLevel={store.contextWarningLevel}


### PR DESCRIPTION
## Summary

Output of a `/code-review` pass over the recent Codex-integration work, fanned out to a 3-agent team and then adversarially re-reviewed. Lands the confirmed findings as four focused commits. No behavior change for Claude sessions; all changes are Codex-path or shared-infra.

## What's fixed

**Security**
- `validate_file_path`'s git-root branch accepted *any* filename under the repo root, letting a renderer / web-server client write e.g. `<repo>/.git/hooks/pre-commit` and gain code execution on the next commit. Restricted to `AGENTS.md` / `CLAUDE.md` (its documented purpose).

**Correctness — Codex app-server transport**
- `add_dirs` now reach the app-server transport: `StartupCtx` carries them and the `workspaceWrite` `sandboxPolicy.writableRoots` is populated on the first `turn/start` (`thread/start`'s bare `sandbox` string can't carry writable roots). The UI copy was corrected to "next session" since writable roots are consumed once per thread.
- Resume replays spawn-time model/effort/approval on the first post-resume turn (`thread/resume` sends none of them); `effort` is now plumbed to app-server at all.
- `approvalPolicy` is derived from `permission_mode` (`bypassPermissions` → `never`) instead of a hardcoded `on-request`.
- `codex_side_question` now injects the provider `-c` overrides + `env_key=api_key` via shared spawn helpers; also fixes the app-server spawn path which never injected the provider API-key env var.
- A steer issued during a `willRetry` auto-retry is no longer dropped (`active_turn_id` is kept on retryable errors).

**Frontend correctness**
- The `/new` `/exit` `/quit` (clear) and `/side` (btw) aliases are gated to Codex so Claude sessions fall through to CLI passthrough; per-agent virtual command variants resolve agent-aware (Codex `/rewind` → `codex-rewind`).

**Perf**
- Codex session discovery (`build_summary`) re-parsed every rollout JSONL on every browser open. A generic `DiskScanCache<T>` lifted into `cli_sessions_common` now keys per-file scans on path+mtime+size, serves unchanged rollouts from cache, and scans cold/changed files under rayon. `codex_usage` reuses the same cache.
- `codexRewindTurns` is built lazily on modal open instead of regex-scanning the timeline on every stream event.

**Cleanup / dedup**
- Codex item→tool-name + status mapping deduped behind `CodexToolKind` / `codex_normalize_status`, shared by the exec and app-server parsers (collab items stay unrendered over app-server — no empty card).
- Shared dropdown util (`AgentAuthBadge`/`AuthSourceBadge`) and a `getModelsForAgent` accessor (replaces 4 copy-pasted model-source ternaries); `supportsLiveAddDir` capability replaces an `agent === 'codex'` check.

## Implementation-review catches

Two regressions introduced by the team were caught in a second adversarial pass and fixed with locking tests:
- A flaky test from a shared `OnceLock<TempDir>` cache path under parallel `cargo test` → now threads an explicit per-test cache path (zero shared process state).
- `collabToolCall` rendered an empty Agent card over app-server post-dedup → restored to `None`.

## Testing

- `cargo test`: 666 pass / 0 fail (3× consecutive at default parallelism — flake confirmed gone)
- `cargo clippy -- -D warnings`, `cargo fmt --check`: clean
- `npm run build`, `lint`, `i18n:check`, `format:check`, `vitest` (1379 pass): all green

## Deferred (documented, not in this PR)

The 7 `agent === 'codex'` branches in `session-store.svelte.ts` (hot IPC/lifecycle path, no test coverage) are left for a follow-up: capability predicates (`persistsRunModel`, `supportsMidTurnSteer`, `resumeKind`, …) gated behind first writing send/resume/steer IPC tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
