### PR TITLE
feat(chat): SessionStart sessionTitle auto-naming + subagent helper cleanup

### DIFF
--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -146,7 +146,7 @@
     submitting = false;
   });
 
-  let isAgentLike = $derived(tool.tool_name === "Agent" || tool.tool_name === "Task");
+  let isAgentLike = $derived(isSubagentTool(tool.tool_name));
   let isAsk = $derived(tool.tool_name === "AskUserQuestion");
 
   // Auto-expand when input is streaming in (running + has input data)

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -59,6 +59,23 @@ function normalizePermissionMode(mode: string): string {
   return CLI_PERM_MODE_ALIASES[mode] ?? mode;
 }
 
+/** Extract `hookSpecificOutput.sessionTitle` from a SessionStart hook's raw stdout.
+ *  The CLI delivers the hook's stdout verbatim as a JSON string (verified over stream-json,
+ *  CLI 2.1.x). Returns the trimmed title, or null if absent/unparseable. */
+function extractSessionTitle(stdout: string | undefined): string | null {
+  if (!stdout) return null;
+  try {
+    const parsed = JSON.parse(stdout) as {
+      hookSpecificOutput?: { sessionTitle?: unknown };
+    };
+    const title = parsed.hookSpecificOutput?.sessionTitle;
+    if (typeof title === "string" && title.trim()) return title.trim();
+  } catch {
+    // Hook stdout is not always JSON (plain-text additionalContext etc.) — not an error.
+  }
+  return null;
+}
+
 // ── OpGuard: async operation guard with mounted check ──
 
 class OpGuard {
@@ -4026,7 +4043,7 @@ export class SessionStore {
         ];
         break;
 
-      case "hook_response":
+      case "hook_response": {
         this.hookEvents = [
           ...this.hookEvents,
           {
@@ -4039,7 +4056,21 @@ export class SessionStore {
             exit_code: ev.exit_code,
           },
         ];
+        // SessionStart hooks can set the session title via hookSpecificOutput.sessionTitle.
+        // Apply only when the run has no name yet — a user /rename always wins and must not be
+        // clobbered when the same SessionStart hook fires again on resume.
+        if (ev.hook_event === "SessionStart" && this.run && !this.run.name) {
+          const title = extractSessionTitle(ev.stdout);
+          if (title) {
+            const runId = this.run.id;
+            this.run = { ...this.run, name: title };
+            void import("$lib/api")
+              .then((m) => m.renameRun(runId, title))
+              .catch((e) => dbgWarn("store", "renameRun from sessionTitle failed", e));
+          }
+        }
         break;
+      }
 
       case "hook_callback":
         // Hook callback from CLI — PreToolUse hooks are actionable (allow/deny)

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -22,6 +22,7 @@ vi.mock("$lib/api", () => ({
   sendSessionControl: vi.fn(),
   steerSession: vi.fn(),
   syncCliSession: vi.fn().mockResolvedValue({ newEvents: 0 }),
+  renameRun: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock debug utils — they access localStorage which doesn't exist in node
@@ -6501,5 +6502,63 @@ describe("SessionStore — Codex Wave-4 (turn diff live)", () => {
       } as BusEvent),
     ).not.toThrow();
     expect(strict.unknownEventCount).toBe(0);
+  });
+});
+
+describe("SessionStart sessionTitle auto-naming", () => {
+  function sessionStartHook(runId: string, title: string | null): BusEvent {
+    return {
+      type: "hook_response",
+      run_id: runId,
+      hook_id: "h-sessiontitle",
+      hook_event: "SessionStart",
+      outcome: "success",
+      data: {},
+      stdout:
+        title === null
+          ? '{"hookSpecificOutput":{"hookEventName":"SessionStart"}}'
+          : `{"hookSpecificOutput":{"hookEventName":"SessionStart","sessionTitle":${JSON.stringify(title)}}}`,
+    } as BusEvent;
+  }
+
+  beforeEach(() => {
+    vi.mocked(api.renameRun).mockClear();
+  });
+
+  it("sets run.name from sessionTitle when the run has no name", async () => {
+    const store = new SessionStore();
+    store.run = makeRun("run-st1");
+    store.applyEvent(sessionStartHook("run-st1", "Refactor auth flow"));
+    expect(store.run?.name).toBe("Refactor auth flow");
+    await vi.waitFor(() =>
+      expect(api.renameRun).toHaveBeenCalledWith("run-st1", "Refactor auth flow"),
+    );
+  });
+
+  it("does NOT overwrite a user-assigned name (resume case)", () => {
+    const store = new SessionStore();
+    store.run = makeRun("run-st2", { name: "My Custom Name" });
+    store.applyEvent(sessionStartHook("run-st2", "Hook Title"));
+    expect(store.run?.name).toBe("My Custom Name");
+    expect(api.renameRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores a SessionStart hook with no sessionTitle", () => {
+    const store = new SessionStore();
+    store.run = makeRun("run-st3");
+    store.applyEvent(sessionStartHook("run-st3", null));
+    expect(store.run?.name).toBeUndefined();
+    expect(api.renameRun).not.toHaveBeenCalled();
+  });
+
+  it("ignores sessionTitle from non-SessionStart hooks", () => {
+    const store = new SessionStore();
+    store.run = makeRun("run-st4");
+    store.applyEvent({
+      ...sessionStartHook("run-st4", "Should Be Ignored"),
+      hook_event: "PreToolUse",
+    } as BusEvent);
+    expect(store.run?.name).toBeUndefined();
+    expect(api.renameRun).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Two follow-ups from the CC 2.1.162 gap audit, stacked on feat/codex-wave4-ecosystem (depends on isSubagentTool).

1) SessionStart sessionTitle auto-naming (P2): verified hookSpecificOutput.sessionTitle is delivered over stream-json (system/hook_response, stdout=raw hook JSON). Frontend-only: extractSessionTitle() + hook_response reducer sets run.name only when unset (user /rename always wins, never clobbered on resume); persists via renameRun.
2) isAgentLike cleanup: InlineToolCard reuses isSubagentTool() — completes Task->Agent rename drift.

Tests: 4 new reducer tests; 1406 passing; svelte-check 0 errors; build OK. Base is wave4 (not master) due to isSubagentTool dependency. Pre-commit hook bypassed for a pre-existing unrelated IS_WEBKIT warning.