### PR TITLE
perf(usage): off-thread stats, app-scope cache, filter-aware heatmap & chart

### DIFF
--- a/src-tauri/src/commands/stats.rs
+++ b/src-tauri/src/commands/stats.rs
@@ -17,7 +17,14 @@ fn parse_started_date_utc(started_at: &str) -> Option<chrono::NaiveDate> {
 }
 
 #[tauri::command]
-pub fn get_global_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
+pub async fn get_global_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
+    // Heavy scan + serialization — run off the main thread so the webview never freezes.
+    tokio::task::spawn_blocking(move || global_usage_overview_inner(days))
+        .await
+        .map_err(|e| format!("Join error: {}", e))?
+}
+
+fn global_usage_overview_inner(days: Option<u32>) -> Result<UsageOverview, String> {
     log::debug!("[stats] get_global_usage_overview: days={:?}", days);
     let claude = storage::claude_usage::read_global_usage(days)?;
     // Codex sessions live in ~/.codex/sessions (parallel to ~/.claude/projects). Merge so
@@ -146,7 +153,14 @@ struct DailyBuilder {
 }
 
 #[tauri::command]
-pub fn get_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
+pub async fn get_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
+    // App-scope scan reads every run's events — keep it off the main thread.
+    tokio::task::spawn_blocking(move || usage_overview_inner(days))
+        .await
+        .map_err(|e| format!("Join error: {}", e))?
+}
+
+fn usage_overview_inner(days: Option<u32>) -> Result<UsageOverview, String> {
     log::debug!("[stats] get_usage_overview: days={:?}", days);
 
     let metas = storage::runs::list_all_run_metas();
@@ -176,8 +190,8 @@ pub fn get_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
             }
         }
 
-        // Extract usage from events.jsonl
-        let usage = storage::events::extract_run_usage(&meta.id);
+        // Extract usage from events.jsonl (cached by file mtime/size — most runs are immutable)
+        let usage = storage::events::extract_run_usage_cached(&meta.id);
 
         let mut cost = usage.as_ref().map(|u| u.total_cost_usd).unwrap_or(0.0);
         // total_tokens = input + output (billable tokens only, not cache)
@@ -366,6 +380,8 @@ pub fn get_usage_overview(days: Option<u32>) -> Result<UsageOverview, String> {
 pub fn clear_usage_cache() -> Result<(), String> {
     log::debug!("[stats] clear_usage_cache");
     storage::claude_usage::clear_cache();
+    storage::codex_usage::clear_cache();
+    storage::events::clear_usage_cache();
     Ok(())
 }
 
@@ -410,7 +426,7 @@ fn get_app_heatmap_daily() -> Result<Vec<DailyAggregate>, String> {
 
         let date = d.format("%Y-%m-%d").to_string();
         let day = daily_map.entry(date).or_default();
-        let usage = storage::events::extract_run_usage(&meta.id);
+        let usage = storage::events::extract_run_usage_cached(&meta.id);
         day.cost_usd += usage.as_ref().map(|u| u.total_cost_usd).unwrap_or(0.0);
         day.runs += 1;
         day.input_tokens += usage.as_ref().map(|u| u.input_tokens).unwrap_or(0);
@@ -434,12 +450,18 @@ fn get_app_heatmap_daily() -> Result<Vec<DailyAggregate>, String> {
 }
 
 #[tauri::command]
-pub fn get_heatmap_daily(scope: String) -> Result<Vec<DailyAggregate>, String> {
+pub async fn get_heatmap_daily(scope: String) -> Result<Vec<DailyAggregate>, String> {
+    tokio::task::spawn_blocking(move || heatmap_daily_inner(scope))
+        .await
+        .map_err(|e| format!("Join error: {}", e))?
+}
+
+fn heatmap_daily_inner(scope: String) -> Result<Vec<DailyAggregate>, String> {
     log::debug!("[stats] get_heatmap_daily: scope={}", scope);
     let raw = match scope.as_str() {
         "global" => {
             // Merge Claude + Codex daily so the global heatmap reflects both agents.
-            let overview = get_global_usage_overview(Some(365))?;
+            let overview = global_usage_overview_inner(Some(365))?;
             overview.daily
         }
         "app" => get_app_heatmap_daily()?,
@@ -586,7 +608,7 @@ mod tests {
 
     #[test]
     fn test_heatmap_daily_invalid_scope() {
-        let result = get_heatmap_daily("foo".to_string());
+        let result = heatmap_daily_inner("foo".to_string());
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("invalid scope"));
     }

--- a/src-tauri/src/storage/claude_usage.rs
+++ b/src-tauri/src/storage/claude_usage.rs
@@ -210,13 +210,17 @@ pub fn read_global_usage(days: Option<u32>) -> Result<UsageOverview, String> {
     // Merge all per-file data into aggregate structures
     let (daily_model, scan_activity) = merge_all_file_data(&per_file);
 
-    // Write updated disk cache (atomic)
-    let new_disk_cache = DiskCache {
-        version: DISK_CACHE_VERSION,
-        manifest: current_manifest,
-        per_file,
-    };
-    write_disk_cache(&new_disk_cache);
+    // Write disk cache only when the file set changed. dirty_count > 0 covers new/modified
+    // files; a manifest length drop covers deletions (clean files keep equal length).
+    let manifest_changed = dirty_count > 0 || current_manifest.len() != old_manifest.len();
+    if manifest_changed {
+        let new_disk_cache = DiskCache {
+            version: DISK_CACHE_VERSION,
+            manifest: current_manifest,
+            per_file,
+        };
+        write_disk_cache(&new_disk_cache);
+    }
 
     // Read stats-cache for activity data (messages, sessions, tool calls)
     let (daily_activity, total_sessions) = read_activity_data(&claude_dir);

--- a/src-tauri/src/storage/codex_usage.rs
+++ b/src-tauri/src/storage/codex_usage.rs
@@ -16,11 +16,30 @@
 use crate::models::{DailyAggregate, ModelAggregate, UsageOverview};
 use crate::pricing;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Instant, UNIX_EPOCH};
 
 const DISK_CACHE_VERSION: u32 = 1;
+const CACHE_TTL_SECS: u64 = 120;
+
+// ── In-memory cache (mirrors claude_usage) ──
+
+static CACHE: LazyLock<Mutex<Option<CachedCodex>>> = LazyLock::new(|| Mutex::new(None));
+
+/// Separate mutex to serialize recomputation across concurrent callers.
+static COMPUTE_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+/// Merged scan result kept hot in memory so repeat global-usage calls (e.g. overview +
+/// heatmap on one page load) skip the disk-cache read/deserialize/merge cycle.
+struct CachedCodex {
+    computed_at: Instant,
+    /// date → model → TokenCounts (merged across all files)
+    merged: HashMap<String, HashMap<String, TokenCounts>>,
+    /// dates with at least one session turn (for activity/streaks)
+    all_dates: HashSet<String>,
+}
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 struct TokenCounts {
@@ -222,10 +241,29 @@ fn write_disk_cache(cache: &DiskCache) {
 
 /// Read aggregated global Codex usage. `days` filters the daily window (None = all time).
 pub fn read_global_codex_usage(days: Option<u32>) -> Result<UsageOverview, String> {
+    let _compute_guard = COMPUTE_LOCK
+        .lock()
+        .map_err(|e| format!("Codex compute lock: {e}"))?;
+
     let dir = match sessions_dir() {
         Some(d) => d,
         None => return Ok(empty_overview()),
     };
+
+    // In-memory cache short-circuit: rebuild the date-filtered overview from hot data.
+    {
+        let lock = CACHE.lock().map_err(|e| format!("Codex cache lock: {e}"))?;
+        if let Some(ref c) = *lock {
+            if c.computed_at.elapsed().as_secs() < CACHE_TTL_SECS {
+                log::debug!(
+                    "[codex_usage] memory cache hit (age {}s)",
+                    c.computed_at.elapsed().as_secs()
+                );
+                return Ok(build_overview(c.merged.clone(), c.all_dates.clone(), days));
+            }
+        }
+    }
+
     let files = list_rollout_files(&dir);
     log::debug!("[codex_usage] {} rollout files", files.len());
 
@@ -234,14 +272,18 @@ pub fn read_global_codex_usage(days: Option<u32>) -> Result<UsageOverview, Strin
 
     // date → model → TokenCounts (merged across all files)
     let mut merged: HashMap<String, HashMap<String, TokenCounts>> = HashMap::new();
-    let mut all_dates: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut all_dates: HashSet<String> = HashSet::new();
+    let mut dirty = false;
 
     for (path, mtime_ns, size) in files {
         let key = path.to_string_lossy().to_string();
-        // Reuse cached scan if unchanged.
+        // Reuse cached scan if unchanged; otherwise (new or modified) rescan and mark dirty.
         let data = match old_cache.remove(&key) {
             Some(cf) if cf.mtime_ns == mtime_ns && cf.size == size => cf.data,
-            _ => scan_single_rollout(&path),
+            _ => {
+                dirty = true;
+                scan_single_rollout(&path)
+            }
         };
         for (date, models) in &data.daily {
             let day = merged.entry(date.clone()).or_default();
@@ -265,12 +307,41 @@ pub fn read_global_codex_usage(days: Option<u32>) -> Result<UsageOverview, Strin
         );
     }
 
-    write_disk_cache(&DiskCache {
-        version: DISK_CACHE_VERSION,
-        manifest: new_manifest,
-    });
+    // Write disk cache only when something changed. Leftover entries in old_cache are files
+    // that no longer exist (deletions) and also warrant a rewrite.
+    if dirty || !old_cache.is_empty() {
+        write_disk_cache(&DiskCache {
+            version: DISK_CACHE_VERSION,
+            manifest: new_manifest,
+        });
+    }
+
+    // Store hot copy before build_overview consumes the originals.
+    if let Ok(mut lock) = CACHE.lock() {
+        *lock = Some(CachedCodex {
+            computed_at: Instant::now(),
+            merged: merged.clone(),
+            all_dates: all_dates.clone(),
+        });
+    }
 
     Ok(build_overview(merged, all_dates, days))
+}
+
+/// Clear both the in-memory and on-disk Codex usage caches (used by the refresh button).
+pub fn clear_cache() {
+    if let Ok(mut lock) = CACHE.lock() {
+        *lock = None;
+        log::debug!("[codex_usage] in-memory cache cleared");
+    }
+    let path = disk_cache_path();
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(&path) {
+            log::error!("[codex_usage] failed to remove disk cache: {e}");
+        } else {
+            log::debug!("[codex_usage] disk cache deleted: {:?}", path);
+        }
+    }
 }
 
 fn empty_overview() -> UsageOverview {

--- a/src-tauri/src/storage/events.rs
+++ b/src-tauri/src/storage/events.rs
@@ -424,6 +424,70 @@ pub fn copy_bus_events(from_run_id: &str, to_run_id: &str) -> Result<(), String>
     Ok(())
 }
 
+// ── Per-run usage cache (App-scope Usage page) ──
+//
+// The Usage page's App scope aggregates over every run by reading each run's full
+// events.jsonl. With ~1000 runs that scan dominates page load. Cache the parsed result
+// keyed by the events file's (mtime, size): completed runs are immutable → cache hits;
+// a growing/changed file invalidates automatically.
+
+struct CachedRunUsage {
+    mtime_ns: u128,
+    size: u64,
+    usage: Option<RawRunUsage>,
+}
+
+static USAGE_CACHE: Lazy<std::sync::Mutex<HashMap<String, CachedRunUsage>>> =
+    Lazy::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Cached wrapper around [`extract_run_usage`]: re-parses only when the run's events.jsonl
+/// changed since the last scan. Memory-only (process lifetime) — first scan after launch
+/// still reads every file; cleared by [`clear_usage_cache`].
+pub fn extract_run_usage_cached(run_id: &str) -> Option<RawRunUsage> {
+    let path = events_path(run_id);
+    let meta = match fs::metadata(&path) {
+        Ok(m) => m,
+        // No events file → no usage (matches extract_run_usage's early return).
+        Err(_) => return None,
+    };
+    let mtime_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let size = meta.len();
+
+    if let Ok(cache) = USAGE_CACHE.lock() {
+        if let Some(c) = cache.get(run_id) {
+            if c.mtime_ns == mtime_ns && c.size == size {
+                return c.usage.clone();
+            }
+        }
+    }
+
+    let usage = extract_run_usage(run_id);
+    if let Ok(mut cache) = USAGE_CACHE.lock() {
+        cache.insert(
+            run_id.to_string(),
+            CachedRunUsage {
+                mtime_ns,
+                size,
+                usage: usage.clone(),
+            },
+        );
+    }
+    usage
+}
+
+/// Clear the in-memory per-run usage cache (used by the Usage refresh button).
+pub fn clear_usage_cache() {
+    if let Ok(mut cache) = USAGE_CACHE.lock() {
+        cache.clear();
+        log::debug!("[events] per-run usage cache cleared");
+    }
+}
+
 /// Extract aggregated usage from bus-events for a single run.
 ///
 /// Three modes:

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -776,7 +776,7 @@ pub async fn dispatch_command(
                 .get("days")
                 .and_then(|v| v.as_u64())
                 .map(|n| n as u32);
-            let result = crate::commands::stats::get_usage_overview(days)?;
+            let result = crate::commands::stats::get_usage_overview(days).await?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "get_global_usage_overview" => {
@@ -784,7 +784,7 @@ pub async fn dispatch_command(
                 .get("days")
                 .and_then(|v| v.as_u64())
                 .map(|n| n as u32);
-            let result = crate::commands::stats::get_global_usage_overview(days)?;
+            let result = crate::commands::stats::get_global_usage_overview(days).await?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "clear_usage_cache" => {
@@ -793,7 +793,7 @@ pub async fn dispatch_command(
         }
         "get_heatmap_daily" => {
             let scope = extract_str(&params, "scope")?;
-            let result = crate::commands::stats::get_heatmap_daily(scope)?;
+            let result = crate::commands::stats::get_heatmap_daily(scope).await?;
             serde_json::to_value(result).map_err(|e| e.to_string())
         }
         "get_changelog" => {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2328,8 +2328,9 @@
       </header>
     {/if}
 
-    <!-- Page content -->
-    <main class="flex-1 overflow-y-auto">
+    <!-- Page content. scrollbar-gutter: stable reserves the scrollbar track so pages whose
+         height crosses the scroll threshold (e.g. Usage scope switch) don't shift horizontally. -->
+    <main class="flex-1 overflow-y-auto" style="scrollbar-gutter: stable;">
       {@render children()}
     </main>
   </div>

--- a/src/routes/usage/+page.svelte
+++ b/src/routes/usage/+page.svelte
@@ -4,7 +4,7 @@
   import * as api from "$lib/api";
   import type { UsageOverview, DailyAggregate } from "$lib/types";
   import { formatCost, formatTokenCount } from "$lib/utils/format";
-  import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { dbg } from "$lib/utils/debug";
   import Card from "$lib/components/Card.svelte";
   import HeatmapCalendar from "$lib/components/HeatmapCalendar.svelte";
   import StackedModelChart from "$lib/components/StackedModelChart.svelte";
@@ -15,8 +15,8 @@
   let loading = $state(true);
   let error = $state("");
   let selectedDays = $state<number | undefined>(undefined); // undefined = all
-  let heatmapDaily = $state<DailyAggregate[] | null>(null);
-  let heatmapRequestId = 0;
+  /** A reload (scope/range switch) is in flight over already-loaded content — dim, don't collapse. */
+  let busy = $state(false);
 
   /** "app" = OpenCovibe runs only, "global" = all Claude Code sessions */
   let scope = $state<"app" | "global">("global");
@@ -54,6 +54,22 @@
     }
     return Math.max(...data.daily.map((d) => d.inputTokens + d.outputTokens), 1);
   });
+
+  // Bars to render in the daily-trend chart. The backend already filters `daily` to the
+  // selected range, so show all of it — slicing to a fixed window made 30d/90d/All look
+  // nearly identical (and scaled bars to an off-screen peak).
+  let chartDaily = $derived(data?.daily ?? []);
+
+  /** Strip per-model breakdown, sort by date, cap at 365 — input for the activity calendar. */
+  function deriveHeatmap(daily: DailyAggregate[]): DailyAggregate[] {
+    const copy = daily.map((d) => ({ ...d, modelBreakdown: undefined }));
+    copy.sort((a, b) => a.date.localeCompare(b.date));
+    return copy.length > 365 ? copy.slice(-365) : copy;
+  }
+
+  // Activity calendar follows the selected range (derived from the same filtered `daily`), so
+  // it stays consistent with the active-days/streak labels instead of always showing a full year.
+  let heatmapDaily = $derived(data ? deriveHeatmap(data.daily) : null);
 
   // Sort state for run history
   let sortCol = $state<"date" | "cost" | "tokens" | "turns">("date");
@@ -99,9 +115,17 @@
 
   async function loadData(days?: number) {
     const thisRequest = ++requestId;
-    if (!data) loading = true; // Only show full spinner on initial load
+    // Full spinner only on the very first load. Reloads (scope/range switch) keep the current
+    // content fully visible and mounted — no collapse, no dim. A small corner spinner appears
+    // only if the reload is slow (cold cache), gated behind a short delay so fast cached
+    // switches swap content instantly with no flicker or jump.
+    if (!data) loading = true;
     error = "";
     showFullScanMessage = false;
+
+    const busyTimer = setTimeout(() => {
+      if (thisRequest === requestId && data) busy = true;
+    }, 180);
 
     // Delayed indicator: show message if full scan takes > 500ms
     const delayTimer = setTimeout(() => {
@@ -138,28 +162,12 @@
       if (thisRequest !== requestId) return;
       error = String(e);
     } finally {
+      clearTimeout(busyTimer);
       clearTimeout(delayTimer);
       if (thisRequest === requestId) {
         loading = false;
+        busy = false;
         showFullScanMessage = false;
-      }
-    }
-  }
-
-  async function loadHeatmapData() {
-    const token = ++heatmapRequestId;
-    try {
-      const result = await api.getHeatmapDaily(scope);
-      if (token === heatmapRequestId) {
-        heatmapDaily = result;
-        dbg("usage", "heatmap loaded", { scope, days: result.length });
-      } else {
-        dbg("usage", "heatmap discarded stale", { token, current: heatmapRequestId });
-      }
-    } catch (e) {
-      if (token === heatmapRequestId) {
-        heatmapDaily = null;
-        dbgWarn("usage", "heatmap load failed", e);
       }
     }
   }
@@ -175,8 +183,8 @@
     if (s === "app" && (chartMode === "messages" || chartMode === "sessions")) {
       chartMode = "cost";
     }
+    // heatmapDaily is derived from data.daily, so it rebuilds automatically on reload.
     loadData(selectedDays);
-    loadHeatmapData();
   }
 
   async function refreshCache() {
@@ -184,7 +192,7 @@
     refreshing = true;
     try {
       await api.clearUsageCache();
-      await Promise.all([loadData(selectedDays), loadHeatmapData()]);
+      await loadData(selectedDays);
     } finally {
       refreshing = false;
     }
@@ -225,11 +233,19 @@
 
   onMount(() => {
     loadData(selectedDays);
-    loadHeatmapData();
   });
 </script>
 
-<div class="max-w-4xl mx-auto p-6 space-y-6 animate-slide-up">
+<div class="relative max-w-4xl mx-auto p-6 space-y-6 animate-slide-up">
+  <!-- Reload indicator (scope/range switch). Absolutely positioned → no layout impact.
+       Hidden during refresh — the refresh button has its own spinner, so a second one is noise. -->
+  {#if busy && !refreshing}
+    <div class="absolute right-6 top-6 z-10">
+      <div
+        class="h-4 w-4 border-2 border-primary/30 border-t-primary rounded-full animate-spin"
+      ></div>
+    </div>
+  {/if}
   <!-- Header -->
   <div class="flex items-center gap-4">
     <div class="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-500/10">
@@ -336,309 +352,230 @@
       {error}
     </div>
   {:else if data}
-    <!-- Summary cards -->
-    <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
-      <Card class="p-4 text-center">
-        <p class="text-2xl font-bold">{formatCost(data.totalCostUsd)}</p>
-        <p class="text-xs text-muted-foreground mt-1">{t("usage_totalCost")}</p>
-      </Card>
-      <Card class="p-4 text-center">
-        <p class="text-2xl font-bold">{formatTokenCount(data.totalTokens)}</p>
-        <p class="text-xs text-muted-foreground mt-1">{t("usage_totalTokens")}</p>
-      </Card>
-      <Card class="p-4 text-center">
-        <p class="text-2xl font-bold">{data.totalRuns}</p>
-        <p class="text-xs text-muted-foreground mt-1">
-          {scope === "global" ? t("usage_sessions") : t("usage_runs")}
-        </p>
-      </Card>
-      <Card class="p-4 text-center">
-        {#if data.currentStreak > 0}
-          <p class="text-2xl font-bold">
-            {t("usage_currentStreak", { count: String(data.currentStreak) })}
-          </p>
+    <div class="space-y-6">
+      <!-- Summary cards -->
+      <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Card class="p-4 text-center">
+          <p class="text-2xl font-bold">{formatCost(data.totalCostUsd)}</p>
+          <p class="text-xs text-muted-foreground mt-1">{t("usage_totalCost")}</p>
+        </Card>
+        <Card class="p-4 text-center">
+          <p class="text-2xl font-bold">{formatTokenCount(data.totalTokens)}</p>
+          <p class="text-xs text-muted-foreground mt-1">{t("usage_totalTokens")}</p>
+        </Card>
+        <Card class="p-4 text-center">
+          <p class="text-2xl font-bold">{data.totalRuns}</p>
           <p class="text-xs text-muted-foreground mt-1">
-            {t("usage_longestStreak", { count: String(data.longestStreak) })}
+            {scope === "global" ? t("usage_sessions") : t("usage_runs")}
           </p>
-        {:else}
-          <p class="text-2xl font-bold">
-            {t("usage_activeDays", { count: String(data.activeDays) })}
-          </p>
-          <p class="text-xs text-muted-foreground mt-1">
-            {scope === "global" ? t("usage_avgCostSession") : t("usage_avgCostRun")}
-          </p>
-        {/if}
-      </Card>
-    </div>
+        </Card>
+        <Card class="p-4 text-center">
+          {#if data.currentStreak > 0}
+            <p class="text-2xl font-bold">
+              {t("usage_currentStreak", { count: String(data.currentStreak) })}
+            </p>
+            <p class="text-xs text-muted-foreground mt-1">
+              {t("usage_longestStreak", { count: String(data.longestStreak) })}
+            </p>
+          {:else}
+            <p class="text-2xl font-bold">
+              {t("usage_activeDays", { count: String(data.activeDays) })}
+            </p>
+            <p class="text-xs text-muted-foreground mt-1">
+              {scope === "global" ? t("usage_avgCostSession") : t("usage_avgCostRun")}
+            </p>
+          {/if}
+        </Card>
+      </div>
 
-    <!-- Activity Heatmap (always 52 weeks, independent of date filter) -->
-    {#if heatmapDaily}
-      <Card class="p-6 space-y-3">
+      <!-- Activity Heatmap (always 52 weeks, independent of date filter) -->
+      {#if heatmapDaily}
+        <Card class="p-6 space-y-3">
+          <div class="flex items-center justify-between">
+            <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+              {t("usage_activityHeatmap")}
+            </h2>
+            <div class="flex gap-3 text-xs text-muted-foreground">
+              {#if data.activeDays > 0}
+                <span>{t("usage_activeDays", { count: String(data.activeDays) })}</span>
+              {/if}
+              {#if data.longestStreak > 0}
+                <span>{t("usage_longestStreak", { count: String(data.longestStreak) })}</span>
+              {/if}
+            </div>
+          </div>
+          <HeatmapCalendar daily={heatmapDaily} metric={chartMode} />
+        </Card>
+      {/if}
+
+      <!-- Daily trend chart -->
+      <Card class="p-6 space-y-4">
         <div class="flex items-center justify-between">
           <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-            {t("usage_activityHeatmap")}
+            {t("usage_dailyTrend")}
           </h2>
-          <div class="flex gap-3 text-xs text-muted-foreground">
-            {#if data.activeDays > 0}
-              <span>{t("usage_activeDays", { count: String(data.activeDays) })}</span>
-            {/if}
-            {#if data.longestStreak > 0}
-              <span>{t("usage_longestStreak", { count: String(data.longestStreak) })}</span>
-            {/if}
-          </div>
-        </div>
-        <HeatmapCalendar daily={heatmapDaily} metric={chartMode} />
-      </Card>
-    {/if}
-
-    <!-- Daily trend chart -->
-    <Card class="p-6 space-y-4">
-      <div class="flex items-center justify-between">
-        <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-          {t("usage_dailyTrend")}
-        </h2>
-        <div class="flex gap-1">
-          <button
-            class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
+          <div class="flex gap-1">
+            <button
+              class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
               {chartMode === 'cost'
-              ? 'bg-primary/20 text-primary'
-              : 'text-muted-foreground hover:text-foreground'}"
-            onclick={() => (chartMode = "cost")}
-          >
-            {t("usage_chartCost")}
-          </button>
-          <button
-            class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
+                ? 'bg-primary/20 text-primary'
+                : 'text-muted-foreground hover:text-foreground'}"
+              onclick={() => (chartMode = "cost")}
+            >
+              {t("usage_chartCost")}
+            </button>
+            <button
+              class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
               {chartMode === 'tokens'
-              ? 'bg-primary/20 text-primary'
-              : 'text-muted-foreground hover:text-foreground'}"
-            onclick={() => (chartMode = "tokens")}
-          >
-            {t("usage_chartTokens")}
-          </button>
-          {#if scope === "global"}
-            <button
-              class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
+                ? 'bg-primary/20 text-primary'
+                : 'text-muted-foreground hover:text-foreground'}"
+              onclick={() => (chartMode = "tokens")}
+            >
+              {t("usage_chartTokens")}
+            </button>
+            {#if scope === "global"}
+              <button
+                class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
                 {chartMode === 'messages'
-                ? 'bg-primary/20 text-primary'
-                : 'text-muted-foreground hover:text-foreground'}"
-              onclick={() => (chartMode = "messages")}
-            >
-              {t("usage_chartMessages")}
-            </button>
-            <button
-              class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
+                  ? 'bg-primary/20 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'}"
+                onclick={() => (chartMode = "messages")}
+              >
+                {t("usage_chartMessages")}
+              </button>
+              <button
+                class="px-2 py-0.5 text-[10px] font-medium rounded transition-colors
                 {chartMode === 'sessions'
-                ? 'bg-primary/20 text-primary'
-                : 'text-muted-foreground hover:text-foreground'}"
-              onclick={() => (chartMode = "sessions")}
-            >
-              {t("usage_chartSessions")}
-            </button>
-          {/if}
-        </div>
-      </div>
-      {#if data.daily.length > 0}
-        {#if scope === "global" && chartMode === "tokens" && data.daily.some((d) => d.modelBreakdown)}
-          <StackedModelChart daily={data.daily} />
-        {:else}
-          <div class="flex h-40">
-            <!-- Y-axis labels -->
-            <div
-              class="flex flex-col justify-between items-end pr-2 text-[10px] text-muted-foreground tabular-nums shrink-0 py-0.5"
-            >
-              <span>{formatAxisValue(maxDailyValue)}</span>
-              <span>{formatAxisValue(maxDailyValue / 2)}</span>
-              <span>0</span>
-            </div>
-            <!-- Bars + X-axis -->
-            <div class="flex-1 flex flex-col min-w-0">
-              <div class="flex-1 flex gap-[2px] border-l border-b border-border/50 relative">
-                <!-- 50% gridline -->
-                <div
-                  class="absolute inset-x-0 top-1/2 border-t border-border/30 pointer-events-none"
-                ></div>
-                {#each data.daily.slice(-30) as day}
-                  {@const value = getDailyValue(day)}
-                  {@const pct = Math.max((value / maxDailyValue) * 100, 2)}
-                  <div
-                    class="flex-1 min-w-0 flex items-end group cursor-default"
-                    title={getDailyTooltip(day)}
-                  >
-                    <div
-                      class="w-full rounded-t bg-primary/60 group-hover:bg-primary transition-colors"
-                      style="height: {pct}%"
-                    ></div>
-                  </div>
-                {/each}
-              </div>
-              <!-- X-axis date labels -->
-              <div class="flex gap-[2px] mt-1">
-                {#each data.daily.slice(-30) as day, i}
-                  {@const showLabel =
-                    data.daily.slice(-30).length <= 10 ||
-                    i % Math.ceil(data.daily.slice(-30).length / 10) === 0}
-                  <div class="flex-1 min-w-0 text-center">
-                    {#if showLabel}
-                      <span class="text-[10px] text-muted-foreground tabular-nums">
-                        {formatShortDate(day.date)}
-                      </span>
-                    {/if}
-                  </div>
-                {/each}
-              </div>
-            </div>
+                  ? 'bg-primary/20 text-primary'
+                  : 'text-muted-foreground hover:text-foreground'}"
+                onclick={() => (chartMode = "sessions")}
+              >
+                {t("usage_chartSessions")}
+              </button>
+            {/if}
           </div>
-        {/if}
-      {:else}
-        <p class="text-sm text-muted-foreground">{t("usage_noDailyData")}</p>
-      {/if}
-    </Card>
-
-    <!-- By Model -->
-    <Card class="p-6 space-y-4">
-      <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-        {t("usage_byModel")}
-      </h2>
-      {#if data.byModel.length > 0}
-        <div class="overflow-x-auto">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="text-xs text-muted-foreground border-b border-border">
-                <th class="text-left py-2 font-medium">{t("usage_thModel")}</th>
-                {#if scope === "app"}
-                  <th class="text-right py-2 font-medium">{t("usage_thRuns")}</th>
-                {/if}
-                <th class="text-right py-2 font-medium">{t("usage_thInTokens")}</th>
-                <th class="text-right py-2 font-medium">{t("usage_thOutTokens")}</th>
-                <th class="text-right py-2 font-medium">{t("usage_thCacheRead")}</th>
-                <th class="text-right py-2 font-medium">{t("usage_thCacheWrite")}</th>
-                <th class="text-right py-2 font-medium">{t("usage_thCost")}</th>
-                <th class="text-right py-2 font-medium w-24">%</th>
-              </tr>
-            </thead>
-            <tbody>
-              {#each data.byModel as modelRow}
-                <tr class="border-b border-border/50 hover:bg-muted/30">
-                  <td class="py-2 font-mono text-xs truncate max-w-[180px]" title={modelRow.model}>
-                    {modelRow.model}
-                  </td>
-                  {#if scope === "app"}
-                    <td class="py-2 text-right tabular-nums">{modelRow.runs}</td>
-                  {/if}
-                  <td class="py-2 text-right tabular-nums font-mono text-xs">
-                    {formatTokenCount(modelRow.inputTokens)}
-                  </td>
-                  <td class="py-2 text-right tabular-nums font-mono text-xs">
-                    {formatTokenCount(modelRow.outputTokens)}
-                  </td>
-                  <td class="py-2 text-right tabular-nums font-mono text-xs text-muted-foreground">
-                    {formatTokenCount(modelRow.cacheReadTokens)}
-                  </td>
-                  <td class="py-2 text-right tabular-nums font-mono text-xs text-muted-foreground">
-                    {formatTokenCount(modelRow.cacheWriteTokens)}
-                  </td>
-                  <td class="py-2 text-right tabular-nums font-mono text-xs">
-                    {formatCost(modelRow.costUsd)}
-                  </td>
-                  <td class="py-2 text-right">
-                    <div class="flex items-center justify-end gap-2">
-                      <div class="w-12 h-1.5 bg-muted rounded-full overflow-hidden">
-                        <div
-                          class="h-full bg-primary rounded-full"
-                          style="width: {Math.min(modelRow.pct, 100)}%"
-                        ></div>
-                      </div>
-                      <span class="text-xs tabular-nums text-muted-foreground w-8 text-right">
-                        {modelRow.pct.toFixed(0)}%
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
         </div>
-      {:else}
-        <p class="text-sm text-muted-foreground">{t("usage_noModelData")}</p>
-      {/if}
-    </Card>
+        {#if data.daily.length > 0}
+          {#if scope === "global" && chartMode === "tokens" && data.daily.some((d) => d.modelBreakdown)}
+            <StackedModelChart daily={data.daily} />
+          {:else}
+            <div class="flex h-40">
+              <!-- Y-axis labels -->
+              <div
+                class="flex flex-col justify-between items-end pr-2 text-[10px] text-muted-foreground tabular-nums shrink-0 py-0.5"
+              >
+                <span>{formatAxisValue(maxDailyValue)}</span>
+                <span>{formatAxisValue(maxDailyValue / 2)}</span>
+                <span>0</span>
+              </div>
+              <!-- Bars + X-axis -->
+              <div class="flex-1 flex flex-col min-w-0">
+                <div class="flex-1 flex gap-[2px] border-l border-b border-border/50 relative">
+                  <!-- 50% gridline -->
+                  <div
+                    class="absolute inset-x-0 top-1/2 border-t border-border/30 pointer-events-none"
+                  ></div>
+                  {#each chartDaily as day}
+                    {@const value = getDailyValue(day)}
+                    {@const pct = Math.max((value / maxDailyValue) * 100, 2)}
+                    <div
+                      class="flex-1 min-w-0 flex items-end group cursor-default"
+                      title={getDailyTooltip(day)}
+                    >
+                      <div
+                        class="w-full rounded-t bg-primary/60 group-hover:bg-primary transition-colors"
+                        style="height: {pct}%"
+                      ></div>
+                    </div>
+                  {/each}
+                </div>
+                <!-- X-axis date labels -->
+                <div class="flex gap-[2px] mt-1">
+                  {#each chartDaily as day, i}
+                    {@const showLabel =
+                      chartDaily.length <= 10 || i % Math.ceil(chartDaily.length / 10) === 0}
+                    <div class="flex-1 min-w-0 text-center">
+                      {#if showLabel}
+                        <span class="text-[10px] text-muted-foreground tabular-nums">
+                          {formatShortDate(day.date)}
+                        </span>
+                      {/if}
+                    </div>
+                  {/each}
+                </div>
+              </div>
+            </div>
+          {/if}
+        {:else}
+          <p class="text-sm text-muted-foreground">{t("usage_noDailyData")}</p>
+        {/if}
+      </Card>
 
-    <!-- Run History (App mode only) -->
-    {#if scope === "app"}
+      <!-- By Model -->
       <Card class="p-6 space-y-4">
         <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-          {t("usage_runHistory")}
+          {t("usage_byModel")}
         </h2>
-        {#if sortedRuns.length > 0}
+        {#if data.byModel.length > 0}
           <div class="overflow-x-auto">
             <table class="w-full text-sm">
               <thead>
                 <tr class="text-xs text-muted-foreground border-b border-border">
-                  <th
-                    class="text-left py-2 font-medium cursor-pointer select-none hover:text-foreground"
-                    onclick={() => toggleSort("date")}
-                  >
-                    {t("usage_thDate")}{sortIndicator("date")}
-                  </th>
-                  <th class="text-left py-2 font-medium">{t("usage_thName")}</th>
                   <th class="text-left py-2 font-medium">{t("usage_thModel")}</th>
-                  <th
-                    class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
-                    onclick={() => toggleSort("tokens")}
-                  >
-                    {t("usage_thTokens")}{sortIndicator("tokens")}
-                  </th>
-                  <th
-                    class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
-                    onclick={() => toggleSort("cost")}
-                  >
-                    {t("usage_thCost")}{sortIndicator("cost")}
-                  </th>
-                  <th
-                    class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
-                    onclick={() => toggleSort("turns")}
-                  >
-                    {t("usage_thTurns")}{sortIndicator("turns")}
-                  </th>
+                  {#if scope === "app"}
+                    <th class="text-right py-2 font-medium">{t("usage_thRuns")}</th>
+                  {/if}
+                  <th class="text-right py-2 font-medium">{t("usage_thInTokens")}</th>
+                  <th class="text-right py-2 font-medium">{t("usage_thOutTokens")}</th>
+                  <th class="text-right py-2 font-medium">{t("usage_thCacheRead")}</th>
+                  <th class="text-right py-2 font-medium">{t("usage_thCacheWrite")}</th>
+                  <th class="text-right py-2 font-medium">{t("usage_thCost")}</th>
+                  <th class="text-right py-2 font-medium w-24">%</th>
                 </tr>
               </thead>
               <tbody>
-                {#each sortedRuns as run}
-                  <tr
-                    class="border-b border-border/50 hover:bg-muted/30 cursor-pointer"
-                    onclick={() => goto(`/chat?run=${run.runId}`)}
-                  >
-                    <td class="py-2 text-xs text-muted-foreground whitespace-nowrap">
-                      {formatDate(run.startedAt)}
-                    </td>
-                    <td class="py-2 truncate max-w-[200px]" title={run.name}>
-                      {run.name}
-                    </td>
+                {#each data.byModel as modelRow}
+                  <tr class="border-b border-border/50 hover:bg-muted/30">
                     <td
-                      class="py-2 font-mono text-xs text-muted-foreground truncate max-w-[120px]"
-                      title={run.model ?? run.agent}
+                      class="py-2 font-mono text-xs truncate max-w-[180px]"
+                      title={modelRow.model}
                     >
-                      {#if run.agent !== "claude"}
-                        <span class="text-[10px] text-emerald-500/70 mr-1 font-sans"
-                          >{run.agent}</span
-                        >
-                      {/if}
-                      {run.model ?? "\u2014"}
+                      {modelRow.model}
+                    </td>
+                    {#if scope === "app"}
+                      <td class="py-2 text-right tabular-nums">{modelRow.runs}</td>
+                    {/if}
+                    <td class="py-2 text-right tabular-nums font-mono text-xs">
+                      {formatTokenCount(modelRow.inputTokens)}
                     </td>
                     <td class="py-2 text-right tabular-nums font-mono text-xs">
-                      {formatTokenCount(run.inputTokens + run.outputTokens)}
+                      {formatTokenCount(modelRow.outputTokens)}
                     </td>
                     <td
-                      class="py-2 text-right tabular-nums font-mono text-xs"
-                      title={run.costEstimated ? "Estimated from token count" : undefined}
+                      class="py-2 text-right tabular-nums font-mono text-xs text-muted-foreground"
                     >
-                      {formatCost(run.totalCostUsd)}{#if run.costEstimated}<span
-                          class="text-[9px] text-muted-foreground/50 ml-0.5">~</span
-                        >{/if}
+                      {formatTokenCount(modelRow.cacheReadTokens)}
                     </td>
-                    <td class="py-2 text-right tabular-nums">
-                      {run.numTurns}
+                    <td
+                      class="py-2 text-right tabular-nums font-mono text-xs text-muted-foreground"
+                    >
+                      {formatTokenCount(modelRow.cacheWriteTokens)}
+                    </td>
+                    <td class="py-2 text-right tabular-nums font-mono text-xs">
+                      {formatCost(modelRow.costUsd)}
+                    </td>
+                    <td class="py-2 text-right">
+                      <div class="flex items-center justify-end gap-2">
+                        <div class="w-12 h-1.5 bg-muted rounded-full overflow-hidden">
+                          <div
+                            class="h-full bg-primary rounded-full"
+                            style="width: {Math.min(modelRow.pct, 100)}%"
+                          ></div>
+                        </div>
+                        <span class="text-xs tabular-nums text-muted-foreground w-8 text-right">
+                          {modelRow.pct.toFixed(0)}%
+                        </span>
+                      </div>
                     </td>
                   </tr>
                 {/each}
@@ -646,11 +583,98 @@
             </table>
           </div>
         {:else}
-          <p class="text-sm text-muted-foreground">
-            {t("usage_noUsageData")}
-          </p>
+          <p class="text-sm text-muted-foreground">{t("usage_noModelData")}</p>
         {/if}
       </Card>
-    {/if}
+
+      <!-- Run History (App mode only) -->
+      {#if scope === "app"}
+        <Card class="p-6 space-y-4">
+          <h2 class="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            {t("usage_runHistory")}
+          </h2>
+          {#if sortedRuns.length > 0}
+            <div class="overflow-x-auto">
+              <table class="w-full text-sm">
+                <thead>
+                  <tr class="text-xs text-muted-foreground border-b border-border">
+                    <th
+                      class="text-left py-2 font-medium cursor-pointer select-none hover:text-foreground"
+                      onclick={() => toggleSort("date")}
+                    >
+                      {t("usage_thDate")}{sortIndicator("date")}
+                    </th>
+                    <th class="text-left py-2 font-medium">{t("usage_thName")}</th>
+                    <th class="text-left py-2 font-medium">{t("usage_thModel")}</th>
+                    <th
+                      class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
+                      onclick={() => toggleSort("tokens")}
+                    >
+                      {t("usage_thTokens")}{sortIndicator("tokens")}
+                    </th>
+                    <th
+                      class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
+                      onclick={() => toggleSort("cost")}
+                    >
+                      {t("usage_thCost")}{sortIndicator("cost")}
+                    </th>
+                    <th
+                      class="text-right py-2 font-medium cursor-pointer select-none hover:text-foreground"
+                      onclick={() => toggleSort("turns")}
+                    >
+                      {t("usage_thTurns")}{sortIndicator("turns")}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {#each sortedRuns as run}
+                    <tr
+                      class="border-b border-border/50 hover:bg-muted/30 cursor-pointer"
+                      onclick={() => goto(`/chat?run=${run.runId}`)}
+                    >
+                      <td class="py-2 text-xs text-muted-foreground whitespace-nowrap">
+                        {formatDate(run.startedAt)}
+                      </td>
+                      <td class="py-2 truncate max-w-[200px]" title={run.name}>
+                        {run.name}
+                      </td>
+                      <td
+                        class="py-2 font-mono text-xs text-muted-foreground truncate max-w-[120px]"
+                        title={run.model ?? run.agent}
+                      >
+                        {#if run.agent !== "claude"}
+                          <span class="text-[10px] text-emerald-500/70 mr-1 font-sans"
+                            >{run.agent}</span
+                          >
+                        {/if}
+                        {run.model ?? "\u2014"}
+                      </td>
+                      <td class="py-2 text-right tabular-nums font-mono text-xs">
+                        {formatTokenCount(run.inputTokens + run.outputTokens)}
+                      </td>
+                      <td
+                        class="py-2 text-right tabular-nums font-mono text-xs"
+                        title={run.costEstimated ? "Estimated from token count" : undefined}
+                      >
+                        {formatCost(run.totalCostUsd)}{#if run.costEstimated}<span
+                            class="text-[9px] text-muted-foreground/50 ml-0.5">~</span
+                          >{/if}
+                      </td>
+                      <td class="py-2 text-right tabular-nums">
+                        {run.numTurns}
+                      </td>
+                    </tr>
+                  {/each}
+                </tbody>
+              </table>
+            </div>
+          {:else}
+            <p class="text-sm text-muted-foreground">
+              {t("usage_noUsageData")}
+            </p>
+          {/if}
+        </Card>
+      {/if}
+    </div>
   {/if}
 </div>


### PR DESCRIPTION
## Summary

Fixes the Usage page jank and several data/UX bugs reported while using it.

Base is `feat/sessiontitle-auto-naming` (this work was built on top of that branch; the diff here is only the 7 usage-related files). Retarget to `master` once the base merges.

## Backend — performance

- **Async stats commands.** `get_usage_overview` / `get_global_usage_overview` / `get_heatmap_daily` are now `async` + `spawn_blocking`. Sync Tauri commands run on the webview main thread; the scan + serialization were freezing the UI.
- **App-scope per-run cache.** `events::extract_run_usage_cached` caches each run's parsed usage keyed by `events.jsonl` (mtime, size). The App overview no longer re-reads every run's `events.jsonl` on each load (was the main "switch to App is slow" cause).
- **Codex in-memory cache.** 120s memory cache for Codex global usage (mirrors `claude_usage`); both disk caches now skip rewriting when nothing changed.
- `clear_usage_cache` clears Claude + Codex + per-run caches.

## Frontend — bug fixes

- **Daily trend respects the date range.** Was hardcoded to `slice(-30)`, so 30d / 90d / All looked nearly identical and bars were scaled to an off-screen peak.
- **Activity heatmap follows the filter.** Derived from the filtered `daily` so it matches the active-days / streak labels instead of showing a stale full-year grid. Removes the redundant heatmap IPC path.
- **No jank on scope/range switch.** Content stays mounted (no collapse to spinner, no opacity flash); a small corner spinner appears only after 180ms and is hidden during refresh (the refresh button has its own spinner).
- `scrollbar-gutter: stable` on the main scroll container to avoid horizontal shift.

## Verification

- Confirmed the cost numbers are correct by aggregating the on-disk caches: token totals match the UI exactly (30d 409.3m, 90d 1729.1m). The small 30d→90d cost delta is real — expensive Opus usage is concentrated in the last 30 days; the extra 90d tokens are cheaper Codex models.
- `npm run check`, `npm test` (1406 pass), `npm run build`, `cargo fmt`, `cargo clippy` all clean.