### PR TITLE
fix(sidebar): collapsed tool panel bleeds text into the 32px rail (#163)

### DIFF
--- a/src/lib/components/ToolActivity.svelte
+++ b/src/lib/components/ToolActivity.svelte
@@ -590,12 +590,19 @@
   class="relative h-full border-l border-border bg-muted/30 overflow-hidden"
   style="width: {collapsed ? '32px' : effectiveWidth + 'px'}; contain: layout style;"
 >
-  <!-- Always-mounted expanded panel (visibility-hidden when collapsed) -->
+  <!-- Always-mounted expanded panel (hidden when collapsed). opacity:0 alongside
+       visibility:hidden: each tab re-asserts visibility:visible for keep-alive, and a
+       child's visibility:visible overrides an ancestor's hidden — so without opacity the
+       active tab's text bleeds into the 32px collapsed rail (#163). opacity on an ancestor
+       can't be overridden by descendants, and (unlike display:none) preserves CodeMirror's
+       layout so the panel can stay mounted. -->
   <div
     class="absolute top-0 left-0 h-full flex flex-col"
     style="width: {effectiveWidth}px; visibility: {collapsed
       ? 'hidden'
-      : 'visible'}; pointer-events: {collapsed ? 'none' : 'auto'};"
+      : 'visible'}; opacity: {collapsed ? '0' : '1'}; pointer-events: {collapsed
+      ? 'none'
+      : 'auto'};"
     aria-hidden={collapsed}
   >
     <!-- Resize handle on the left edge -->


### PR DESCRIPTION
Collapsing the tool panel leaves the active tab's text showing inside the 32px rail. The panel collapses with `visibility:hidden`, but each tab re-asserts `visibility:visible` for keep-alive, and a child's `visible` overrides an ancestor's `hidden` — so the active tab paints into the rail.

Fix: add `opacity:0` on the collapsed wrapper. Descendants can't override an ancestor's opacity, and unlike `display:none` it preserves CodeMirror's layout so the panel can stay mounted.

Verified: `npm run check` 0 errors, prettier clean.

Fixes #163.