### PR TITLE
feat(chat): surface silent session auto-recovery (#115)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -488,6 +488,8 @@
   "prompt_dropFiles": "Drop files here",
   "prompt_hasRunPlaceholder": "Send a message...",
   "prompt_newPlaceholder": "Type a message to start...",
+  "prompt_continueSessionPlaceholder": "Send a message to continue this session...",
+  "chat_restoringSession": "Restoring session…",
   "prompt_removePaste": "Remove pasted text",
   "prompt_editPaste": "Edit pasted text",
   "prompt_editPasteTitle": "Edit paste #{seq}",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -488,6 +488,8 @@
   "prompt_dropFiles": "将文件拖放到此处",
   "prompt_hasRunPlaceholder": "发送消息...",
   "prompt_newPlaceholder": "输入消息以开始...",
+  "prompt_continueSessionPlaceholder": "发送消息以继续此会话...",
+  "chat_restoringSession": "正在恢复会话…",
   "prompt_removePaste": "移除粘贴的文本",
   "prompt_editPaste": "编辑粘贴内容",
   "prompt_editPasteTitle": "编辑粘贴 #{seq}",

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -193,9 +193,13 @@
       ? "Ask a side question..."
       : pendingPermission
         ? t("prompt_pendingPermission")
-        : hasRun
-          ? t("prompt_hasRunPlaceholder")
-          : t("prompt_newPlaceholder"),
+        : // Inactive but resumable: tell the user they can just type — the session
+          // auto-recovers on send, no need to click "Resume Session" first. (#115)
+          canResume && !sessionAlive && !running
+          ? t("prompt_continueSessionPlaceholder")
+          : hasRun
+            ? t("prompt_hasRunPlaceholder")
+            : t("prompt_newPlaceholder"),
   );
 
   // ── Git branch (fetched from cwd) ──

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -2245,6 +2245,9 @@
           runId: store.run.id,
           sessionId: store.run.session_id,
         });
+        // Make the silent recovery visible so users don't think they must click
+        // "Resume Session" first. (#115)
+        promptRef?.showToast(t("chat_restoringSession"), "info");
         if (slashCmd) {
           processingSlashCmd = slashCmd;
           slashCmdSeenRunning = false;


### PR DESCRIPTION
Stopped stream sessions already auto-recover when you send a message, but it's silent — so users keep clicking "Resume Session" first, thinking it's required.

Two small cues, no behavior change:
- The composer placeholder reads "Send a message to continue this session…" when the session is inactive but resumable (`canResume && !sessionAlive && !running`).
- The auto-resume-on-send path shows a brief "Restoring session…" toast.

The manual Resume Session menu item is left as-is.

Verified: `npm run check` 0 errors, prettier clean.

Fixes #115.