### PR TITLE
fix(sidebar): conversation titles truncate prematurely (#132)

### DIFF
--- a/src/lib/components/ConversationItem.svelte
+++ b/src/lib/components/ConversationItem.svelte
@@ -3,7 +3,7 @@
   import { TERMINAL_PHASES, canResumeNow } from "$lib/stores";
   import { getNoSessionPersistence } from "$lib/stores/agent-settings-cache.svelte";
   import StatusBadge from "./StatusBadge.svelte";
-  import { relativeTime, truncate } from "$lib/utils/format";
+  import { relativeTime } from "$lib/utils/format";
   import { PLATFORM_PRESETS } from "$lib/utils/platform-presets";
   import { t } from "$lib/i18n/index.svelte";
   import { dbg, dbgWarn } from "$lib/utils/debug";
@@ -28,7 +28,10 @@
   } = $props();
 
   const run = $derived(conversation.latestRun);
-  const label = $derived(truncate(conversation.title, 28));
+  // Let CSS handle truncation (the title <span> has `truncate`). A hard JS char cap
+  // here truncated titles at 28 chars regardless of available width, so they were
+  // often cut off well before the rail ran out of room. (#132)
+  const label = $derived(conversation.title);
   const time = $derived(relativeTime(run.last_activity_at ?? run.started_at));
   const canResume = $derived(
     canResumeNow(run, run.status as any, getNoSessionPersistence(run.agent)),
@@ -107,7 +110,7 @@
   onkeydown={handleKeydown}
 >
   <div class="flex items-center justify-between gap-2">
-    <div class="flex items-center gap-1.5 min-w-0">
+    <div class="flex items-center gap-1.5 min-w-0 flex-1">
       {#if conversation.isFavorite}
         <svg
           class="h-3 w-3 shrink-0 text-yellow-500"

--- a/src/lib/components/ConversationItem.svelte
+++ b/src/lib/components/ConversationItem.svelte
@@ -148,6 +148,7 @@
       {:else}
         <span
           class="truncate"
+          title={conversation.title}
           ondblclick={(e) => {
             e.stopPropagation();
             startRename();

--- a/src/lib/components/RunListItem.svelte
+++ b/src/lib/components/RunListItem.svelte
@@ -3,7 +3,7 @@
   import { canResumeNow } from "$lib/stores";
   import { getNoSessionPersistence } from "$lib/stores/agent-settings-cache.svelte";
   import StatusBadge from "./StatusBadge.svelte";
-  import { relativeTime, truncate } from "$lib/utils/format";
+  import { relativeTime } from "$lib/utils/format";
   import { PLATFORM_PRESETS } from "$lib/utils/platform-presets";
   import { t } from "$lib/i18n/index.svelte";
   import { hasAttention } from "$lib/stores/attention-store.svelte";
@@ -28,7 +28,10 @@
     onresume?: (runId: string, mode: "resume") => void;
   } = $props();
 
-  const label = $derived(truncate(run.name || run.prompt, 28));
+  // Let CSS handle truncation (the title <span> has `truncate`). A hard JS char cap
+  // here truncated titles at 28 chars regardless of available width, so they were
+  // often cut off well before the rail ran out of room. (#132)
+  const label = $derived(run.name || run.prompt);
   const time = $derived(relativeTime(run.last_activity_at ?? run.started_at));
   const canResume = $derived(
     canResumeNow(run, run.status as any, getNoSessionPersistence(run.agent)),
@@ -90,7 +93,7 @@
   onkeydown={handleKeydown}
 >
   <div class="flex items-center justify-between gap-2">
-    <div class="flex items-center gap-1.5 min-w-0">
+    <div class="flex items-center gap-1.5 min-w-0 flex-1">
       {#if favorite}
         <svg
           class="h-3 w-3 shrink-0 text-yellow-500"
@@ -146,6 +149,7 @@
       {:else}
         <span
           class="truncate"
+          title={run.name || run.prompt}
           ondblclick={(e) => {
             e.stopPropagation();
             startRename();


### PR DESCRIPTION
One of the points in #132: conversation titles in the sidebar sometimes get an ellipsis well before the rail actually runs out of room.

Cause: the title is hard-capped at 28 characters in JS (`truncate(title, 28)`), independent of the available width. The title `<span>` already has a CSS `.truncate`, but it can never kick in because the string is pre-shortened.

Fix: drop the JS cap and let CSS handle width-based truncation, and give the title container `flex-1` so it claims the free space before ellipsizing.

Scoped to just the truncation point — the other items in #132 (icon-only status, indentation) are separate UI calls and left out here.

Verified: `svelte-check` 0 errors.