### PR TITLE
fix(theme): make terminal output blocks follow the CLI theme (#171)

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -503,10 +503,12 @@
   font-size: inherit;
 }
 
-/* Tool terminal output (Bash, shell commands) */
+/* Tool terminal output (Bash, shell commands) — theme-aware surface.
+   Light: follows --muted/--foreground like other tool cards (Read/Edit/Grep).
+   Dark: keeps a deeper "terminal" black, matching .tool-code-block's dark override. */
 .tool-terminal {
-  background: hsl(0 0% 5%);
-  color: hsl(0 0% 85%);
+  background: hsl(var(--muted));
+  color: hsl(var(--foreground));
   font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
   font-size: 0.8125rem;
   line-height: 1.5;
@@ -515,6 +517,58 @@
   overflow-x: auto;
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+.dark .tool-terminal {
+  background: hsl(0 0% 8%);
+  color: hsl(0 0% 85%);
+}
+
+/* Shell command syntax colors (colorizeCommand output) — theme-aware.
+   Light palette is darkened for contrast on the light surface; dark palette
+   keeps the original terminal-bright colors. */
+.sh-prompt {
+  color: #16a34a;
+}
+.sh-command {
+  color: #1f2937;
+}
+.sh-flag {
+  color: #0891b2;
+}
+.sh-string {
+  color: #a16207;
+}
+.sh-operator {
+  color: #9333ea;
+}
+.sh-assign {
+  color: #0891b2;
+}
+.sh-arg {
+  color: #4b5563;
+}
+
+.dark .sh-prompt {
+  color: #4ade80;
+}
+.dark .sh-command {
+  color: #e5e7eb;
+}
+.dark .sh-flag {
+  color: #22d3ee;
+}
+.dark .sh-string {
+  color: #facc15;
+}
+.dark .sh-operator {
+  color: #c084fc;
+}
+.dark .sh-assign {
+  color: #22d3ee;
+}
+.dark .sh-arg {
+  color: #9ca3af;
 }
 
 /* Diff view (Edit tool) */

--- a/src/lib/components/ToolDetailView.svelte
+++ b/src/lib/components/ToolDetailView.svelte
@@ -615,30 +615,33 @@
       <div
         class="tool-terminal relative group/copy {outputExpanded ? '' : 'max-h-96 overflow-hidden'}"
       >
-        <div>{@html commandHtml}</div>
+        <!-- pr-12 reserves room so a long command's first line doesn't run under the copy button -->
+        <div class="pr-12">{@html commandHtml}</div>
         {#if bashResult}
           {#if bashResult.stdout}
             {#if stdoutHtml}
-              <div class="mt-1 text-neutral-300/80">{@html stdoutHtml}</div>
+              <div class="mt-1 text-foreground/80">{@html stdoutHtml}</div>
             {:else}
-              <div class="mt-1 text-neutral-300/80">{stdoutStripped}</div>
+              <div class="mt-1 text-foreground/80">{stdoutStripped}</div>
             {/if}
           {/if}
           {#if bashResult.stderr}
             {#if stderrHtml}
-              <div class="mt-1 text-red-400/80">{@html stderrHtml}</div>
+              <div class="mt-1 text-red-600 dark:text-red-400/80">{@html stderrHtml}</div>
             {:else}
-              <div class="mt-1 text-red-400/80">{stderrStripped}</div>
+              <div class="mt-1 text-red-600 dark:text-red-400/80">{stderrStripped}</div>
             {/if}
           {/if}
           {#if bashResult.interrupted}
-            <div class="mt-1 text-amber-400/80 text-[10px]">{t("tool_interrupted")}</div>
+            <div class="mt-1 text-amber-600 dark:text-amber-400/80 text-[10px]">
+              {t("tool_interrupted")}
+            </div>
           {/if}
         {:else if outputText}
           {#if outputHtml}
-            <div class="mt-1 text-neutral-300/80">{@html outputHtml}</div>
+            <div class="mt-1 text-foreground/80">{@html outputHtml}</div>
           {:else}
-            <div class="mt-1 text-neutral-300/80">{outputStripped}</div>
+            <div class="mt-1 text-foreground/80">{outputStripped}</div>
           {/if}
         {/if}
         {#if isInputStreaming || tool.status === "running"}
@@ -646,7 +649,7 @@
           ></span>
         {/if}
         <button
-          class="absolute top-1.5 right-1.5 text-xs text-neutral-500 hover:text-neutral-300 opacity-0 group-hover/copy:opacity-100 transition-opacity"
+          class="absolute top-1.5 right-1.5 text-xs text-muted-foreground hover:text-foreground opacity-0 group-hover/copy:opacity-100 transition-opacity"
           onclick={() => handleCopy(`$ ${tool.input?.command}\n${terminalPlainText}`)}
           >{copyFeedback ?? t("common_copy")}</button
         >

--- a/src/lib/utils/shell-colorize.test.ts
+++ b/src/lib/utils/shell-colorize.test.ts
@@ -6,50 +6,50 @@ function stripTags(html: string): string {
   return html.replace(/<[^>]*>/g, "");
 }
 
-/** Helper: check if a token has a specific color */
-function hasColor(html: string, text: string, color: string): boolean {
-  return html.includes(`color:${color}">${text}</span>`);
+/** Helper: check if a token is wrapped in a specific syntax class */
+function hasColor(html: string, text: string, cls: string): boolean {
+  return html.includes(`class="${cls}">${text}</span>`);
 }
 
 describe("colorizeCommand", () => {
   it("simple command: ls -la", () => {
     const html = colorizeCommand("ls -la");
-    expect(hasColor(html, "$", "#4ade80")).toBe(true); // prompt green
-    expect(hasColor(html, "ls", "#e5e7eb")).toBe(true); // command white
-    expect(hasColor(html, "-la", "#22d3ee")).toBe(true); // flag cyan
+    expect(hasColor(html, "$", "sh-prompt")).toBe(true); // prompt
+    expect(hasColor(html, "ls", "sh-command")).toBe(true); // command name
+    expect(hasColor(html, "-la", "sh-flag")).toBe(true); // flag
   });
 
   it("pipe: echo hello | grep h", () => {
     const html = colorizeCommand("echo hello | grep h");
-    expect(hasColor(html, "|", "#c084fc")).toBe(true); // pipe magenta
-    expect(hasColor(html, "echo", "#e5e7eb")).toBe(true); // first command
-    expect(hasColor(html, "grep", "#e5e7eb")).toBe(true); // command after pipe
+    expect(hasColor(html, "|", "sh-operator")).toBe(true); // pipe
+    expect(hasColor(html, "echo", "sh-command")).toBe(true); // first command
+    expect(hasColor(html, "grep", "sh-command")).toBe(true); // command after pipe
   });
 
   it("quoted strings", () => {
     const html = colorizeCommand('echo "hello world"');
-    expect(hasColor(html, "&quot;hello world&quot;", "#facc15")).toBe(true); // yellow
+    expect(hasColor(html, "&quot;hello world&quot;", "sh-string")).toBe(true);
   });
 
   it("flags: npm install --save-dev", () => {
     const html = colorizeCommand("npm install --save-dev");
-    expect(hasColor(html, "--save-dev", "#22d3ee")).toBe(true); // cyan
+    expect(hasColor(html, "--save-dev", "sh-flag")).toBe(true);
   });
 
   it("redirection: cat file > out.txt", () => {
     const html = colorizeCommand("cat file > out.txt");
-    expect(hasColor(html, "&gt;", "#c084fc")).toBe(true); // magenta
+    expect(hasColor(html, "&gt;", "sh-operator")).toBe(true);
   });
 
   it("chained commands: cd /tmp && ls", () => {
     const html = colorizeCommand("cd /tmp && ls");
-    expect(hasColor(html, "&amp;&amp;", "#c084fc")).toBe(true); // magenta
-    expect(hasColor(html, "ls", "#e5e7eb")).toBe(true); // command after &&
+    expect(hasColor(html, "&amp;&amp;", "sh-operator")).toBe(true);
+    expect(hasColor(html, "ls", "sh-command")).toBe(true); // command after &&
   });
 
   it("empty command: only $ prompt with trailing space", () => {
     const html = colorizeCommand("");
-    expect(hasColor(html, "$", "#4ade80")).toBe(true);
+    expect(hasColor(html, "$", "sh-prompt")).toBe(true);
     expect(stripTags(html)).toBe("$ ");
   });
 
@@ -69,9 +69,9 @@ describe("colorizeCommand", () => {
 
   it("env var assignment: FOO=1 BAR=2 npm run dev", () => {
     const html = colorizeCommand("FOO=1 BAR=2 npm run dev");
-    expect(hasColor(html, "FOO=1", "#22d3ee")).toBe(true); // assign cyan
-    expect(hasColor(html, "BAR=2", "#22d3ee")).toBe(true); // assign cyan
-    expect(hasColor(html, "npm", "#e5e7eb")).toBe(true); // command white
+    expect(hasColor(html, "FOO=1", "sh-assign")).toBe(true); // assign
+    expect(hasColor(html, "BAR=2", "sh-assign")).toBe(true); // assign
+    expect(hasColor(html, "npm", "sh-command")).toBe(true); // command name
   });
 
   it("complex syntax graceful degradation: $(date)", () => {

--- a/src/lib/utils/shell-colorize.ts
+++ b/src/lib/utils/shell-colorize.ts
@@ -9,19 +9,20 @@
 import { escapeHtml } from "./ansi";
 import { dbg } from "./debug";
 
-// Color palette (terminal-inspired)
+// Syntax token CSS classes — actual colors live in app.css (.sh-*) so they can
+// switch with the light/dark theme instead of being baked into inline styles.
 const C = {
-  prompt: "#4ade80", // bright green — $ prompt
-  command: "#e5e7eb", // white/bright — command name
-  flag: "#22d3ee", // cyan — --flags, -f
-  string: "#facc15", // yellow — "quoted" / 'quoted'
-  operator: "#c084fc", // magenta — |, &&, ||, ;, >, >>, <, 2>&1
-  assign: "#22d3ee", // cyan — FOO=bar env var assignment
-  arg: "#9ca3af", // default gray — other arguments
+  prompt: "sh-prompt", // $ prompt
+  command: "sh-command", // command name
+  flag: "sh-flag", // --flags, -f
+  string: "sh-string", // "quoted" / 'quoted'
+  operator: "sh-operator", // |, &&, ||, ;, >, >>, <, 2>&1
+  assign: "sh-assign", // FOO=bar env var assignment
+  arg: "sh-arg", // other arguments
 } as const;
 
-function span(color: string, text: string): string {
-  return `<span style="color:${color}">${text}</span>`;
+function span(cls: string, text: string): string {
+  return `<span class="${cls}">${text}</span>`;
 }
 
 // Regex to tokenize shell commands into meaningful pieces

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -5056,7 +5056,7 @@
                       <div class="w-full py-2">
                         <div class="chat-content-width pl-7">
                           <div
-                            class="command-output rounded-lg border border-border/40 bg-[#1a1b26] px-4 py-3 text-sm overflow-x-auto"
+                            class="command-output rounded-lg border border-border/40 bg-muted dark:bg-[#1a1b26] px-4 py-3 text-sm overflow-x-auto"
                           >
                             {#if entry.content.includes("## Context Usage")}
                               <ContextUsageGrid text={entry.content} />
@@ -5068,7 +5068,7 @@
                               <ReleaseNotesCard text={entry.content} />
                             {:else if hasAnsiCodes(entry.content)}
                               <pre
-                                class="whitespace-pre font-mono text-xs leading-relaxed text-[#c0caf5] m-0">{@html ansiToHtml(
+                                class="whitespace-pre font-mono text-xs leading-relaxed text-foreground dark:text-[#c0caf5] m-0">{@html ansiToHtml(
                                   entry.content,
                                 )}</pre>
                             {:else}


### PR DESCRIPTION
## Summary

Fixes #171. After switching the CLI theme to light, the Bash tool card kept a dark background with low-contrast text, unlike the Read/Edit/Grep cards. Root cause: the terminal blocks were hardcoded for a dark surface and never wired to the theme CSS variables. Includes two closely related polish items found while verifying.

## Changes

- **`.tool-terminal`** now uses `--muted`/`--foreground` in light mode and keeps a deeper terminal black in dark mode (mirrors the existing `.tool-code-block` dark override).
- **`colorizeCommand`** emits `.sh-*` classes instead of inline hex, so the shell syntax palette switches with the theme. The old dark palette was invisible on a light surface (e.g. the near-white command name, yellow strings).
- **Bash stdout/stderr/interrupted text** and the **copy button** use theme tokens instead of fixed `neutral`/`red` shades.
- **(B) `command_output`** (slash-command output, e.g. `/context`, `/cost`) follows the theme in light mode and keeps its dark TokyoNight palette in dark mode.
- **(C) Copy button** no longer overlaps a long command's first line (`pr-12` reserves space).

## Notes

- ANSI program output (`ansiToHtml`) keeps its existing palette — those are semantic colors emitted by the program (red/green etc.), readable on both themes; remapping them is out of scope.
- Both themes verified manually in the running app (light: light-bg + dark text matching other cards; dark: terminal black + colored syntax retained).

## Test plan

- `npm run lint` — 0 errors
- `npm run check` — 0 errors
- `npm test` — all pass
- `npm run build` — OK