### PR TITLE
feat(permissions): add "Always allow {tool}" to auto-approve a tool for the session

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -927,6 +927,7 @@
   "history_allAgents": "All Agents",
 
   "common_allow": "Allow",
+  "common_alwaysAllowTool": "Always allow {tool}",
   "common_deny": "Deny",
   "common_denied": "Denied",
   "common_save": "Save",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -927,6 +927,7 @@
   "history_allAgents": "所有代理",
 
   "common_allow": "允许",
+  "common_alwaysAllowTool": "始终允许 {tool}",
   "common_deny": "拒绝",
   "common_denied": "已拒绝",
   "common_save": "保存",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "OpenCovibe"
-version = "0.2.0"
+version = "0.2.5"
 dependencies = [
  "axum",
  "base64 0.22.1",

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -26,7 +26,7 @@ use crate::storage;
 use crate::storage::runs;
 use crate::web_server::broadcaster::BroadcastEmitter;
 use serde_json::Value;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -177,6 +177,9 @@ pub enum ActorCommand {
     RespondPermission {
         request_id: String,
         response: Value,
+        /// When true and the response allows, remember the request's tool for the
+        /// rest of this session so future prompts for that tool auto-allow.
+        remember_tool: bool,
         reply: oneshot::Sender<Result<(), String>>,
     },
     /// Cancel a pending control_request (top-level message type, not a control_request subtype).
@@ -300,6 +303,12 @@ struct SessionActor {
     /// Set when emitting PermissionPrompt / HookCallback(PreToolUse) / ElicitationPrompt.
     /// Cleared when the response is received. Retained during quarantine for diagnostics.
     pending_interactive_request: Option<PendingInteractiveRequest>,
+
+    /// Tool names the user chose to "remember" via an allow response. While a tool
+    /// is in this set, future `can_use_tool` prompts for it are auto-allowed for the
+    /// rest of this session instead of prompting again. Session-scoped only —
+    /// not persisted across runs.
+    remembered_tools: HashSet<String>,
 }
 
 // ── Spawn entry point ──
@@ -377,6 +386,7 @@ pub fn spawn_actor(
         ralph_loop: None,
         ralph_needs_dispatch: false,
         pending_interactive_request: None,
+        remembered_tools: HashSet::new(),
     };
 
     let join_handle = tokio::spawn(async move {
@@ -450,8 +460,8 @@ impl SessionActor {
                             let r = self.handle_send_control_async(request).await;
                             let _ = reply.send(r);
                         }
-                        Some(ActorCommand::RespondPermission { request_id, response, reply }) => {
-                            let r = self.handle_respond_permission(&request_id, response).await;
+                        Some(ActorCommand::RespondPermission { request_id, response, remember_tool, reply }) => {
+                            let r = self.handle_respond_permission(&request_id, response, remember_tool).await;
                             let _ = reply.send(r);
                         }
                         Some(ActorCommand::CancelControlRequest { request_id, reply }) => {
@@ -1685,12 +1695,33 @@ impl SessionActor {
         &mut self,
         request_id: &str,
         response: Value,
+        remember_tool: bool,
     ) -> Result<(), String> {
         log::debug!(
-            "[actor] respond_permission: run_id={}, req_id={}",
+            "[actor] respond_permission: run_id={}, req_id={}, remember_tool={}",
             self.run_id,
             request_id,
+            remember_tool,
         );
+        // If asked to remember, and this is an allow, record the request's tool so future
+        // prompts for it auto-allow. Read the tool name from the pending request (matched
+        // by request_id) before clearing it.
+        if remember_tool && response.get("behavior").and_then(|v| v.as_str()) == Some("allow") {
+            if let Some(tool) = self
+                .pending_interactive_request
+                .as_ref()
+                .filter(|req| req.request_id == request_id && req.subtype == "can_use_tool")
+                .map(|req| req.detail.clone())
+            {
+                if self.remembered_tools.insert(tool.clone()) {
+                    log::info!(
+                        "[actor] remembering tool '{}' for run_id={} — future prompts auto-allow",
+                        tool,
+                        self.run_id,
+                    );
+                }
+            }
+        }
         self.clear_pending_interactive_request(request_id);
         self.write_interactive_response(PendingKind::Permission, request_id, response)
             .await
@@ -2450,6 +2481,30 @@ impl SessionActor {
                 .and_then(|v| v.as_array())
                 .cloned()
                 .unwrap_or_default();
+
+            // Auto-allow if the user previously chose to remember this tool this session.
+            // Respond directly to the CLI and skip the prompt entirely.
+            if self.remembered_tools.contains(&tool_name) {
+                log::debug!(
+                    "[actor] auto-allowing remembered tool '{}': run_id={}, req_id={}",
+                    tool_name,
+                    self.run_id,
+                    request_id
+                );
+                let response = serde_json::json!({
+                    "behavior": "allow",
+                    "updatedInput": tool_input,
+                });
+                if let Err(e) = self.write_control_response(&request_id, response).await {
+                    log::warn!(
+                        "[actor] auto-allow write failed for tool '{}', req_id={}: {}",
+                        tool_name,
+                        request_id,
+                        e
+                    );
+                }
+                return;
+            }
 
             log::debug!(
                 "[actor] permission prompt: run_id={}, req_id={}, tool={}, reason={}, parent={:?}, suggestions={}",

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1499,9 +1499,11 @@ pub async fn respond_permission(
     updated_input: Option<serde_json::Value>,
     deny_message: Option<String>,
     interrupt: Option<bool>,
+    remember_tool: Option<bool>,
 ) -> Result<(), String> {
+    let remember_tool = remember_tool.unwrap_or(false);
     log::debug!(
-        "[session] respond_permission: run_id={}, req_id={}, behavior={}, updated_perms={}, has_updated_input={}, has_deny_message={}, interrupt={:?}",
+        "[session] respond_permission: run_id={}, req_id={}, behavior={}, updated_perms={}, has_updated_input={}, has_deny_message={}, interrupt={:?}, remember_tool={}",
         run_id,
         request_id,
         behavior,
@@ -1509,6 +1511,7 @@ pub async fn respond_permission(
         updated_input.is_some(),
         deny_message.is_some(),
         interrupt,
+        remember_tool,
     );
 
     let cmd_tx = get_cmd_tx(&sessions, &run_id).await?;
@@ -1546,6 +1549,7 @@ pub async fn respond_permission(
         .send(ActorCommand::RespondPermission {
             request_id: request_id.clone(),
             response,
+            remember_tool,
             reply: reply_tx,
         })
         .await

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -1076,11 +1076,16 @@ pub async fn dispatch_command(
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let interrupt = params.get("interrupt").and_then(|v| v.as_bool());
+            let remember_tool = params
+                .get("remember_tool")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             log::debug!(
-                "[dispatch] respond_permission: run_id={}, req_id={}, behavior={}",
+                "[dispatch] respond_permission: run_id={}, req_id={}, behavior={}, remember_tool={}",
                 run_id,
                 request_id,
-                behavior
+                behavior,
+                remember_tool
             );
             let cmd_tx = {
                 let map = state.sessions.lock().await;
@@ -1115,6 +1120,7 @@ pub async fn dispatch_command(
                 .send(ActorCommand::RespondPermission {
                     request_id,
                     response,
+                    remember_tool,
                     reply: reply_tx,
                 })
                 .await

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -650,6 +650,7 @@ export async function respondPermission(
   updatedInput?: Record<string, unknown>,
   denyMessage?: string,
   interrupt?: boolean,
+  rememberTool?: boolean,
 ): Promise<void> {
   dbg("api", "respondPermission", {
     runId,
@@ -659,6 +660,7 @@ export async function respondPermission(
     updatedInput,
     denyMessage,
     interrupt,
+    rememberTool,
   });
   return invoke("respond_permission", {
     runId,
@@ -668,6 +670,7 @@ export async function respondPermission(
     updatedInput: updatedInput ?? null,
     denyMessage: denyMessage ?? null,
     interrupt: interrupt ?? null,
+    rememberTool: rememberTool ?? null,
   });
 }
 

--- a/src/lib/components/PermissionPanel.svelte
+++ b/src/lib/components/PermissionPanel.svelte
@@ -19,6 +19,7 @@
       updatedInput?: Record<string, unknown>,
       denyMessage?: string,
       interrupt?: boolean,
+      rememberTool?: boolean,
     ) => void | Promise<void>;
     agentDisplayName?: string;
   } = $props();
@@ -45,9 +46,10 @@
     updatedInput?: Record<string, unknown>,
     denyMessage?: string,
     interrupt?: boolean,
+    rememberTool?: boolean,
   ) {
     if (submittingAll || submittingIds.has(requestId)) return;
-    dbg("PermissionPanel", "respondSingle", { requestId, behavior });
+    dbg("PermissionPanel", "respondSingle", { requestId, behavior, rememberTool });
     markSubmitting(requestId);
     try {
       await onPermissionRespond(
@@ -57,6 +59,7 @@
         updatedInput,
         denyMessage,
         interrupt,
+        rememberTool,
       );
     } catch (e) {
       dbgWarn("PermissionPanel", "respondSingle failed", { requestId, reason: e });
@@ -161,6 +164,21 @@
               disabled={busy}
               onclick={() => respondSingle(item.requestId, "allow", undefined, item.tool.input)}
               >{t("common_allow")}</button
+            >
+            <button
+              class="rounded-md border border-emerald-600/40 bg-emerald-600/10 px-3 py-1.5 text-xs font-medium text-emerald-600 dark:text-emerald-400 hover:bg-emerald-600/20 transition-all disabled:opacity-50"
+              disabled={busy}
+              title={t("common_alwaysAllowTool", { tool: item.tool.tool_name })}
+              onclick={() =>
+                respondSingle(
+                  item.requestId,
+                  "allow",
+                  undefined,
+                  item.tool.input,
+                  undefined,
+                  undefined,
+                  true,
+                )}>{t("common_alwaysAllowTool", { tool: item.tool.tool_name })}</button
             >
             <button
               class="rounded-md border border-border px-4 py-1.5 text-xs font-medium text-foreground hover:bg-accent transition-all disabled:opacity-50"

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -4095,6 +4095,7 @@
     updatedInput?: Record<string, unknown>,
     denyMessage?: string,
     interrupt?: boolean,
+    rememberTool?: boolean,
   ) {
     if (!store.run || !store.sessionAlive) return;
     const runId = store.run.id; // snapshot — store.run may change after await
@@ -4106,6 +4107,7 @@
       updatedInput,
       denyMessage,
       interrupt,
+      rememberTool,
     });
     try {
       // Set pending mode override BEFORE responding (so reducer picks it up)
@@ -4125,6 +4127,7 @@
         updatedInput,
         denyMessage,
         interrupt,
+        rememberTool,
       );
       // Optimistic resolve + clear attention flag
       resolvePermissionOptimistic(store, runId, requestId, behavior);


### PR DESCRIPTION
## Summary

Adds a per-session **“Always allow {tool}”** option to the permission prompt. Today every `can_use_tool` request re-prompts even for a tool the user has already approved many times in the same session. With this change, when the user allows a request with the new toggle, subsequent prompts for that **same tool** are auto-allowed for the rest of the session — no repeated clicking.

Opt-in and session-scoped: nothing is persisted across runs, and the default path is unchanged.

## What changed

**Backend**
- `session_actor`: `ActorCommand::RespondPermission` gains a `remember_tool` flag. On an `allow`, the request’s tool name (read from the pending `can_use_tool` request) is recorded in a session-scoped `remembered_tools: HashSet<String>`. The `can_use_tool` ingestion path checks this set first and, for a remembered tool, writes an `allow` `control_response` directly — skipping the prompt and the `PermissionPrompt` event entirely.
- `respond_permission` command + web-server dispatch thread `remember_tool` through. Defaults to `false`, so existing callers are unaffected.

**Frontend**
- `PermissionPanel`: an “Allow, don’t ask again for {tool}” action, wired through `api.ts` (`rememberTool`).
- i18n strings for `en` + `zh-CN`.

## Notes
- Session-scoped only (in-memory), matching how the CLI’s own permission state works — no new persistence.
- Only triggers on **allow** (a remembered deny would be a footgun).
- Based on `master` (v0.2.5); backend `cargo check` passes clean.