### PR TITLE
fix(sidebar): show real app version in rail instead of hardcoded "v0.1"

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,6 +57,9 @@
   import { TeamStore } from "$lib/stores/team-store.svelte";
   import { KeybindingStore } from "$lib/stores/keybindings.svelte";
   import { getTransport } from "$lib/transport";
+  // Build-time app version — fallback for the sidebar rail when the Tauri runtime
+  // getVersion() isn't available (web/remote mode). Bumped by the release script.
+  import { version as pkgVersion } from "../../package.json";
   import {
     t,
     LOCALE_REGISTRY,
@@ -81,6 +84,19 @@
   let showAbout = $state(false);
   let showCliBrowser = $state(false);
   let permissionsModalOpen = $state(false);
+
+  // Sidebar rail version. getVersion() is the installed app version (matches the About
+  // dialog — issue #178: the rail was hardcoded to "v0.1"); fall back to the build-time
+  // package version for non-Tauri (web/remote) mode.
+  let appVersion = $state(pkgVersion);
+  onMount(async () => {
+    try {
+      const { getVersion } = await import("@tauri-apps/api/app");
+      appVersion = await getVersion();
+    } catch {
+      // Non-Tauri context — keep the build-time fallback.
+    }
+  });
 
   // Team store (shared via context with /teams page)
   const teamStore = new TeamStore();
@@ -1401,7 +1417,7 @@
             <button
               class="text-xs text-muted-foreground hover:text-muted-foreground transition-colors cursor-pointer"
               onclick={() => (showAbout = true)}
-              title="About OpenCovibe">v0.1</button
+              title="About OpenCovibe">v{appVersion}</button
             >
           </div>
           <div class="relative mx-auto mb-0.5">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,9 +57,7 @@
   import { TeamStore } from "$lib/stores/team-store.svelte";
   import { KeybindingStore } from "$lib/stores/keybindings.svelte";
   import { getTransport } from "$lib/transport";
-  // Build-time app version — fallback for the sidebar rail when the Tauri runtime
-  // getVersion() isn't available (web/remote mode). Bumped by the release script.
-  import { version as pkgVersion } from "../../package.json";
+  import { version as packageVersion } from "../../package.json";
   import {
     t,
     LOCALE_REGISTRY,
@@ -84,19 +82,25 @@
   let showAbout = $state(false);
   let showCliBrowser = $state(false);
   let permissionsModalOpen = $state(false);
+  let appVersion = $state(packageVersion);
 
-  // Sidebar rail version. getVersion() is the installed app version (matches the About
-  // dialog — issue #178: the rail was hardcoded to "v0.1"); fall back to the build-time
-  // package version for non-Tauri (web/remote) mode.
-  let appVersion = $state(pkgVersion);
-  onMount(async () => {
+  async function loadAppVersion() {
+    if (!getTransport().isDesktop()) {
+      dbg("layout", "app version loaded", { source: "package", version: appVersion });
+      return;
+    }
+
     try {
       const { getVersion } = await import("@tauri-apps/api/app");
       appVersion = await getVersion();
-    } catch {
-      // Non-Tauri context — keep the build-time fallback.
+      dbg("layout", "app version loaded", { source: "tauri", version: appVersion });
+    } catch (error) {
+      dbgWarn("layout", "failed to load Tauri app version", {
+        error,
+        fallbackVersion: packageVersion,
+      });
     }
-  });
+  }
 
   // Team store (shared via context with /teams page)
   const teamStore = new TeamStore();
@@ -606,6 +610,7 @@
     loadSettings();
     loadSidebarFavorites();
     loadAgentSettingsCache();
+    void loadAppVersion();
 
     // Load saved CWD and pinned folders from localStorage
     const saved = localStorage.getItem("ocv:project-cwd");


### PR DESCRIPTION
## Problem

Fixes #178. On an installed **v0.2.x** build, the sidebar rail displays **v0.1**, while the About dialog correctly shows the real version (e.g. v0.2.7). Reported on Windows after installing v0.2.6.

Root cause — the rail's About button label is hardcoded in `src/routes/+layout.svelte`:

```svelte
title="About OpenCovibe">v0.1</button>
```

The About dialog is correct because it reads the actual version via `getVersion()` from `@tauri-apps/api/app`; the rail button never did.

## Fix

Read the version the same way the About dialog does — `getVersion()` — and render `v{appVersion}` on the rail button. Fall back to the build-time `package.json` version for non-Tauri (web/remote) mode so the label is never blank or stale.

Frontend-only, one file changed.

## Testing

- `npm run check` → 0 errors; ESLint and Prettier clean on the changed file.
- Desktop (Tauri): the rail now shows the installed version, matching the About dialog.
- Web/remote (no Tauri runtime): the rail shows the build-time package version instead of a blank label.