### PR TITLE
feat: support Codex sub-agent protocol

### DIFF
--- a/src-tauri/src/agent/claude_protocol.rs
+++ b/src-tauri/src/agent/claude_protocol.rs
@@ -91,6 +91,9 @@ pub fn validate_bus_event(ev: &BusEvent) -> Option<ValidationWarn> {
         // State-class (Codex thread goal): never drop — the GoalPanel needs every update,
         // including the null-goal "cleared" signal.
         BusEvent::GoalUpdate { .. } => None,
+        // Info-class event: partial identity is valid because older Codex versions may omit
+        // nickname, role, or parent linkage from `thread/read`.
+        BusEvent::CodexAgentInfo { .. } => None,
         // Everything else: pass through
         _ => None,
     }

--- a/src-tauri/src/agent/codex_appserver.rs
+++ b/src-tauri/src/agent/codex_appserver.rs
@@ -21,7 +21,13 @@ use crate::agent::session_protocol::{
 };
 use crate::models::BusEvent;
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::time::{Duration, Instant};
+
+const MAX_UNCLAIMED_THREADS: usize = 32;
+const MAX_DEFERRED_MESSAGES_PER_THREAD: usize = 64;
+const MAX_DEFERRED_PAYLOAD_BYTES: usize = 512 * 1024;
+const DEFERRED_MESSAGE_TTL: Duration = Duration::from_secs(30);
 
 /// app-server method names for server→client interactive requests we handle.
 const M_CMD_APPROVAL: &str = "item/commandExecution/requestApproval";
@@ -49,6 +55,41 @@ struct PendingServerReq {
     requested_permissions: Option<Value>,
 }
 
+enum DeferredThreadMessage {
+    Notification { method: String, params: Value },
+    Interactive { method: String, message: Value },
+}
+
+impl DeferredThreadMessage {
+    fn is_interactive(&self) -> bool {
+        matches!(self, Self::Interactive { .. })
+    }
+
+    fn payload_bytes(&self) -> usize {
+        match self {
+            Self::Notification { method, params } => method.len() + params.to_string().len(),
+            Self::Interactive { method, message } => method.len() + message.to_string().len(),
+        }
+    }
+}
+
+fn reject_deferred_interactive(message: DeferredThreadMessage, reason: &str, out: &mut ParsedLine) {
+    if let DeferredThreadMessage::Interactive { message, .. } = message {
+        out.outbound.push(json!({
+            "jsonrpc": "2.0",
+            "id": message.get("id").cloned().unwrap_or(Value::Null),
+            "error": { "code": -32600, "message": reason }
+        }));
+    }
+}
+
+struct DeferredThreadEntry {
+    message: DeferredThreadMessage,
+    received_at: Instant,
+    sequence: u64,
+    payload_bytes: usize,
+}
+
 pub struct CodexAppServer {
     phase: Phase,
     thread_id: Option<String>,
@@ -64,6 +105,20 @@ pub struct CodexAppServer {
     /// When the reply arrives (`parse_line` sees a matching id with no `method`) we resolve the
     /// actor's `control_waiter` for that frontend request_id with the JSON-RPC `result`/`error`.
     client_waiters: HashMap<i64, String>,
+    /// Autonomous `thread/read` requests keyed by JSON-RPC id → spawned thread id.
+    internal_waiters: HashMap<i64, String>,
+    /// Spawned threads already scheduled for identity lookup. Collab items can be repeated as
+    /// their status changes, but their immutable identity only needs one read per session.
+    seen_subagent_threads: HashSet<String>,
+    /// Spawned thread id → Agent card id. Child notifications share the parent's app-server
+    /// connection, so this mapping lets their activity enter the card's sub-timeline.
+    child_parent_tools: HashMap<String, String>,
+    /// Notifications and requests can race ahead of the parent's spawn item. Keep them isolated
+    /// until that item proves ownership; both dimensions are capped so unrelated threads cannot
+    /// grow session memory without bound.
+    deferred_thread_messages: HashMap<String, VecDeque<DeferredThreadEntry>>,
+    deferred_payload_bytes: usize,
+    next_deferred_sequence: u64,
     /// Extra writable directories from settings (`StartupCtx.add_dirs`). `thread/start`'s
     /// `sandbox` is a bare mode string and can't carry writable roots, so these are injected
     /// into the `workspaceWrite` `sandboxPolicy` on `turn/start` (persists server-side).
@@ -87,6 +142,12 @@ impl Default for CodexAppServer {
             next_client_id: 3,
             pending: HashMap::new(),
             client_waiters: HashMap::new(),
+            internal_waiters: HashMap::new(),
+            seen_subagent_threads: HashSet::new(),
+            child_parent_tools: HashMap::new(),
+            deferred_thread_messages: HashMap::new(),
+            deferred_payload_bytes: 0,
+            next_deferred_sequence: 0,
             add_dirs: Vec::new(),
             startup_overrides: CodexTurnOverrides::default(),
             pending_startup_replay: true,
@@ -99,10 +160,280 @@ impl CodexAppServer {
         Self::default()
     }
 
+    /// Expire unclaimed requests even while app-server stdout is quiet waiting for a response.
+    /// The actor calls this from its existing periodic timeout tick and writes returned frames.
+    pub fn expire_deferred(&mut self) -> Vec<Value> {
+        let mut out = ParsedLine::default();
+        self.expire_deferred_messages(&mut out);
+        out.outbound
+    }
+
     fn next_id(&mut self) -> i64 {
         let id = self.next_client_id;
         self.next_client_id += 1;
         id
+    }
+
+    /// Register newly spawned threads and request their identity. Codex 0.147 reports spawn via
+    /// `subAgentActivity.agentThreadId`; older spawnAgent payloads use `receiverThreadIds`.
+    fn register_subagents(
+        &mut self,
+        run_id: &str,
+        item: &Value,
+        containing_parent_tool_id: Option<&str>,
+        out: &mut ParsedLine,
+    ) {
+        // The frontend supports one sub-timeline level. Descendants therefore stay in the
+        // original top-level Agent card instead of targeting a nested Agent item as parent.
+        let parent_tool_id = containing_parent_tool_id
+            .or_else(|| item.get("id").and_then(Value::as_str))
+            .unwrap_or("");
+        let thread_ids: Vec<&str> = match item.get("type").and_then(Value::as_str) {
+            Some("subAgentActivity")
+                if item.get("kind").and_then(Value::as_str) == Some("started") =>
+            {
+                item.get("agentThreadId")
+                    .and_then(Value::as_str)
+                    .into_iter()
+                    .collect()
+            }
+            Some("collabAgentToolCall")
+                if item.get("tool").and_then(Value::as_str) == Some("spawnAgent") =>
+            {
+                item.get("receiverThreadIds")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                    .filter_map(Value::as_str)
+                    .collect()
+            }
+            _ => return,
+        };
+
+        for thread_id in thread_ids {
+            if thread_id.is_empty() {
+                continue;
+            }
+            if !parent_tool_id.is_empty() {
+                self.child_parent_tools
+                    .insert(thread_id.to_string(), parent_tool_id.to_string());
+                self.replay_deferred_thread(run_id, thread_id, out);
+            }
+            if !self.seen_subagent_threads.insert(thread_id.to_string()) {
+                continue;
+            }
+
+            let id = self.next_id();
+            self.internal_waiters.insert(id, thread_id.to_string());
+            out.outbound.push(json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": "thread/read",
+                "params": { "threadId": thread_id, "includeTurns": false }
+            }));
+            log::debug!(
+                "[codex_appserver] sub-agent identity requested: thread_id={}, request_id={}",
+                thread_id,
+                id
+            );
+        }
+    }
+
+    fn defer_thread_message(
+        &mut self,
+        thread_id: &str,
+        message: DeferredThreadMessage,
+        out: &mut ParsedLine,
+    ) -> bool {
+        self.expire_deferred_messages(out);
+        let payload_bytes = message.payload_bytes();
+        if payload_bytes > MAX_DEFERRED_PAYLOAD_BYTES {
+            reject_deferred_interactive(message, "Interactive request exceeds buffer limit", out);
+            return false;
+        }
+        let interactive = message.is_interactive();
+        while self.deferred_thread_messages.len() >= MAX_UNCLAIMED_THREADS
+            && !self.deferred_thread_messages.contains_key(thread_id)
+        {
+            if !self.evict_oldest_deferred(interactive, out) {
+                reject_deferred_interactive(message, "Interactive request buffer is full", out);
+                return false;
+            }
+        }
+        while self
+            .deferred_thread_messages
+            .get(thread_id)
+            .is_some_and(|queue| queue.len() >= MAX_DEFERRED_MESSAGES_PER_THREAD)
+        {
+            if !self.evict_oldest_deferred_in_thread(thread_id, interactive, out) {
+                reject_deferred_interactive(message, "Interactive request buffer is full", out);
+                return false;
+            }
+        }
+        while self.deferred_payload_bytes + payload_bytes > MAX_DEFERRED_PAYLOAD_BYTES {
+            if !self.evict_oldest_deferred(interactive, out) {
+                reject_deferred_interactive(message, "Interactive request buffer is full", out);
+                return false;
+            }
+        }
+        let sequence = self.next_deferred_sequence;
+        self.next_deferred_sequence = self.next_deferred_sequence.wrapping_add(1);
+        self.deferred_payload_bytes += payload_bytes;
+        let queue = self
+            .deferred_thread_messages
+            .entry(thread_id.to_string())
+            .or_default();
+        queue.push_back(DeferredThreadEntry {
+            message,
+            received_at: Instant::now(),
+            sequence,
+            payload_bytes,
+        });
+        log::debug!(
+            "[codex_appserver] unclaimed thread message deferred: thread_id={}, queued={}, total_bytes={}",
+            thread_id,
+            queue.len(),
+            self.deferred_payload_bytes
+        );
+        true
+    }
+
+    fn evict_oldest_deferred_in_thread(
+        &mut self,
+        thread_id: &str,
+        incoming_interactive: bool,
+        out: &mut ParsedLine,
+    ) -> bool {
+        let Some(queue) = self.deferred_thread_messages.get(thread_id) else {
+            return false;
+        };
+        let oldest_notification = queue
+            .iter()
+            .find(|entry| !entry.message.is_interactive())
+            .map(|entry| entry.sequence);
+        let sequence = oldest_notification.or_else(|| {
+            incoming_interactive
+                .then(|| queue.front().map(|entry| entry.sequence))
+                .flatten()
+        });
+        let Some(sequence) = sequence else {
+            return false;
+        };
+        self.remove_deferred_entry(
+            thread_id,
+            sequence,
+            out,
+            "Interactive request evicted from buffer",
+        );
+        true
+    }
+
+    fn expire_deferred_messages(&mut self, out: &mut ParsedLine) {
+        let now = Instant::now();
+        let expired: Vec<(String, u64)> = self
+            .deferred_thread_messages
+            .iter()
+            .flat_map(|(thread_id, queue)| {
+                queue
+                    .iter()
+                    .take_while(|entry| {
+                        now.duration_since(entry.received_at) >= DEFERRED_MESSAGE_TTL
+                    })
+                    .map(|entry| (thread_id.clone(), entry.sequence))
+            })
+            .collect();
+        for (thread_id, sequence) in expired {
+            self.remove_deferred_entry(&thread_id, sequence, out, "Interactive request expired");
+        }
+    }
+
+    fn evict_oldest_deferred(&mut self, incoming_interactive: bool, out: &mut ParsedLine) -> bool {
+        let oldest_matching = |interactive: bool| {
+            self.deferred_thread_messages
+                .iter()
+                .flat_map(|(thread_id, queue)| {
+                    queue.iter().filter_map(move |entry| {
+                        (entry.message.is_interactive() == interactive)
+                            .then_some((thread_id.clone(), entry.sequence))
+                    })
+                })
+                .min_by_key(|(_, sequence)| *sequence)
+        };
+        // Ordinary notifications are disposable telemetry. Never evict an unanswered request
+        // for another notification; an incoming request may evict a request only after every
+        // buffered notification has already been removed.
+        let oldest = oldest_matching(false).or_else(|| {
+            incoming_interactive
+                .then(|| oldest_matching(true))
+                .flatten()
+        });
+        let Some((thread_id, sequence)) = oldest else {
+            return false;
+        };
+        self.remove_deferred_entry(
+            &thread_id,
+            sequence,
+            out,
+            "Interactive request evicted from buffer",
+        );
+        true
+    }
+
+    fn remove_deferred_entry(
+        &mut self,
+        thread_id: &str,
+        sequence: u64,
+        out: &mut ParsedLine,
+        reason: &str,
+    ) {
+        let mut removed = None;
+        let mut empty = false;
+        if let Some(queue) = self.deferred_thread_messages.get_mut(thread_id) {
+            if let Some(index) = queue.iter().position(|entry| entry.sequence == sequence) {
+                removed = queue.remove(index);
+            }
+            empty = queue.is_empty();
+        }
+        if empty {
+            self.deferred_thread_messages.remove(thread_id);
+        }
+        if let Some(entry) = removed {
+            self.deferred_payload_bytes = self
+                .deferred_payload_bytes
+                .saturating_sub(entry.payload_bytes);
+            reject_deferred_interactive(entry.message, reason, out);
+        }
+    }
+
+    fn replay_deferred_thread(&mut self, run_id: &str, thread_id: &str, out: &mut ParsedLine) {
+        let Some(mut messages) = self.deferred_thread_messages.remove(thread_id) else {
+            return;
+        };
+        log::debug!(
+            "[codex_appserver] replaying deferred thread messages: thread_id={}, count={}",
+            thread_id,
+            messages.len()
+        );
+        while let Some(entry) = messages.pop_front() {
+            self.deferred_payload_bytes = self
+                .deferred_payload_bytes
+                .saturating_sub(entry.payload_bytes);
+            if entry.received_at.elapsed() >= DEFERRED_MESSAGE_TTL {
+                reject_deferred_interactive(entry.message, "Interactive request expired", out);
+                continue;
+            }
+            match entry.message {
+                DeferredThreadMessage::Notification { method, params } => {
+                    self.handle_notification(run_id, &method, &params, out);
+                }
+                DeferredThreadMessage::Interactive { method, message } => {
+                    let replayed = self.handle_server_request(run_id, &method, &message);
+                    out.events.extend(replayed.events);
+                    out.interactive.extend(replayed.interactive);
+                    out.outbound.extend(replayed.outbound);
+                }
+            }
+        }
     }
 
     /// True once the thread is open and `turn/start` can be sent.
@@ -495,6 +826,30 @@ impl SessionProtocol for CodexAppServer {
             return out;
         }
 
+        // Autonomous metadata replies are not frontend control responses. A failed identity
+        // lookup is non-fatal: the Agent card still renders with its thread id and live status.
+        if let Some(id) = msg.get("id").and_then(Value::as_i64) {
+            if let Some(thread_id) = self.internal_waiters.remove(&id) {
+                if let Some(thread) = msg.get("result").and_then(|r| r.get("thread")) {
+                    let string_field =
+                        |name: &str| thread.get(name).and_then(Value::as_str).map(str::to_string);
+                    out.events.push(BusEvent::CodexAgentInfo {
+                        run_id: run_id.to_string(),
+                        thread_id,
+                        nickname: string_field("agentNickname"),
+                        role: string_field("agentRole"),
+                        parent_thread_id: string_field("parentThreadId"),
+                    });
+                } else {
+                    log::debug!(
+                        "[codex_appserver] sub-agent identity unavailable: thread_id={}",
+                        thread_id
+                    );
+                }
+                return out;
+            }
+        }
+
         // Reply to one of our data-returning requests (id present in client_waiters, no method):
         // thread/fork, thread/rollback, thread/goal/get, … Route the JSON-RPC result (or error)
         // back to the actor's control waiter keyed by the frontend request_id.
@@ -524,6 +879,9 @@ impl SessionProtocol for CodexAppServer {
                 {
                     self.thread_id = Some(id.to_string());
                     out.thread_id = Some(id.to_string());
+                    // Root notifications can also race ahead of the thread/start reply that
+                    // proves ownership. Replay them now using the same bounded isolation path.
+                    self.replay_deferred_thread(run_id, id, &mut out);
                 }
             }
             self.phase = Phase::Ready;
@@ -629,6 +987,10 @@ fn is_interactive_method(method: &str) -> bool {
     )
 }
 
+fn is_legacy_interactive_method(method: &str) -> bool {
+    matches!(method, M_CMD_APPROVAL_LEGACY | M_FILE_APPROVAL_LEGACY)
+}
+
 /// Convert the frontend's `{answers: {qid: [labels]}}` into Codex's
 /// `ToolRequestUserInputResponse` `{answers: {qid: {answers: [labels]}}}`.
 fn build_user_input_result(response: &Value) -> Value {
@@ -655,6 +1017,48 @@ impl CodexAppServer {
         let raw_id = msg.get("id").cloned().unwrap_or(Value::Null);
         let request_id = req_id_str(&raw_id);
         let params = msg.get("params").cloned().unwrap_or(Value::Null);
+        let request_thread = params.get("threadId").and_then(Value::as_str);
+        // Stable app-server requests always carry threadId. Only the two pre-v2 approval
+        // methods predate that field, so keeping their compatibility cannot weaken v2 routing.
+        if !is_legacy_interactive_method(method) && request_thread.is_none_or(str::is_empty) {
+            log::warn!(
+                "[codex_appserver] interactive request missing thread id: method={}",
+                method
+            );
+            out.outbound.push(json!({
+                "jsonrpc": "2.0",
+                "id": raw_id,
+                "error": {
+                    "code": -32602,
+                    "message": "Interactive request is missing threadId"
+                }
+            }));
+            return out;
+        }
+        let parent_tool_id = request_thread
+            .and_then(|id| self.child_parent_tools.get(id))
+            .map(String::as_str);
+        if request_thread.is_some_and(|id| {
+            self.thread_id.as_deref() != Some(id) && !self.child_parent_tools.contains_key(id)
+        }) {
+            let thread_id = request_thread.unwrap_or_default();
+            if self.defer_thread_message(
+                thread_id,
+                DeferredThreadMessage::Interactive {
+                    method: method.to_string(),
+                    message: msg.clone(),
+                },
+                &mut out,
+            ) {
+                return out;
+            }
+            log::warn!(
+                "[codex_appserver] unclaimed interactive request rejected at buffer limit: method={}, thread_id={}",
+                method,
+                thread_id
+            );
+            return out;
+        }
         log::debug!(
             "[codex_appserver] interactive request: method={}, request_id={}",
             method,
@@ -664,11 +1068,23 @@ impl CodexAppServer {
         let (kind, events) = match method {
             M_CMD_APPROVAL | M_CMD_APPROVAL_LEGACY => (
                 PendingKind::Permission,
-                vec![approval_prompt(run_id, &request_id, "Bash", &params)],
+                vec![approval_prompt(
+                    run_id,
+                    &request_id,
+                    "Bash",
+                    &params,
+                    parent_tool_id,
+                )],
             ),
             M_FILE_APPROVAL | M_FILE_APPROVAL_LEGACY => (
                 PendingKind::Permission,
-                vec![approval_prompt(run_id, &request_id, "Edit", &params)],
+                vec![approval_prompt(
+                    run_id,
+                    &request_id,
+                    "Edit",
+                    &params,
+                    parent_tool_id,
+                )],
             ),
             M_PERM_APPROVAL => (
                 PendingKind::Permission,
@@ -677,11 +1093,12 @@ impl CodexAppServer {
                     &request_id,
                     "RequestPermissions",
                     &params,
+                    parent_tool_id,
                 )],
             ),
             M_REQUEST_USER_INPUT => (
                 PendingKind::UserInput,
-                ask_user_question_events(run_id, &request_id, &params),
+                ask_user_question_events(run_id, &request_id, &params, parent_tool_id),
             ),
             M_ELICITATION => (
                 PendingKind::Elicitation,
@@ -703,7 +1120,8 @@ impl CodexAppServer {
             },
         );
         out.events = events;
-        out.interactive = Some(PendingInteractive { request_id, kind });
+        out.interactive
+            .push(PendingInteractive { request_id, kind });
         out
     }
 
@@ -714,6 +1132,61 @@ impl CodexAppServer {
         params: &Value,
         out: &mut ParsedLine,
     ) {
+        let notification_thread = params.get("threadId").and_then(Value::as_str);
+        let parent_tool = notification_thread
+            .and_then(|id| self.child_parent_tools.get(id))
+            .cloned();
+        let is_child = parent_tool.is_some();
+        let parent_tool_id = parent_tool.as_deref();
+        let is_foreign = notification_thread.is_some_and(|id| {
+            self.thread_id.as_deref() != Some(id) && !self.child_parent_tools.contains_key(id)
+        });
+
+        // Codex app-server can multiplex notifications from multiple active threads. Until a
+        // spawn item proves the relationship, isolate the thread so it cannot mutate this run.
+        if is_foreign && method != "thread/started" {
+            let thread_id = notification_thread.unwrap_or_default();
+            if !self.defer_thread_message(
+                thread_id,
+                DeferredThreadMessage::Notification {
+                    method: method.to_string(),
+                    params: params.clone(),
+                },
+                out,
+            ) {
+                log::warn!(
+                    "[codex_appserver] unclaimed notification dropped at buffer limit: method={}, thread_id={}",
+                    method,
+                    thread_id
+                );
+            }
+            return;
+        }
+
+        if is_child
+            && !matches!(
+                method,
+                "turn/started"
+                    | "turn/completed"
+                    | "turn/failed"
+                    | "error"
+                    | "item/agentMessage/delta"
+                    | "item/reasoning/textDelta"
+                    | "item/reasoning/summaryTextDelta"
+                    | "item/started"
+                    | "item/completed"
+                    | "item/commandExecution/outputDelta"
+                    | "item/mcpToolCall/progress"
+            )
+        {
+            log::debug!(
+                "[codex_appserver] sub-agent state notification ignored: method={}, thread_id={}",
+                method,
+                notification_thread.unwrap_or_default()
+            );
+            return;
+        }
+
         match method {
             "thread/started" => {
                 if let Some(id) = params
@@ -721,12 +1194,20 @@ impl CodexAppServer {
                     .and_then(|t| t.get("id"))
                     .and_then(|v| v.as_str())
                 {
-                    self.thread_id = Some(id.to_string());
-                    out.thread_id = Some(id.to_string());
+                    if self.thread_id.as_deref() == Some(id) {
+                        out.thread_id = Some(id.to_string());
+                        self.phase = Phase::Ready;
+                    } else {
+                        // The id:2 thread/start|resume reply is the authoritative root. Global
+                        // app-server notifications can be interleaved before that reply arrives.
+                        log::debug!(
+                            "[codex_appserver] uncorrelated thread/started ignored: thread_id={}",
+                            id
+                        );
+                    }
                 }
-                self.phase = Phase::Ready;
             }
-            "turn/started" => {
+            "turn/started" if !is_child => {
                 // Capture the active turn id (TurnStartedNotification.turn.id) for turn/steer's
                 // `expectedTurnId`. `params` is sometimes `{}` — tolerate the absence.
                 if let Some(id) = params
@@ -738,11 +1219,11 @@ impl CodexAppServer {
                 }
                 out.lifecycle = Some(LifecycleSignal::TurnStarted);
             }
-            "turn/completed" => {
+            "turn/completed" if !is_child => {
                 self.active_turn_id = None;
                 out.lifecycle = Some(LifecycleSignal::TurnCompleted);
             }
-            "turn/failed" => {
+            "turn/failed" if !is_child => {
                 self.active_turn_id = None;
                 let err = params
                     .get("error")
@@ -751,6 +1232,9 @@ impl CodexAppServer {
                     .map(|s| s.to_string());
                 out.lifecycle = Some(LifecycleSignal::TurnFailed(err));
             }
+            // Child turns are represented by the parent collab item. They must not transition
+            // the top-level run or replace the parent's active turn id.
+            "turn/started" | "turn/completed" | "turn/failed" => {}
             "error" => {
                 // ErrorNotification = { error: TurnError, willRetry: bool, threadId, turnId }.
                 // The message lives in `error.message` (a TurnError) — NOT a top-level `message`.
@@ -770,6 +1254,8 @@ impl CodexAppServer {
                     .unwrap_or(false);
                 if will_retry {
                     log::debug!("[codex] transient error (will retry): {m}");
+                } else if is_child {
+                    log::debug!("[codex] sub-agent terminal error: {m}");
                 } else {
                     // Terminal error — the turn is over; drop the stale id so a later
                     // steer doesn't target a turn that's no longer running.
@@ -785,7 +1271,7 @@ impl CodexAppServer {
                     out.events.push(BusEvent::MessageDelta {
                         run_id: run_id.to_string(),
                         text: delta.to_string(),
-                        parent_tool_use_id: None,
+                        parent_tool_use_id: parent_tool_id.map(str::to_string),
                     });
                 }
             }
@@ -794,23 +1280,25 @@ impl CodexAppServer {
                     out.events.push(BusEvent::ThinkingDelta {
                         run_id: run_id.to_string(),
                         text: delta.to_string(),
-                        parent_tool_use_id: None,
+                        parent_tool_use_id: parent_tool_id.map(str::to_string),
                     });
                 }
             }
             "item/started" => {
                 if let Some(item) = params.get("item") {
-                    if let Some(ev) = item_started_event(run_id, item) {
+                    if let Some(ev) = item_started_event(run_id, item, parent_tool_id) {
                         out.events.push(ev);
                     }
+                    self.register_subagents(run_id, item, parent_tool_id, out);
                 }
             }
             "item/completed" => {
                 if let Some(item) = params.get("item") {
-                    item_completed_events(run_id, item, &mut out.events);
+                    item_completed_events(run_id, item, parent_tool_id, &mut out.events);
+                    self.register_subagents(run_id, item, parent_tool_id, out);
                 }
             }
-            "thread/tokenUsage/updated" => {
+            "thread/tokenUsage/updated" if !is_child => {
                 if let Some(ev) = token_usage_event(run_id, params) {
                     out.events.push(ev);
                 }
@@ -850,7 +1338,7 @@ impl CodexAppServer {
                             run_id: run_id.to_string(),
                             tool_use_id: id.to_string(),
                             delta: delta.to_string(),
-                            parent_tool_use_id: None,
+                            parent_tool_use_id: parent_tool_id.map(str::to_string),
                         });
                     }
                 }
@@ -968,7 +1456,7 @@ impl CodexAppServer {
                             run_id: run_id.to_string(),
                             tool_use_id: id.to_string(),
                             delta: format!("{msg}\n"),
-                            parent_tool_use_id: None,
+                            parent_tool_use_id: parent_tool_id.map(str::to_string),
                         });
                     }
                 }
@@ -1020,7 +1508,13 @@ impl CodexAppServer {
 
 // ── ServerRequest → interactive BusEvent ──────────────────────────────────────────────
 
-fn approval_prompt(run_id: &str, request_id: &str, tool_name: &str, params: &Value) -> BusEvent {
+fn approval_prompt(
+    run_id: &str,
+    request_id: &str,
+    tool_name: &str,
+    params: &Value,
+    parent_tool_id: Option<&str>,
+) -> BusEvent {
     let command = params
         .get("command")
         .and_then(|v| v.as_str())
@@ -1059,7 +1553,7 @@ fn approval_prompt(run_id: &str, request_id: &str, tool_name: &str, params: &Val
         tool_use_id: item_id,
         tool_input: Value::Object(input),
         decision_reason: reason,
-        parent_tool_use_id: None,
+        parent_tool_use_id: parent_tool_id.map(str::to_string),
         suggestions: vec![],
     }
 }
@@ -1067,7 +1561,12 @@ fn approval_prompt(run_id: &str, request_id: &str, tool_name: &str, params: &Val
 /// Map `item/tool/requestUserInput` to an AskUserQuestion tool (ToolStart + ToolEnd) so it
 /// renders in the existing `InlineToolCard`. `tool_use_id == request_id` so the frontend can
 /// route the answer back via `respond_user_input`.
-fn ask_user_question_events(run_id: &str, request_id: &str, params: &Value) -> Vec<BusEvent> {
+fn ask_user_question_events(
+    run_id: &str,
+    request_id: &str,
+    params: &Value,
+    parent_tool_id: Option<&str>,
+) -> Vec<BusEvent> {
     let mut questions = vec![];
     if let Some(arr) = params.get("questions").and_then(|v| v.as_array()) {
         for q in arr {
@@ -1100,7 +1599,7 @@ fn ask_user_question_events(run_id: &str, request_id: &str, params: &Value) -> V
             tool_use_id: request_id.to_string(),
             tool_name: "AskUserQuestion".to_string(),
             input: input.clone(),
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
         },
         BusEvent::ToolEnd {
             run_id: run_id.to_string(),
@@ -1111,7 +1610,7 @@ fn ask_user_question_events(run_id: &str, request_id: &str, params: &Value) -> V
             // that's the state that renders the interactive option buttons (InlineToolCard).
             status: "error".to_string(),
             duration_ms: None,
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
             tool_use_result: None,
         },
     ]
@@ -1167,11 +1666,8 @@ fn item_tool_name(item: &Value) -> Option<String> {
             let tool = item.get("tool").and_then(|v| v.as_str()).unwrap_or("tool");
             Some(format!("{server}:{tool}"))
         }
-        // `collabToolCall` IS reachable over app-server (multi-agent / spawn_agent sessions), but
-        // this transport's `item_started_event` only copies a `command` field — it has none of the
-        // collab fields (tool/prompt/agents_states), so rendering it would yield an empty Agent
-        // card. The app-server path has never rendered collab items; preserve that (return None)
-        // until the collab fields are properly extracted. The exec parser DOES render them.
+        // Collab items are handled before this generic mapper because they need their full
+        // operation/agent payload rather than the command-only input assembled below.
         CodexToolKind::CollabToolCall => None,
         kind => kind.fixed_tool_name().map(|s| s.to_string()),
     }
@@ -1203,17 +1699,70 @@ fn collab_input(item: &Value) -> Value {
         "model": item.get("model").and_then(|v| v.as_str()),
         "reasoningEffort": item.get("reasoningEffort").and_then(|v| v.as_str()),
         "status": item.get("status").and_then(|v| v.as_str()),
+        "senderThreadId": item.get("senderThreadId").and_then(|v| v.as_str()),
         "receiverThreadIds": item.get("receiverThreadIds").cloned().unwrap_or(json!([])),
         "agents": agents,
     })
 }
 
-fn item_started_event(run_id: &str, item: &Value) -> Option<BusEvent> {
+fn subagent_activity_input(item: &Value, completed: bool) -> Value {
+    let thread_id = item
+        .get("agentThreadId")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let kind = item.get("kind").and_then(Value::as_str).unwrap_or("");
+    let operation = match kind {
+        "started" => "spawnAgent",
+        "interacted" => "interacted",
+        "interrupted" => "interrupted",
+        _ => "subAgentActivity",
+    };
+    let activity_status = if kind == "interrupted" {
+        "interrupted"
+    } else if completed {
+        "completed"
+    } else {
+        "inProgress"
+    };
+    let agent_status = if kind == "interrupted" {
+        "interrupted"
+    } else {
+        "running"
+    };
+    json!({
+        "codexCollab": true,
+        "operation": operation,
+        "activityKind": kind,
+        "status": activity_status,
+        "agentPath": item.get("agentPath").and_then(Value::as_str),
+        "receiverThreadIds": if thread_id.is_empty() { json!([]) } else { json!([thread_id]) },
+        "agents": if thread_id.is_empty() {
+            json!([])
+        } else {
+            json!([{ "thread_id": thread_id, "status": agent_status, "message": null }])
+        }
+    })
+}
+
+fn item_started_event(
+    run_id: &str,
+    item: &Value,
+    parent_tool_id: Option<&str>,
+) -> Option<BusEvent> {
     let id = item
         .get("id")
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    if item.get("type").and_then(Value::as_str) == Some("subAgentActivity") {
+        return Some(BusEvent::ToolStart {
+            run_id: run_id.to_string(),
+            tool_use_id: id,
+            tool_name: "Agent".to_string(),
+            input: subagent_activity_input(item, false),
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
+        });
+    }
     // Codex multi-agent: collabAgentToolCall (spawn_agent etc.) renders as an "Agent" subagent
     // card. item_tool_name doesn't cover it (it's not a plain tool), so handle it up front —
     // otherwise it's dropped entirely on the app-server path.
@@ -1223,7 +1772,7 @@ fn item_started_event(run_id: &str, item: &Value) -> Option<BusEvent> {
             tool_use_id: id,
             tool_name: "Agent".to_string(),
             input: collab_input(item),
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
         });
     }
     let tool_name = item_tool_name(item)?;
@@ -1236,12 +1785,41 @@ fn item_started_event(run_id: &str, item: &Value) -> Option<BusEvent> {
         tool_use_id: id,
         tool_name,
         input: Value::Object(input),
-        parent_tool_use_id: None,
+        parent_tool_use_id: parent_tool_id.map(str::to_string),
     })
 }
 
-fn item_completed_events(run_id: &str, item: &Value, out: &mut Vec<BusEvent>) {
+fn item_completed_events(
+    run_id: &str,
+    item: &Value,
+    parent_tool_id: Option<&str>,
+    out: &mut Vec<BusEvent>,
+) {
     let item_type = item.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    if item_type == "subAgentActivity" {
+        let id = item
+            .get("id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let payload = subagent_activity_input(item, true);
+        let status = if item.get("kind").and_then(Value::as_str) == Some("interrupted") {
+            "error"
+        } else {
+            "success"
+        };
+        out.push(BusEvent::ToolEnd {
+            run_id: run_id.to_string(),
+            tool_use_id: id,
+            tool_name: "Agent".to_string(),
+            output: json!({ "content": payload.clone() }),
+            status: status.to_string(),
+            duration_ms: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
+            tool_use_result: Some(payload),
+        });
+        return;
+    }
     if item_type == "agentMessage" {
         let text = item.get("text").and_then(|v| v.as_str()).unwrap_or("");
         let id = item
@@ -1253,7 +1831,7 @@ fn item_completed_events(run_id: &str, item: &Value, out: &mut Vec<BusEvent>) {
             run_id: run_id.to_string(),
             message_id: id,
             text: text.to_string(),
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
             model: None,
             stop_reason: None,
             message_usage: None,
@@ -1293,7 +1871,7 @@ fn item_completed_events(run_id: &str, item: &Value, out: &mut Vec<BusEvent>) {
             output: json!({ "content": payload.clone() }),
             status: status.to_string(),
             duration_ms: None,
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
             tool_use_result: Some(payload),
         });
         return;
@@ -1320,7 +1898,7 @@ fn item_completed_events(run_id: &str, item: &Value, out: &mut Vec<BusEvent>) {
             output: json!({ "content": output }),
             status: status.to_string(),
             duration_ms: None,
-            parent_tool_use_id: None,
+            parent_tool_use_id: parent_tool_id.map(str::to_string),
             tool_use_result: None,
         });
     }
@@ -1541,10 +2119,7 @@ mod tests {
 
     fn ready_server() -> CodexAppServer {
         let mut s = CodexAppServer::new();
-        s.parse_line(
-            "run1",
-            r#"{"method":"thread/started","params":{"thread":{"id":"th-123"}}}"#,
-        );
+        s.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
         s
     }
 
@@ -1586,14 +2161,14 @@ mod tests {
     }
 
     #[test]
-    fn thread_started_captures_id_and_readies() {
+    fn uncorrelated_thread_started_is_ignored() {
         let mut s = CodexAppServer::new();
         let out = s.parse_line(
             "run1",
             r#"{"method":"thread/started","params":{"thread":{"id":"th-123"}}}"#,
         );
-        assert_eq!(out.thread_id.as_deref(), Some("th-123"));
-        assert_eq!(s.phase, Phase::Ready);
+        assert!(out.thread_id.is_none());
+        assert_eq!(s.phase, Phase::Opening);
     }
 
     #[test]
@@ -1908,9 +2483,9 @@ mod tests {
     #[test]
     fn command_approval_request() {
         let mut s = ready_server();
-        let line = r#"{"id":0,"method":"item/commandExecution/requestApproval","params":{"itemId":"call_1","reason":"allow write?","command":"echo hi","cwd":"/tmp"}}"#;
+        let line = r#"{"id":0,"method":"item/commandExecution/requestApproval","params":{"threadId":"th-123","turnId":"turn-1","itemId":"call_1","startedAtMs":1,"reason":"allow write?","command":"echo hi","cwd":"/tmp"}}"#;
         let out = s.parse_line("run1", line);
-        let pi = out.interactive.expect("interactive");
+        let pi = out.interactive.first().expect("interactive");
         assert_eq!(pi.kind, PendingKind::Permission);
         assert_eq!(pi.request_id, "0");
         match &out.events[0] {
@@ -1947,12 +2522,96 @@ mod tests {
     }
 
     #[test]
+    fn legacy_approval_without_thread_id_remains_supported() {
+        let mut server = ready_server();
+        let out = server.parse_line(
+            "r",
+            r#"{"id":87,"method":"execCommandApproval","params":{"itemId":"cmd-1","command":"pwd"}}"#,
+        );
+
+        assert!(matches!(
+            out.interactive.first(),
+            Some(PendingInteractive {
+                kind: PendingKind::Permission,
+                ..
+            })
+        ));
+        assert!(matches!(
+            out.events.first(),
+            Some(BusEvent::PermissionPrompt { .. })
+        ));
+        assert!(out.outbound.is_empty());
+    }
+
+    #[test]
+    fn modern_interactive_request_without_thread_id_is_rejected() {
+        for (index, method) in [
+            M_CMD_APPROVAL,
+            M_FILE_APPROVAL,
+            M_PERM_APPROVAL,
+            M_REQUEST_USER_INPUT,
+            M_ELICITATION,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            for params in [json!({}), json!({ "threadId": "" })] {
+                let mut server = ready_server();
+                let out = server.parse_line(
+                    "r",
+                    &json!({
+                        "id": 90 + index,
+                        "method": method,
+                        "params": params,
+                    })
+                    .to_string(),
+                );
+
+                assert!(out.events.is_empty(), "method={method}");
+                assert!(out.interactive.is_empty(), "method={method}");
+                assert_eq!(out.outbound[0]["error"]["code"], -32602, "method={method}");
+                assert!(server.pending.is_empty(), "method={method}");
+            }
+        }
+    }
+
+    #[test]
+    fn unclaimed_interactive_request_evicts_notification_when_thread_buffer_is_full() {
+        let mut server = ready_server();
+        for index in 0..MAX_DEFERRED_MESSAGES_PER_THREAD {
+            let line = json!({
+                "method": "item/agentMessage/delta",
+                "params": {"threadId": "another-thread", "delta": index.to_string()}
+            });
+            assert!(server.parse_line("r", &line.to_string()).events.is_empty());
+        }
+        let out = server.parse_line(
+            "r",
+            r#"{"id":88,"method":"item/commandExecution/requestApproval","params":{"threadId":"another-thread","turnId":"turn-1","itemId":"cmd-1","startedAtMs":1,"command":"touch foreign"}}"#,
+        );
+
+        assert!(out.events.is_empty());
+        assert!(out.interactive.is_empty());
+        assert!(out.outbound.is_empty());
+        assert!(server.pending.is_empty());
+        let queue = &server.deferred_thread_messages["another-thread"];
+        assert_eq!(queue.len(), MAX_DEFERRED_MESSAGES_PER_THREAD);
+        assert_eq!(
+            queue
+                .iter()
+                .filter(|entry| entry.message.is_interactive())
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn permissions_approval_returns_granted_subset_or_empty_profile() {
         let line = r#"{"id":61,"method":"item/permissions/requestApproval","params":{"threadId":"th-123","turnId":"turn-1","itemId":"call-1","cwd":"/project","reason":"Allow workspace writes","permissions":{"fileSystem":{"write":["/project","/shared"]},"network":{"enabled":true}}}}"#;
 
         let mut allowed = ready_server();
         let out = allowed.parse_line("run1", line);
-        let pi = out.interactive.expect("interactive");
+        let pi = out.interactive.first().expect("interactive");
         assert_eq!(pi.kind, PendingKind::Permission);
         match &out.events[0] {
             BusEvent::PermissionPrompt {
@@ -1990,7 +2649,12 @@ mod tests {
             r#"{"method":"turn/started","params":{"turn":{"id":"turn-1"}}}"#,
         );
         let out = denied.parse_line("run1", line);
-        let request_id = out.interactive.expect("interactive").request_id;
+        let request_id = out
+            .interactive
+            .first()
+            .expect("interactive")
+            .request_id
+            .clone();
         let response = denied.frame_response(
             PendingKind::Permission,
             &request_id,
@@ -2007,9 +2671,9 @@ mod tests {
     #[test]
     fn request_user_input_to_ask_question_and_back() {
         let mut s = ready_server();
-        let line = r#"{"id":0,"method":"item/tool/requestUserInput","params":{"questions":[{"id":"word","header":"Word","question":"Which word?","isOther":true,"isSecret":false,"options":[{"label":"FOO","description":"Select FOO."},{"label":"BAR","description":"Select BAR."}]}]}}"#;
+        let line = r#"{"id":0,"method":"item/tool/requestUserInput","params":{"threadId":"th-123","turnId":"turn-1","itemId":"ask-1","isBlocking":true,"questions":[{"id":"word","header":"Word","question":"Which word?","isOther":true,"isSecret":false,"options":[{"label":"FOO","description":"Select FOO."},{"label":"BAR","description":"Select BAR."}]}]}}"#;
         let out = s.parse_line("run1", line);
-        let pi = out.interactive.expect("interactive");
+        let pi = out.interactive.first().expect("interactive");
         assert_eq!(pi.kind, PendingKind::UserInput);
         // Renders as AskUserQuestion ToolStart+ToolEnd with tool_use_id == request_id.
         match &out.events[0] {
@@ -2044,9 +2708,12 @@ mod tests {
     #[test]
     fn elicitation_request() {
         let mut s = ready_server();
-        let line = r#"{"id":1,"method":"mcpServer/elicitation/request","params":{"serverName":"srv","mode":"form","message":"Pick","requestedSchema":{"type":"object"}}}"#;
+        let line = r#"{"id":1,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","mode":"form","message":"Pick","requestedSchema":{"type":"object"}}}"#;
         let out = s.parse_line("run1", line);
-        assert_eq!(out.interactive.unwrap().kind, PendingKind::Elicitation);
+        assert_eq!(
+            out.interactive.first().expect("interactive").kind,
+            PendingKind::Elicitation
+        );
         match &out.events[0] {
             BusEvent::ElicitationPrompt {
                 mcp_server_name,
@@ -2128,6 +2795,448 @@ mod tests {
             }
             e => panic!("expected ToolEnd, got {e:?}"),
         }
+    }
+
+    #[test]
+    fn spawned_thread_identity_and_activity_are_correlated() {
+        let mut server = ready_server();
+        let spawn = server.parse_line(
+            "r",
+            r#"{"method":"item/completed","params":{"threadId":"th-123","item":{"id":"agent-1","type":"collabAgentToolCall","tool":"spawnAgent","status":"completed","senderThreadId":"th-123","receiverThreadIds":["child-1"],"agentsStates":{"child-1":{"status":"running","message":null}}}}}"#,
+        );
+        let read = spawn
+            .outbound
+            .iter()
+            .find(|frame| frame["method"] == "thread/read")
+            .expect("spawn schedules identity lookup");
+        assert_eq!(read["params"]["threadId"], "child-1");
+        assert_eq!(read["params"]["includeTurns"], false);
+
+        let read_id = read["id"].as_i64().unwrap();
+        let info = server.parse_line(
+            "r",
+            &format!(
+                r#"{{"id":{read_id},"result":{{"thread":{{"id":"child-1","agentNickname":"Dewey","agentRole":"explorer","parentThreadId":"th-123"}}}}}}"#
+            ),
+        );
+        match &info.events[0] {
+            BusEvent::CodexAgentInfo {
+                thread_id,
+                nickname,
+                role,
+                parent_thread_id,
+                ..
+            } => {
+                assert_eq!(thread_id, "child-1");
+                assert_eq!(nickname.as_deref(), Some("Dewey"));
+                assert_eq!(role.as_deref(), Some("explorer"));
+                assert_eq!(parent_thread_id.as_deref(), Some("th-123"));
+            }
+            event => panic!("expected CodexAgentInfo, got {event:?}"),
+        }
+
+        let child_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cmd-1","type":"commandExecution","command":"rg TODO"}}}"#,
+        );
+        match &child_tool.events[0] {
+            BusEvent::ToolStart {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("agent-1")),
+            event => panic!("expected nested ToolStart, got {event:?}"),
+        }
+
+        let child_completed = server.parse_line(
+            "r",
+            r#"{"method":"turn/completed","params":{"threadId":"child-1"}}"#,
+        );
+        assert!(child_completed.lifecycle.is_none());
+        let root_completed = server.parse_line(
+            "r",
+            r#"{"method":"turn/completed","params":{"threadId":"th-123"}}"#,
+        );
+        assert_eq!(
+            root_completed.lifecycle,
+            Some(LifecycleSignal::TurnCompleted)
+        );
+    }
+
+    #[test]
+    fn stable_subagent_activity_registers_child_thread() {
+        let mut server = ready_server();
+        let started = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"agent-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        match &started.events[0] {
+            BusEvent::ToolStart {
+                tool_name, input, ..
+            } => {
+                assert_eq!(tool_name, "Agent");
+                assert_eq!(input["operation"], "spawnAgent");
+                assert_eq!(input["agentPath"], "/root/explorer");
+                assert_eq!(input["receiverThreadIds"][0], "child-1");
+            }
+            event => panic!("expected Agent ToolStart, got {event:?}"),
+        }
+        assert_eq!(started.outbound[0]["method"], "thread/read");
+        assert_eq!(started.outbound[0]["params"]["threadId"], "child-1");
+
+        let child_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        match &child_tool.events[0] {
+            BusEvent::ToolStart {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("agent-1")),
+            event => panic!("expected nested ToolStart, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn child_notification_before_spawn_registration_is_replayed_in_parent_card() {
+        let mut server = ready_server();
+        let early = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        assert!(early.events.is_empty());
+        assert_eq!(server.deferred_thread_messages["child-1"].len(), 1);
+
+        let registered = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        assert_eq!(registered.events.len(), 2);
+        match &registered.events[1] {
+            BusEvent::ToolStart {
+                tool_use_id,
+                parent_tool_use_id,
+                ..
+            } => {
+                assert_eq!(tool_use_id, "cmd-1");
+                assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1"));
+            }
+            event => panic!("expected replayed child ToolStart, got {event:?}"),
+        }
+        assert!(!server.deferred_thread_messages.contains_key("child-1"));
+    }
+
+    #[test]
+    fn child_approval_before_spawn_registration_is_replayed_without_early_rejection() {
+        let mut server = ready_server();
+        let early = server.parse_line(
+            "r",
+            r#"{"id":77,"method":"item/commandExecution/requestApproval","params":{"threadId":"child-1","turnId":"child-turn","itemId":"cmd-1","startedAtMs":1,"command":"touch file"}}"#,
+        );
+        assert!(early.events.is_empty());
+        assert!(early.interactive.is_empty());
+        assert!(early.outbound.is_empty());
+        assert!(server.pending.is_empty());
+
+        let registered = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        assert_eq!(registered.interactive.len(), 1);
+        assert_eq!(registered.interactive[0].request_id, "77");
+        assert!(server.pending.contains_key("77"));
+        match &registered.events[1] {
+            BusEvent::PermissionPrompt {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1")),
+            event => panic!("expected replayed child PermissionPrompt, got {event:?}"),
+        }
+        assert!(registered
+            .outbound
+            .iter()
+            .all(|frame| frame.get("error").is_none()));
+    }
+
+    #[test]
+    fn unclaimed_thread_buffer_caps_distinct_threads() {
+        let mut server = ready_server();
+        for index in 0..=MAX_UNCLAIMED_THREADS {
+            let line = json!({
+                "method": "item/agentMessage/delta",
+                "params": {"threadId": format!("foreign-{index}"), "delta": "x"}
+            });
+            assert!(server.parse_line("r", &line.to_string()).events.is_empty());
+        }
+
+        assert_eq!(server.deferred_thread_messages.len(), MAX_UNCLAIMED_THREADS);
+        assert!(server
+            .deferred_thread_messages
+            .contains_key(&format!("foreign-{MAX_UNCLAIMED_THREADS}")));
+        assert!(!server.deferred_thread_messages.contains_key("foreign-0"));
+    }
+
+    #[test]
+    fn deferred_payload_budget_rejects_oversized_interactive_request() {
+        let mut server = ready_server();
+        let out = server.parse_line(
+            "r",
+            &json!({
+                "id": 99,
+                "method": M_FILE_APPROVAL,
+                "params": {
+                    "threadId": "child-oversized",
+                    "changes": "x".repeat(MAX_DEFERRED_PAYLOAD_BYTES)
+                }
+            })
+            .to_string(),
+        );
+
+        assert_eq!(out.outbound[0]["id"], 99);
+        assert_eq!(out.outbound[0]["error"]["code"], -32600);
+        assert!(server.deferred_thread_messages.is_empty());
+        assert_eq!(server.deferred_payload_bytes, 0);
+    }
+
+    #[test]
+    fn expired_deferred_interactive_request_receives_error_and_frees_capacity() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"id":77,"method":"item/commandExecution/requestApproval","params":{"threadId":"child-old","command":"pwd"}}"#,
+        );
+        server
+            .deferred_thread_messages
+            .get_mut("child-old")
+            .unwrap()[0]
+            .received_at = Instant::now() - DEFERRED_MESSAGE_TTL - Duration::from_secs(1);
+
+        let out = server.parse_line(
+            "r",
+            r#"{"method":"item/agentMessage/delta","params":{"threadId":"child-new","delta":"x"}}"#,
+        );
+
+        assert_eq!(out.outbound[0]["id"], 77);
+        assert_eq!(
+            out.outbound[0]["error"]["message"],
+            "Interactive request expired"
+        );
+        assert!(!server.deferred_thread_messages.contains_key("child-old"));
+        assert!(server.deferred_thread_messages.contains_key("child-new"));
+    }
+
+    #[test]
+    fn expired_interactive_is_rejected_instead_of_replayed_on_registration() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"id":78,"method":"item/commandExecution/requestApproval","params":{"threadId":"child-old","command":"pwd"}}"#,
+        );
+        server
+            .deferred_thread_messages
+            .get_mut("child-old")
+            .unwrap()[0]
+            .received_at = Instant::now() - DEFERRED_MESSAGE_TTL - Duration::from_secs(1);
+
+        let registered = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-old"}}}"#,
+        );
+
+        assert!(registered.interactive.is_empty());
+        assert!(!server.pending.contains_key("78"));
+        assert_eq!(registered.outbound[0]["id"], 78);
+        assert_eq!(
+            registered.outbound[0]["error"]["message"],
+            "Interactive request expired"
+        );
+    }
+
+    #[test]
+    fn spawned_thread_lookup_is_deduplicated() {
+        let mut server = ready_server();
+        let line = r#"{"method":"item/completed","params":{"item":{"id":"agent-1","type":"collabAgentToolCall","tool":"spawnAgent","receiverThreadIds":["child-1"]}}}"#;
+        assert_eq!(server.parse_line("r", line).outbound.len(), 1);
+        assert!(server.parse_line("r", line).outbound.is_empty());
+    }
+
+    #[test]
+    fn wait_agent_does_not_reparent_spawned_thread() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        let wait = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"id":"wait-1","type":"collabAgentToolCall","tool":"wait","receiverThreadIds":["child-1"]}}}"#,
+        );
+        assert!(wait.outbound.is_empty());
+
+        let child_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        match &child_tool.events[0] {
+            BusEvent::ToolStart {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1")),
+            event => panic!("expected nested ToolStart, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn later_subagent_activity_does_not_reparent_spawned_thread() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        let interacted = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"interaction-1","kind":"interacted","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+        assert!(interacted.outbound.is_empty());
+        match &interacted.events[0] {
+            BusEvent::ToolStart { input, .. } => {
+                assert_eq!(input["operation"], "interacted");
+                assert_eq!(input["activityKind"], "interacted");
+                assert_eq!(input["status"], "inProgress");
+            }
+            event => panic!("expected interaction ToolStart, got {event:?}"),
+        }
+
+        let child_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        match &child_tool.events[0] {
+            BusEvent::ToolStart {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1")),
+            event => panic!("expected nested ToolStart, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn interrupted_subagent_activity_maps_to_terminal_error() {
+        let mut server = ready_server();
+        let completed = server.parse_line(
+            "r",
+            r#"{"method":"item/completed","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"interrupt-1","kind":"interrupted","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        match &completed.events[0] {
+            BusEvent::ToolEnd {
+                status,
+                tool_use_result,
+                ..
+            } => {
+                assert_eq!(status, "error");
+                let result = tool_use_result.as_ref().unwrap();
+                assert_eq!(result["operation"], "interrupted");
+                assert_eq!(result["activityKind"], "interrupted");
+                assert_eq!(result["status"], "interrupted");
+                assert_eq!(result["agents"][0]["status"], "interrupted");
+            }
+            event => panic!("expected interrupted ToolEnd, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_spawn_stays_in_top_level_agent_card() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+        let nested = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"child-1","item":{"type":"subAgentActivity","id":"spawn-2","kind":"started","agentThreadId":"grandchild-1","agentPath":"/root/explorer/worker"}}}"#,
+        );
+        assert_eq!(nested.outbound[0]["params"]["threadId"], "grandchild-1");
+
+        let grandchild_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"grandchild-1","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        match &grandchild_tool.events[0] {
+            BusEvent::ToolStart {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1")),
+            event => panic!("expected nested ToolStart, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn child_state_notifications_do_not_mutate_parent_state() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        for line in [
+            r#"{"method":"thread/goal/updated","params":{"threadId":"child-1","goal":{"objective":"child"}}}"#,
+            r#"{"method":"turn/plan/updated","params":{"threadId":"child-1","turnId":"child-turn","plan":[]}}"#,
+            r#"{"method":"turn/diff/updated","params":{"threadId":"child-1","turnId":"child-turn","diff":"child diff"}}"#,
+            r#"{"method":"account/rateLimits/updated","params":{"threadId":"child-1","rateLimits":{}}}"#,
+        ] {
+            assert!(server.parse_line("r", line).events.is_empty());
+        }
+    }
+
+    #[test]
+    fn child_interactive_request_is_nested_in_agent_card() {
+        let mut server = ready_server();
+        server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"th-123","item":{"type":"subAgentActivity","id":"spawn-1","kind":"started","agentThreadId":"child-1","agentPath":"/root/explorer"}}}"#,
+        );
+
+        let request = server.parse_line(
+            "r",
+            r#"{"id":77,"method":"item/commandExecution/requestApproval","params":{"threadId":"child-1","turnId":"child-turn","itemId":"cmd-1","startedAtMs":1,"command":"touch file"}}"#,
+        );
+        match &request.events[0] {
+            BusEvent::PermissionPrompt {
+                parent_tool_use_id, ..
+            } => assert_eq!(parent_tool_use_id.as_deref(), Some("spawn-1")),
+            event => panic!("expected nested PermissionPrompt, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn unrelated_thread_notifications_do_not_mutate_the_run() {
+        let mut server = ready_server();
+        let foreign_tool = server.parse_line(
+            "r",
+            r#"{"method":"item/started","params":{"threadId":"another-thread","item":{"id":"cmd-1","type":"commandExecution","command":"pwd"}}}"#,
+        );
+        assert!(foreign_tool.events.is_empty());
+
+        let foreign_turn = server.parse_line(
+            "r",
+            r#"{"method":"turn/completed","params":{"threadId":"another-thread"}}"#,
+        );
+        assert!(foreign_turn.lifecycle.is_none());
+    }
+
+    #[test]
+    fn codex_agent_info_serializes_as_bus_contract() {
+        let event = BusEvent::CodexAgentInfo {
+            run_id: "r".into(),
+            thread_id: "child-1".into(),
+            nickname: Some("Dewey".into()),
+            role: None,
+            parent_thread_id: Some("root".into()),
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert_eq!(value["type"], "codex_agent_info");
+        assert_eq!(value["thread_id"], "child-1");
+        assert!(value.get("role").is_none());
+        assert!(crate::agent::claude_protocol::validate_bus_event(&event).is_none());
     }
 
     #[test]
@@ -2632,7 +3741,7 @@ mod tests {
         // Terminal error: message is nested under `error.message` (TurnError), surfaced.
         let out = s.parse_line(
             "r",
-            r#"{"method":"error","params":{"error":{"message":"model overloaded"},"willRetry":false,"threadId":"t","turnId":"u"}}"#,
+            r#"{"method":"error","params":{"error":{"message":"model overloaded"},"willRetry":false,"threadId":"th-123","turnId":"u"}}"#,
         );
         match &out.events[0] {
             BusEvent::CommandOutput { content, .. } => {
@@ -2643,7 +3752,7 @@ mod tests {
         // Transient error (willRetry): Codex auto-retries → no user-facing event.
         let out = s.parse_line(
             "r",
-            r#"{"method":"error","params":{"error":{"message":"tls handshake eof"},"willRetry":true,"threadId":"t","turnId":"u"}}"#,
+            r#"{"method":"error","params":{"error":{"message":"tls handshake eof"},"willRetry":true,"threadId":"th-123","turnId":"u"}}"#,
         );
         assert!(
             out.events.is_empty(),
@@ -2691,7 +3800,7 @@ mod tests {
         let mut s = ready_server();
         let out = s.parse_line(
             "r",
-            r#"{"method":"guardianWarning","params":{"threadId":"t","message":"high-risk action detected"}}"#,
+            r#"{"method":"guardianWarning","params":{"threadId":"th-123","message":"high-risk action detected"}}"#,
         );
         match &out.events[0] {
             BusEvent::CommandOutput { content, .. } => {
@@ -2701,7 +3810,7 @@ mod tests {
         }
         let out = s.parse_line(
             "r",
-            r#"{"method":"model/verification","params":{"threadId":"t","turnId":"u","verifications":["trustedAccessForCyber"]}}"#,
+            r#"{"method":"model/verification","params":{"threadId":"th-123","turnId":"u","verifications":["trustedAccessForCyber"]}}"#,
         );
         match &out.events[0] {
             BusEvent::CommandOutput { content, .. } => {
@@ -2715,7 +3824,7 @@ mod tests {
         // Empty verifications → no event.
         let out = s.parse_line(
             "r",
-            r#"{"method":"model/verification","params":{"threadId":"t","turnId":"u","verifications":[]}}"#,
+            r#"{"method":"model/verification","params":{"threadId":"th-123","turnId":"u","verifications":[]}}"#,
         );
         assert!(out.events.is_empty());
     }
@@ -2745,7 +3854,7 @@ mod tests {
         let mut s = ready_server();
         let out = s.parse_line(
             "r",
-            r#"{"method":"turn/diff/updated","params":{"threadId":"t","turnId":"tu","diff":"--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new"}}"#,
+            r#"{"method":"turn/diff/updated","params":{"threadId":"th-123","turnId":"tu","diff":"--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new"}}"#,
         );
         assert_eq!(out.events.len(), 1);
         match &out.events[0] {
@@ -2784,6 +3893,33 @@ mod tests {
         // frame_user_turn now has a thread id and emits turn/start (not dropped).
         let msgs = s.frame_user_turn("hi", &[], no_skills(), &no_overrides());
         assert_eq!(msgs[0]["params"]["threadId"], "th-ack");
+    }
+
+    #[test]
+    fn root_notification_before_start_ack_is_replayed_after_ownership_is_known() {
+        let mut server = CodexAppServer::new();
+        let early = server.parse_line(
+            "r",
+            r#"{"method":"item/agentMessage/delta","params":{"threadId":"root-1","delta":"hello"}}"#,
+        );
+        assert!(early.events.is_empty());
+
+        let ack = server.parse_line(
+            "r",
+            r#"{"jsonrpc":"2.0","id":2,"result":{"thread":{"id":"root-1"}}}"#,
+        );
+        assert_eq!(ack.thread_id.as_deref(), Some("root-1"));
+        match &ack.events[0] {
+            BusEvent::MessageDelta {
+                text,
+                parent_tool_use_id,
+                ..
+            } => {
+                assert_eq!(text, "hello");
+                assert!(parent_tool_use_id.is_none());
+            }
+            event => panic!("expected replayed root MessageDelta, got {event:?}"),
+        }
     }
 
     #[test]
@@ -3048,7 +4184,7 @@ mod tests {
                         }
                         stdin.flush().await.unwrap();
                     }
-                    if let Some(pi) = &parsed.interactive {
+                    for pi in &parsed.interactive {
                         if pi.kind == PendingKind::Permission {
                             saw_approval = true;
                             assert!(matches!(parsed.events[0], BusEvent::PermissionPrompt { .. }));
@@ -3151,7 +4287,7 @@ mod tests {
                         stdin.flush().await.unwrap();
                     }
 
-                    if let Some(pi) = &parsed.interactive {
+                    for pi in &parsed.interactive {
                         if pi.kind == PendingKind::UserInput {
                             saw_user_input = true;
                             // Pull qid + first option label out of the AskUserQuestion ToolStart.

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -352,10 +352,10 @@ struct SessionActor {
     ralph_needs_dispatch: bool,
 
     // ── Observability: pending interactive request tracking ──
-    /// Tracks the most recent interactive control request awaiting user response.
+    /// Tracks interactive control requests awaiting user responses by request id.
     /// Set when emitting PermissionPrompt / HookCallback(PreToolUse) / ElicitationPrompt.
     /// Cleared when the response is received. Retained during quarantine for diagnostics.
-    pending_interactive_request: Option<PendingInteractiveRequest>,
+    pending_interactive_requests: HashMap<String, PendingInteractiveRequest>,
 }
 
 // ── Spawn entry point ──
@@ -436,7 +436,7 @@ pub fn spawn_actor(
         user_hard_timeout,
         ralph_loop: None,
         ralph_needs_dispatch: false,
-        pending_interactive_request: None,
+        pending_interactive_requests: HashMap::new(),
     };
 
     let join_handle = tokio::spawn(async move {
@@ -1179,6 +1179,34 @@ impl SessionActor {
 
     /// Independent timeout clock — checks soft/hard deadlines and quarantine. (HC #4)
     async fn on_tick_timeout(&mut self) {
+        let expired_codex_requests = self
+            .codex
+            .as_mut()
+            .map(CodexAppServer::expire_deferred)
+            .unwrap_or_default();
+        for frame in &expired_codex_requests {
+            if let Err(error) = self
+                .write_json_line(frame, "expired codex interactive request")
+                .await
+            {
+                log::error!(
+                    "[codex] expired request response failed: run_id={}, error={}",
+                    self.run_id,
+                    error
+                );
+            }
+        }
+        let oldest_pending = self
+            .pending_interactive_requests
+            .values()
+            .min_by_key(|request| request.received_at)
+            .map(|request| {
+                (
+                    request.subtype.clone(),
+                    request.detail.clone(),
+                    request.received_at.elapsed().as_secs(),
+                )
+            });
         // Check quarantine deadline first
         if self.quarantine_until_result {
             if let Some(deadline) = self.quarantine_deadline {
@@ -1188,7 +1216,7 @@ impl SessionActor {
                         "[turn] quarantine hard-timeout: run_id={}, from_internal={}, pending_request={:?}",
                         self.run_id,
                         self.quarantine_from_internal,
-                        self.pending_interactive_request.as_ref().map(|r| (&r.subtype, &r.detail, r.received_at.elapsed().as_secs()))
+                        oldest_pending.as_ref()
                     );
                     self.protocol.set_pending_slash_command(None);
                     if let Some(ref mut child) = self.child {
@@ -1196,11 +1224,10 @@ impl SessionActor {
                     }
                     let error_msg = if self.quarantine_from_internal {
                         "Auto-context hard timeout — process killed".to_string()
-                    } else if let Some(ref req) = self.pending_interactive_request {
-                        let wait_secs = req.received_at.elapsed().as_secs();
+                    } else if let Some((subtype, detail, wait_secs)) = oldest_pending.as_ref() {
                         format!(
                             "Session timeout — waited {}s for {} response ({}). Process killed.",
-                            wait_secs, req.subtype, req.detail
+                            wait_secs, subtype, detail
                         )
                     } else {
                         "Session timeout — no output from CLI for 30 minutes. Process killed."
@@ -1285,7 +1312,7 @@ impl SessionActor {
                 "[turn] user hard timeout: entering quarantine for run_id={} (turn_seq={}), pending_request={:?}",
                 self.run_id,
                 turn.turn_seq,
-                self.pending_interactive_request.as_ref().map(|r| (&r.subtype, &r.detail, r.received_at.elapsed().as_secs()))
+                oldest_pending.as_ref()
             );
             self.protocol.set_pending_slash_command(None);
             self.active_turn = None;
@@ -1793,16 +1820,25 @@ impl SessionActor {
 
     /// Clear pending interactive request if it matches the given request_id.
     fn clear_pending_interactive_request(&mut self, request_id: &str) {
-        if let Some(ref req) = self.pending_interactive_request {
-            if req.request_id == request_id {
-                log::debug!(
-                    "[actor] clearing pending_interactive_request: subtype={}, detail={}, waited={}s",
-                    req.subtype,
-                    req.detail,
-                    req.received_at.elapsed().as_secs()
-                );
-                self.pending_interactive_request = None;
-            }
+        Self::clear_pending_interactive_request_map(
+            &mut self.pending_interactive_requests,
+            request_id,
+        );
+    }
+
+    fn clear_pending_interactive_request_map(
+        pending: &mut HashMap<String, PendingInteractiveRequest>,
+        request_id: &str,
+    ) {
+        if let Some(req) = pending.remove(request_id) {
+            log::debug!(
+                "[actor] clearing pending_interactive_request: request_id={}, subtype={}, detail={}, waited={}s, remaining={}",
+                req.request_id,
+                req.subtype,
+                req.detail,
+                req.received_at.elapsed().as_secs(),
+                pending.len()
+            );
         }
     }
 
@@ -1895,6 +1931,18 @@ impl SessionActor {
 
         let parsed = self.codex.as_mut().unwrap().parse_line(&self.run_id, text);
 
+        // Parser-generated requests (currently spawned-thread identity reads) must be written
+        // before processing later notifications that can depend on their metadata.
+        for frame in &parsed.outbound {
+            if let Err(error) = self.write_json_line(frame, "codex protocol request").await {
+                log::error!(
+                    "[codex] protocol request failed: run_id={}, error={}",
+                    self.run_id,
+                    error
+                );
+            }
+        }
+
         // Route a data-returning request reply (thread/fork, thread/rollback, thread/goal/get)
         // back to the waiting control caller — mirrors the Claude control_response path.
         if let Some((rid, resp)) = parsed.control_response {
@@ -1947,18 +1995,21 @@ impl SessionActor {
         }
 
         // Track a pending interactive request (observability + desktop notification).
-        if let Some(pi) = parsed.interactive {
+        for pi in parsed.interactive {
             let subtype = match pi.kind {
                 PendingKind::Permission => "can_use_tool",
                 PendingKind::Elicitation => "elicitation",
                 PendingKind::UserInput => "request_user_input",
             };
-            self.pending_interactive_request = Some(PendingInteractiveRequest {
-                request_id: pi.request_id,
-                subtype: subtype.to_string(),
-                detail: String::new(),
-                received_at: Instant::now(),
-            });
+            self.pending_interactive_requests.insert(
+                pi.request_id.clone(),
+                PendingInteractiveRequest {
+                    request_id: pi.request_id,
+                    subtype: subtype.to_string(),
+                    detail: String::new(),
+                    received_at: Instant::now(),
+                },
+            );
             notify_if_background(self.emitter.app(), "Codex", "needs your input");
         }
 
@@ -2455,12 +2506,15 @@ impl SessionActor {
                 }
             }
             if hook_event == "PreToolUse" {
-                self.pending_interactive_request = Some(PendingInteractiveRequest {
-                    request_id: request_id.clone(),
-                    subtype: "hook_callback".to_string(),
-                    detail: format!("PreToolUse:{}", hook_label),
-                    received_at: Instant::now(),
-                });
+                self.pending_interactive_requests.insert(
+                    request_id.clone(),
+                    PendingInteractiveRequest {
+                        request_id: request_id.clone(),
+                        subtype: "hook_callback".to_string(),
+                        detail: format!("PreToolUse:{}", hook_label),
+                        received_at: Instant::now(),
+                    },
+                );
                 notify_if_background(
                     self.emitter.app(),
                     "Hook Review Required",
@@ -2533,12 +2587,15 @@ impl SessionActor {
                 url,
                 requested_schema,
             });
-            self.pending_interactive_request = Some(PendingInteractiveRequest {
-                request_id: request_id.clone(),
-                subtype: "elicitation".to_string(),
-                detail: mcp_server_name.clone(),
-                received_at: Instant::now(),
-            });
+            self.pending_interactive_requests.insert(
+                request_id.clone(),
+                PendingInteractiveRequest {
+                    request_id: request_id.clone(),
+                    subtype: "elicitation".to_string(),
+                    detail: mcp_server_name.clone(),
+                    received_at: Instant::now(),
+                },
+            );
             notify_if_background(
                 self.emitter.app(),
                 "MCP Input Required",
@@ -2601,12 +2658,15 @@ impl SessionActor {
                 parent_tool_use_id,
                 suggestions,
             });
-            self.pending_interactive_request = Some(PendingInteractiveRequest {
-                request_id,
-                subtype: "can_use_tool".to_string(),
-                detail: tool_label.clone(),
-                received_at: Instant::now(),
-            });
+            self.pending_interactive_requests.insert(
+                request_id.clone(),
+                PendingInteractiveRequest {
+                    request_id,
+                    subtype: "can_use_tool".to_string(),
+                    detail: tool_label.clone(),
+                    received_at: Instant::now(),
+                },
+            );
             notify_if_background(
                 self.emitter.app(),
                 "Permission Required",
@@ -3215,9 +3275,11 @@ pub fn build_user_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::build_control_response;
+    use super::{build_control_response, PendingInteractiveRequest, SessionActor};
     use crate::models::{max_attachment_size, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES};
     use serde_json::json;
+    use std::collections::HashMap;
+    use std::time::{Duration, Instant};
 
     /// Helper: build a multimodal content array the same way handle_send_message does,
     /// including size validation (base64 len * 3/4 vs max_attachment_size).
@@ -3291,6 +3353,36 @@ mod tests {
         assert_eq!(p["response"]["error"], "nope");
         // Error responses carry no nested `response` body.
         assert!(p["response"].get("response").is_none());
+    }
+
+    #[test]
+    fn pending_interactive_requests_clear_independently() {
+        let now = Instant::now();
+        let mut pending = HashMap::from([
+            (
+                "first".to_string(),
+                PendingInteractiveRequest {
+                    request_id: "first".to_string(),
+                    subtype: "can_use_tool".to_string(),
+                    detail: "Bash".to_string(),
+                    received_at: now - Duration::from_secs(2),
+                },
+            ),
+            (
+                "second".to_string(),
+                PendingInteractiveRequest {
+                    request_id: "second".to_string(),
+                    subtype: "request_user_input".to_string(),
+                    detail: String::new(),
+                    received_at: now,
+                },
+            ),
+        ]);
+
+        SessionActor::clear_pending_interactive_request_map(&mut pending, "second");
+
+        assert!(pending.contains_key("first"));
+        assert!(!pending.contains_key("second"));
     }
 
     #[test]

--- a/src-tauri/src/agent/session_protocol.rs
+++ b/src-tauri/src/agent/session_protocol.rs
@@ -95,8 +95,9 @@ pub struct ParsedLine {
     /// BusEvents to persist + emit (message deltas, tool start/end, usage, and any
     /// interactive prompt events).
     pub events: Vec<BusEvent>,
-    /// Set when this line is a server→client interactive request awaiting a user response.
-    pub interactive: Option<PendingInteractive>,
+    /// Server→client interactive requests awaiting user responses. A parent notification can
+    /// register a child thread and replay more than one request that arrived before registration.
+    pub interactive: Vec<PendingInteractive>,
     /// Set when this line marks a turn boundary.
     pub lifecycle: Option<LifecycleSignal>,
     /// Set when this line carries the (resume) conversation id to persist.
@@ -106,6 +107,9 @@ pub struct ParsedLine {
     /// where `request_id` is the frontend control request id and `value` is the JSON-RPC
     /// `result` (or `error`). The actor routes it to the matching `control_waiter`.
     pub control_response: Option<(String, Value)>,
+    /// JSON-RPC frames the protocol must send immediately without waiting for frontend input.
+    /// Codex uses this for autonomous metadata reads such as spawned-thread identity lookup.
+    pub outbound: Vec<Value>,
 }
 
 /// Localizes all wire-format differences between agent transports. The actor calls these at

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1406,6 +1406,17 @@ pub enum BusEvent {
         turn_id: String,
         diff: String,
     },
+    /// Identity metadata resolved for a spawned Codex thread through `thread/read`.
+    CodexAgentInfo {
+        run_id: String,
+        thread_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        nickname: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        role: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parent_thread_id: Option<String>,
+    },
     /// Tool use summary — top-level event type "tool_use_summary".
     ToolUseSummary {
         run_id: String,

--- a/src-tauri/src/storage/events.rs
+++ b/src-tauri/src/storage/events.rs
@@ -36,6 +36,7 @@ pub const REPLAY_TYPES: &[&str] = &[
     "elicitation_prompt",
     "rate_limit_event",
     "codex_hook_run",
+    "codex_agent_info",
 ];
 
 /// Check if a BusEvent's serde tag is in REPLAY_TYPES.

--- a/src-tauri/src/web_server/broadcaster.rs
+++ b/src-tauri/src/web_server/broadcaster.rs
@@ -204,6 +204,7 @@ fn event_type_name(event: &BusEvent) -> &'static str {
         BusEvent::CodexHookRun { .. } => "codex_hook_run",
         BusEvent::CodexMcpStatus { .. } => "codex_mcp_status",
         BusEvent::CodexTurnDiff { .. } => "codex_turn_diff",
+        BusEvent::CodexAgentInfo { .. } => "codex_agent_info",
         BusEvent::Raw { .. } => "raw",
     }
 }

--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import type { BusToolItem, TimelineEntry, PermissionSuggestion } from "$lib/types";
+  import type {
+    BusToolItem,
+    TimelineEntry,
+    PermissionSuggestion,
+    CodexAgentIdentity,
+  } from "$lib/types";
   import type { TaskNotificationItem } from "$lib/stores/session-store.svelte";
   import { getToolColor } from "$lib/utils/tool-colors";
   import {
@@ -21,6 +26,7 @@
     getPermissionProfileDetails,
     isToolTerminal,
     formatSuggestionLabel as _fmtSuggestion,
+    singleCodexReceiverThreadId,
   } from "$lib/utils/tool-rendering";
   import MarkdownContent from "$lib/components/MarkdownContent.svelte";
   import ToolDetailView from "$lib/components/ToolDetailView.svelte";
@@ -41,6 +47,7 @@
     planContent,
     latestPlanTool,
     showPermissionInPanel,
+    codexAgentInfo,
     agentDisplayName,
     onPreviewFile,
   }: {
@@ -71,6 +78,8 @@
     latestPlanTool?: boolean;
     /** Whether generic tool permissions are handled by the floating PermissionPanel. */
     showPermissionInPanel?: boolean;
+    /** Spawned Codex thread identity keyed by thread id. */
+    codexAgentInfo?: Record<string, CodexAgentIdentity>;
     /** Display name for the agent (e.g. "Claude" or "Codex"). */
     agentDisplayName?: string;
     /** Click on Edit/Write/Read tool card's file path → open preview in right panel. */
@@ -243,6 +252,15 @@
     if (res?.codexCollab && typeof res.operation === "string") return res.operation;
     return null;
   });
+  let codexAgentThreadId = $derived.by<string | null>(() => {
+    if (!codexCollabOp) return null;
+    const inp = tool.input as Record<string, unknown> | undefined;
+    const res = tool.tool_use_result as Record<string, unknown> | undefined;
+    return singleCodexReceiverThreadId(inp, res);
+  });
+  let codexIdentity = $derived(
+    codexAgentThreadId ? codexAgentInfo?.[codexAgentThreadId] : undefined,
+  );
 
   // Status display
   let statusKind = $derived(
@@ -1646,7 +1664,12 @@
       <div class="flex-1 min-w-0 flex items-center gap-1.5">
         {#if codexCollabOp}
           <!-- Codex collab subagent: "Sub-agent · {operation}" -->
-          <span class="text-xs font-medium text-foreground">{t("inline_subagent")}</span>
+          <span class="text-xs font-medium text-foreground"
+            >{codexIdentity?.nickname ?? t("inline_subagent")}</span
+          >
+          {#if codexIdentity?.role}
+            <span class="text-[10px] text-cyan-500/80">{codexIdentity.role}</span>
+          {/if}
           <span class="text-xs text-muted-foreground">· {codexCollabOp}</span>
           {#if subToolCount > 0}
             <span class="text-[10px] px-1 py-0.5 rounded bg-muted text-muted-foreground">
@@ -1823,7 +1846,7 @@
             </button>
           {/if}
         {:else}
-          <ToolDetailView tool={enrichedTool} {isInputStreaming} {onPreviewFile} />
+          <ToolDetailView tool={enrichedTool} {isInputStreaming} {onPreviewFile} {codexAgentInfo} />
         {/if}
       </div>
     {/if}
@@ -1879,6 +1902,7 @@
             {onPermissionRespond}
             {taskNotifications}
             {showPermissionInPanel}
+            {codexAgentInfo}
             {agentDisplayName}
             {onPreviewFile}
           />

--- a/src/lib/components/ToolDetailView.svelte
+++ b/src/lib/components/ToolDetailView.svelte
@@ -3,7 +3,7 @@
   import { dbg } from "$lib/utils/debug";
   import { ansiToHtml, hasAnsiCodes, escapeHtml, stripAnsi } from "$lib/utils/ansi";
   import { colorizeCommand } from "$lib/utils/shell-colorize";
-  import type { BusToolItem, TodoItem } from "$lib/types";
+  import type { BusToolItem, TodoItem, CodexAgentIdentity } from "$lib/types";
   import {
     extractOutputText,
     getLanguageFromPath,
@@ -35,10 +35,12 @@
     tool,
     isInputStreaming = false,
     onPreviewFile,
+    codexAgentInfo,
   }: {
     tool: BusToolItem;
     isInputStreaming?: boolean;
     onPreviewFile?: (path: string) => void;
+    codexAgentInfo?: Record<string, CodexAgentIdentity>;
   } = $props();
 
   // ── Helpers ──
@@ -426,6 +428,9 @@
     status?: string | null; // CollabAgentToolCallStatus
     receiverThreadIds?: string[];
     agents?: CodexCollabAgent[];
+  }
+  function codexAgentLabel(agent: CodexCollabAgent): string {
+    return codexAgentInfo?.[agent.thread_id]?.nickname ?? agent.thread_id.slice(0, 8);
   }
   // The marker may ride on input (ToolStart) or on the result payload (ToolEnd); prefer the
   // result (richer/final) and fall back to input for the in-flight render.
@@ -1167,8 +1172,13 @@
         {#each codexCollab.agents as agent}
           <div class="flex items-center gap-2 text-xs">
             <span class="font-mono text-[10px] text-muted-foreground/70"
-              >{agent.thread_id.slice(0, 8)}</span
+              >{codexAgentLabel(agent)}</span
             >
+            {#if codexAgentInfo?.[agent.thread_id]?.role}
+              <span class="text-[10px] text-cyan-500/70"
+                >{codexAgentInfo[agent.thread_id].role}</span
+              >
+            {/if}
             <span
               class="px-1.5 py-0.5 rounded text-[10px] font-medium {codexCollabBadgeClass(
                 agent.status,

--- a/src/lib/stores/__fixtures__/protocol-events.json
+++ b/src/lib/stores/__fixtures__/protocol-events.json
@@ -130,6 +130,14 @@
   },
   { "type": "control_cancelled", "run_id": "run-1", "request_id": "req-elicit-1" },
   {
+    "type": "codex_agent_info",
+    "run_id": "run-1",
+    "thread_id": "child-1",
+    "nickname": "Dewey",
+    "role": "explorer",
+    "parent_thread_id": "root"
+  },
+  {
     "type": "message_complete",
     "run_id": "run-1",
     "message_id": "msg-1",

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -19,6 +19,7 @@ import type {
   SessionMode,
   TodoItem,
   PanelTask,
+  CodexAgentIdentity,
 } from "$lib/types";
 import { dbg, dbgWarn } from "$lib/utils/debug";
 import { yieldToMain } from "$lib/utils/yield";
@@ -163,6 +164,10 @@ interface ReduceCtx {
    *  creation; only committed in _commitReduceCtx. Keeps async replay
    *  stale-safe (mid-batch abort doesn't pollute live store). */
   scheduledTasks: ScheduledTask[];
+  /** Spawned Codex identities resolved during replay; committed atomically with the timeline. */
+  codexAgentInfo: Record<string, CodexAgentIdentity>;
+  codexAgentInfoVersion: number;
+  codexAgentInfoDirty: boolean;
 }
 
 // ── Helpers ──
@@ -343,6 +348,9 @@ export class SessionStore {
   /** Codex Wave-4: latest cumulative turn diff (`turn/diff/updated`). Live-only,
    *  not replayed — cleared at the start of each turn (run_state→running) and on reset. */
   turnDiff = $state<string>("");
+  /** Spawned Codex thread identities resolved by the backend via `thread/read`. */
+  codexAgentInfo = $state<Record<string, CodexAgentIdentity>>({});
+  private _codexAgentInfoVersion = 0;
 
   // ── CLI verbose fields (from session_init / usage_update) ──
   cliVersion = $state<string>("");
@@ -1304,6 +1312,9 @@ export class SessionStore {
       toolTlIndex: batchTlIndex,
       toolHeIndex: batchHeIndex,
       scheduledTasks: [...this.scheduledTasks],
+      codexAgentInfo: { ...this.codexAgentInfo },
+      codexAgentInfoVersion: this._codexAgentInfoVersion,
+      codexAgentInfoDirty: false,
     };
   }
 
@@ -1353,6 +1364,15 @@ export class SessionStore {
     this._toolTlIndex = ctx.toolTlIndex;
     this._toolHeIndex = ctx.toolHeIndex;
     this.scheduledTasks = ctx.scheduledTasks;
+    if (ctx.codexAgentInfoDirty) {
+      // A live identity may arrive while async replay yields. Preserve that newer value while
+      // still publishing identities that exist only in the replay batch.
+      this.codexAgentInfo =
+        this._codexAgentInfoVersion === ctx.codexAgentInfoVersion
+          ? ctx.codexAgentInfo
+          : { ...ctx.codexAgentInfo, ...this.codexAgentInfo };
+      this._codexAgentInfoVersion++;
+    }
     if (!replayOnly) {
       this._setPhase(ctx.phase);
       this.error = ctx.error;
@@ -1536,6 +1556,8 @@ export class SessionStore {
     this.sessionCommands = [];
     this.mcpServers = [];
     this.turnDiff = "";
+    this.codexAgentInfo = {};
+    this._codexAgentInfoVersion++;
     this.cliVersion = "";
     // NOTE: permissionMode intentionally NOT cleared — user-level preference, same as platformId.
     // However, if persist had failed, reset the flag so next session_init can re-sync.
@@ -1669,6 +1691,7 @@ export class SessionStore {
       apiKeySource: this.apiKeySource,
       sessionCommands: this.sessionCommands,
       mcpServers: this.mcpServers,
+      codexAgentInfo: this.codexAgentInfo,
       sessionTools: this.sessionTools,
       availableAgents: this.availableAgents,
       availableSkills: this.availableSkills,
@@ -1751,6 +1774,8 @@ export class SessionStore {
       this.apiKeySource = (obj.apiKeySource as string) ?? "";
       this.sessionCommands = (obj.sessionCommands ?? []) as CliCommand[];
       this.mcpServers = dedupeMcpServersByName((obj.mcpServers ?? []) as McpServerInfo[]);
+      this.codexAgentInfo = (obj.codexAgentInfo as typeof this.codexAgentInfo | undefined) ?? {};
+      this._codexAgentInfoVersion++;
       this.sessionTools = (obj.sessionTools ?? []) as string[];
       this.availableAgents = (obj.availableAgents ?? []) as string[];
       this.availableSkills = (obj.availableSkills ?? []) as string[];
@@ -4415,6 +4440,30 @@ export class SessionStore {
         // Cleared at the next turn start (run_state→running) and on reset.
         dbg("store", "codex_turn_diff", { len: ev.diff.length });
         this.turnDiff = ev.diff;
+        break;
+      }
+
+      case "codex_agent_info": {
+        dbg("store", "codex_agent_info", {
+          threadId: ev.thread_id,
+          nickname: ev.nickname,
+          role: ev.role,
+        });
+        const next = {
+          ...(ctx ? ctx.codexAgentInfo : this.codexAgentInfo),
+          [ev.thread_id]: {
+            nickname: ev.nickname,
+            role: ev.role,
+            parentThreadId: ev.parent_thread_id,
+          },
+        };
+        if (ctx) {
+          ctx.codexAgentInfo = next;
+          ctx.codexAgentInfoDirty = true;
+        } else {
+          this.codexAgentInfo = next;
+          this._codexAgentInfoVersion++;
+        }
         break;
       }
 

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -1750,6 +1750,121 @@ describe("SessionStore reducer", () => {
       expect(agents[0].thread_id).toBe("t2");
       expect(agents[0].status).toBe("completed");
     });
+
+    it("stores resolved Codex agent identities", () => {
+      store.run = makeRun("run-collab");
+      store.applyEvent({
+        type: "codex_agent_info",
+        run_id: "run-collab",
+        thread_id: "child-1",
+        nickname: "Dewey",
+        role: "explorer",
+        parent_thread_id: "root",
+      });
+
+      expect(store.codexAgentInfo["child-1"]).toEqual({
+        nickname: "Dewey",
+        role: "explorer",
+        parentThreadId: "root",
+      });
+      expect(store.unknownEventCount).toBe(0);
+    });
+
+    it("commits Codex agent identities through batch reduction", () => {
+      store.run = makeRun("run-collab");
+      store.applyEventBatch([
+        {
+          type: "codex_agent_info",
+          run_id: "run-collab",
+          thread_id: "child-batch",
+          nickname: "Huey",
+          role: "worker",
+          parent_thread_id: "root",
+        },
+      ]);
+
+      expect(store.codexAgentInfo["child-batch"]).toEqual({
+        nickname: "Huey",
+        role: "worker",
+        parentThreadId: "root",
+      });
+    });
+
+    it("does not publish Codex identities from a stale async batch", async () => {
+      store.run = makeRun("run-collab");
+      store.codexAgentInfo = {
+        existing: { nickname: "Live", role: "worker", parentThreadId: "root" },
+      };
+      const events: BusEvent[] = Array.from({ length: 501 }, (_, index) =>
+        index === 0
+          ? {
+              type: "codex_agent_info",
+              run_id: "run-collab",
+              thread_id: "stale-child",
+              nickname: "Stale",
+            }
+          : {
+              type: "message_delta",
+              run_id: "run-collab",
+              text: "x",
+            },
+      );
+      let staleChecks = 0;
+
+      const result = await store.applyEventBatchAsync(events, {
+        isStale: () => ++staleChecks >= 3,
+      });
+
+      expect(result).toBeNull();
+      expect(store.codexAgentInfo).toEqual({
+        existing: { nickname: "Live", role: "worker", parentThreadId: "root" },
+      });
+    });
+
+    it("preserves a live Codex identity that arrives while async replay yields", async () => {
+      store.run = makeRun("run-collab");
+      const events: BusEvent[] = Array.from({ length: 501 }, (_, index) =>
+        index === 0
+          ? {
+              type: "codex_agent_info",
+              run_id: "run-collab",
+              thread_id: "child-1",
+              nickname: "Historical",
+            }
+          : { type: "message_delta", run_id: "run-collab", text: "x" },
+      );
+
+      const replay = store.applyEventBatchAsync(events);
+      store.applyEvent({
+        type: "codex_agent_info",
+        run_id: "run-collab",
+        thread_id: "child-1",
+        nickname: "Live",
+      });
+      await replay;
+
+      expect(store.codexAgentInfo["child-1"]?.nickname).toBe("Live");
+    });
+
+    it("snapshot round-trip preserves resolved Codex identities", () => {
+      store.run = makeRun("run-collab");
+      store.applyEvent({
+        type: "codex_agent_info",
+        run_id: "run-collab",
+        thread_id: "child-1",
+        nickname: "Dewey",
+        parent_thread_id: "root",
+      });
+
+      const body = (store as unknown as { _buildSnapshot(): string })._buildSnapshot();
+      const fresh = new SessionStore();
+      const restored = (
+        fresh as unknown as { _tryApplySnapshot(body: string): boolean }
+      )._tryApplySnapshot(body);
+
+      expect(restored).toBe(true);
+      expect(fresh.codexAgentInfo["child-1"]?.nickname).toBe("Dewey");
+    });
   });
 
   // ── Subagent streaming deltas ──

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1095,6 +1095,14 @@ export type BusEvent =
       data: Record<string, unknown>;
     }
   | { type: "control_cancelled"; run_id: string; request_id: string }
+  | {
+      type: "codex_agent_info";
+      run_id: string;
+      thread_id: string;
+      nickname?: string;
+      role?: string;
+      parent_thread_id?: string;
+    }
   | { type: "command_output"; run_id: string; content: string }
   | {
       type: "elicitation_prompt";
@@ -1189,6 +1197,12 @@ export interface ElicitationSchema {
   properties?: Record<string, ElicitationFieldSchema>;
   required?: string[];
   [key: string]: unknown;
+}
+
+export interface CodexAgentIdentity {
+  nickname?: string;
+  role?: string;
+  parentThreadId?: string;
 }
 
 export interface BusToolItem {

--- a/src/lib/utils/__tests__/tool-rendering.test.ts
+++ b/src/lib/utils/__tests__/tool-rendering.test.ts
@@ -19,6 +19,7 @@ import {
   getPermissionProfileDetails,
   isSubagentTool,
   friendlyToolName,
+  singleCodexReceiverThreadId,
 } from "../tool-rendering";
 
 // ── extractOutputText ──
@@ -54,6 +55,35 @@ describe("extractOutputText", () => {
   it("falls back to JSON.stringify for unknown objects", () => {
     const output = { foo: 42 };
     expect(extractOutputText(output)).toBe('{"foo":42}');
+  });
+});
+
+describe("singleCodexReceiverThreadId", () => {
+  it("returns the sole receiver from the final result", () => {
+    expect(
+      singleCodexReceiverThreadId(
+        { receiverThreadIds: ["initial"] },
+        { receiverThreadIds: ["child-1"] },
+      ),
+    ).toBe("child-1");
+  });
+
+  it("falls back to input when no result is available", () => {
+    expect(singleCodexReceiverThreadId({ receiverThreadIds: ["child-1"] }, undefined)).toBe(
+      "child-1",
+    );
+  });
+
+  it("does not attribute a multi-agent operation to its first receiver", () => {
+    expect(
+      singleCodexReceiverThreadId({ receiverThreadIds: ["child-1", "child-2"] }, undefined),
+    ).toBeNull();
+  });
+
+  it("rejects empty and malformed receiver lists", () => {
+    expect(singleCodexReceiverThreadId({ receiverThreadIds: [] }, undefined)).toBeNull();
+    expect(singleCodexReceiverThreadId({ receiverThreadIds: [""] }, undefined)).toBeNull();
+    expect(singleCodexReceiverThreadId({ receiverThreadIds: "child-1" }, undefined)).toBeNull();
   });
 });
 

--- a/src/lib/utils/tool-rendering.ts
+++ b/src/lib/utils/tool-rendering.ts
@@ -43,6 +43,17 @@ export function extractOutputText(output: unknown): string {
   }
 }
 
+/** Resolve the sole receiver for a Codex collab card; multi-agent operations stay generic. */
+export function singleCodexReceiverThreadId(
+  input: Record<string, unknown> | undefined,
+  result: Record<string, unknown> | undefined,
+): string | null {
+  const ids = result?.receiverThreadIds ?? input?.receiverThreadIds;
+  return Array.isArray(ids) && ids.length === 1 && typeof ids[0] === "string" && ids[0]
+    ? ids[0]
+    : null;
+}
+
 /** Extract image content blocks (base64) from tool output, if any. */
 export function extractImageBlocks(
   output: unknown,

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -5046,6 +5046,7 @@
                               latestPlanTool={entry.kind === "tool" &&
                                 entry.tool.tool_use_id === latestPlanToolId}
                               showPermissionInPanel={showPermissionPanel}
+                              codexAgentInfo={store.codexAgentInfo}
                               {agentDisplayName}
                               onPreviewFile={openPreviewForPath}
                             />


### PR DESCRIPTION
## What changed

- support Codex 0.147 `subAgentActivity` events and route child activity into the owning Agent timeline
- defer early child notifications and interactive requests until ownership is established, with FIFO replay, TTL expiry, and bounded memory limits
- resolve spawned-thread nickname and role through `thread/read`, persist the identity event, and render it in Agent cards
- support multiple simultaneous interactive requests and preserve child permission/user-input routing
- add Rust protocol coverage and frontend reducer/rendering coverage

## Why

Codex app-server can multiplex parent and spawned-thread events on one connection. Child events and approval requests may arrive before the parent spawn activity, causing them to be dropped, misattributed, or left unanswered. The protocol now isolates those early messages until the parent-child relationship is known.

## Validation

- `npm run lint:fix` — 0 errors, 1 existing warning
- `npm run format` / `npm run format:check`
- `npm run check` — 0 errors, 75 existing warnings
- `npm test` — 39 files, 1,446 tests passed
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `scripts/check-serde-sync.sh`
- Rust suite: 729 passed, 2 ignored after temporarily repairing two existing master fixtures; one unrelated existing diagnostics timing assertion still fails because a local request completes in 0 ms (`test_api_connectivity_success_200` expects `latency_ms > 0`). The temporary fixture repairs are not included in this PR.
