### PR TITLE
fix: repair Rust test fixtures

### DIFF
--- a/src-tauri/src/agent/adapter.rs
+++ b/src-tauri/src/agent/adapter.rs
@@ -654,6 +654,7 @@ mod tests {
     fn make_user_settings() -> UserSettings {
         UserSettings {
             default_agent: "claude".to_string(),
+            claude_path: None,
             default_model: None,
             allowed_tools: vec![],
             working_directory: None,

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -3276,7 +3276,7 @@ pub fn build_user_payload(
 #[cfg(test)]
 mod tests {
     use super::{build_control_response, PendingInteractiveRequest, SessionActor};
-    use crate::models::{max_attachment_size, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES};
+    use crate::models::{max_attachment_size, BusEvent, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES};
     use serde_json::json;
     use std::collections::HashMap;
     use std::time::{Duration, Instant};

--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -1620,7 +1620,8 @@ mod tests {
             let result = test_api_inner("test-key", &url, "ANTHROPIC_API_KEY", "test-model").await;
             assert!(result.success);
             assert!(!result.partial);
-            assert!(result.latency_ms > 0);
+            // A loopback response can complete within the millisecond clock resolution.
+            assert!(result.latency_ms < 5_000);
             assert_eq!(result.reply, Some("Hello!".to_string()));
             assert!(result.error.is_none());
         });


### PR DESCRIPTION
## What changed

- add the missing `claude_path` field to the `UserSettings` test fixture
- import `BusEvent` in the session actor test module
- allow successful loopback API probes to report `0ms`, which is valid at millisecond clock resolution

## Why

Two Rust test fixtures drifted after their production types changed, preventing the test target from compiling. After repairing them, the connectivity test exposed a timing assumption that fails when a local response completes within one millisecond.

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml` — 708 passed, 2 ignored
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `npm run lint:fix` — 0 errors, 1 existing warning
- `npm run format` / `npm run format:check`
- `npm run check` — 0 errors, 75 existing warnings
- `npm test` — 39 files, 1,437 tests passed
- `npm run build`
