### PR TITLE
fix: retain interactive requests until response delivery

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1526,6 +1526,7 @@
   "toast_permissionPersistFailed": "Mode active for this session only — save failed",
   "toast_permissionChangeFailed": "Permission mode change failed — save error",
   "toast_permissionModeNextTurn": "{mode} — takes effect next message",
+  "toast_permissionInterruptFailed": "Request denied, but stopping the turn failed — use Stop to retry",
   "toast_rewindSuccess": "Changes reverted",
   "error_rewindNoCheckpoint": "No file checkpoint found to rewind to",
   "error_rewindFailed": "Failed to rewind files",

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1526,6 +1526,7 @@
   "toast_permissionPersistFailed": "模式仅当前会话生效 — 保存失败",
   "toast_permissionChangeFailed": "权限模式切换失败 — 保存错误",
   "toast_permissionModeNextTurn": "{mode} — 下条消息生效",
+  "toast_permissionInterruptFailed": "请求已拒绝，但停止当前任务失败 — 请点击停止重试",
   "toast_rewindSuccess": "文件已回退",
   "error_rewindNoCheckpoint": "没有可回退的文件检查点",
   "error_rewindFailed": "文件回退失败",

--- a/src-tauri/src/agent/codex_appserver.rs
+++ b/src-tauri/src/agent/codex_appserver.rs
@@ -16,8 +16,8 @@
 
 use crate::agent::codex_parser::{codex_normalize_status, CodexToolKind};
 use crate::agent::session_protocol::{
-    CodexSkillRef, CodexTurnOverrides, LifecycleSignal, ParsedLine, PendingInteractive,
-    PendingKind, SessionProtocol, StartupCtx,
+    CodexSkillRef, CodexTurnOverrides, InteractiveResponse, LifecycleSignal, ParsedLine,
+    PendingInteractive, PendingKind, SessionProtocol, StartupCtx,
 };
 use crate::models::BusEvent;
 use serde_json::{json, Value};
@@ -50,6 +50,7 @@ struct PendingServerReq {
     /// Raw json-rpc id to echo in the response.
     raw_id: Value,
     method: String,
+    kind: PendingKind,
     /// Requested grant profile for `item/permissions/requestApproval`. Codex requires the
     /// response to echo only the subset the user granted; command/file approvals use decisions.
     requested_permissions: Option<Value>,
@@ -890,18 +891,26 @@ impl SessionProtocol for CodexAppServer {
     }
 
     fn frame_response(
-        &mut self,
+        &self,
         kind: PendingKind,
         request_id: &str,
         response: Value,
-    ) -> Vec<Value> {
-        let pending = match self.pending.remove(request_id) {
+    ) -> Result<InteractiveResponse, String> {
+        let pending = match self.pending.get(request_id) {
             Some(p) => p,
             None => {
                 log::warn!("[codex_appserver] frame_response: unknown request_id {request_id}");
-                return vec![];
+                return Err(format!("unknown interactive request_id: {request_id}"));
             }
         };
+        if pending.kind != kind {
+            log::warn!(
+                "[codex_appserver] frame_response: request kind mismatch for request_id={request_id}"
+            );
+            return Err(format!(
+                "interactive request kind mismatch for request_id: {request_id}"
+            ));
+        }
         let result = match kind {
             PendingKind::Permission => {
                 let behavior = response
@@ -957,20 +966,46 @@ impl SessionProtocol for CodexAppServer {
                 build_user_input_result(&response)
             }
         };
-        let mut frames = vec![json!({
+        let primary = json!({
             "jsonrpc": "2.0",
             "id": pending.raw_id,
             "result": result
-        })];
+        });
         // The permission-profile response has no cancel decision. Preserve the UI's
         // deny-and-stop contract by denying the grant first, then interrupting the active turn.
-        if pending.method == M_PERM_APPROVAL
+        let interrupt = pending.method == M_PERM_APPROVAL
             && response.get("behavior").and_then(Value::as_str) != Some("allow")
-            && response.get("interrupt").and_then(Value::as_bool) == Some(true)
-        {
-            frames.extend(self.frame_interrupt());
+            && response.get("interrupt").and_then(Value::as_bool) == Some(true);
+        Ok(InteractiveResponse {
+            primary,
+            interrupt_after_commit: interrupt,
+        })
+    }
+
+    fn frame_cancel(&self, request_id: &str) -> Result<Value, String> {
+        let pending = self.pending.get(request_id).ok_or_else(|| {
+            log::warn!("[codex_appserver] frame_cancel: unknown request_id {request_id}");
+            format!("unknown interactive request_id: {request_id}")
+        })?;
+        Ok(json!({
+            "jsonrpc": "2.0",
+            "id": pending.raw_id,
+            "error": {
+                "code": -32000,
+                "message": "Interactive request cancelled by user"
+            }
+        }))
+    }
+
+    fn commit_response(&mut self, request_id: &str) -> bool {
+        let removed = self.pending.remove(request_id).is_some();
+        if removed {
+            log::debug!(
+                "[codex_appserver] interactive response committed: request_id={}",
+                request_id
+            );
         }
-        frames
+        removed
     }
 }
 
@@ -1112,6 +1147,7 @@ impl CodexAppServer {
             PendingServerReq {
                 raw_id,
                 method: method.to_string(),
+                kind,
                 requested_permissions: if method == M_PERM_APPROVAL {
                     params.get("permissions").cloned()
                 } else {
@@ -2502,23 +2538,114 @@ mod tests {
             e => panic!("expected PermissionPrompt, got {e:?}"),
         }
         // Allow → {decision:"accept"} on id 0.
-        let resp = s.frame_response(PendingKind::Permission, "0", json!({"behavior":"allow"}));
-        assert_eq!(resp[0]["id"], 0);
-        assert_eq!(resp[0]["result"]["decision"], "accept");
+        let resp = s
+            .frame_response(PendingKind::Permission, "0", json!({"behavior":"allow"}))
+            .unwrap();
+        assert_eq!(resp.primary["id"], 0);
+        assert_eq!(resp.primary["result"]["decision"], "accept");
+        assert!(s.pending.contains_key("0"));
+        assert!(s.commit_response("0"));
+        assert!(!s.pending.contains_key("0"));
         // Deny path.
         let mut s2 = ready_server();
         s2.parse_line("run1", line);
-        let resp2 = s2.frame_response(PendingKind::Permission, "0", json!({"behavior":"deny"}));
-        assert_eq!(resp2[0]["result"]["decision"], "decline");
+        let resp2 = s2
+            .frame_response(PendingKind::Permission, "0", json!({"behavior":"deny"}))
+            .unwrap();
+        assert_eq!(resp2.primary["result"]["decision"], "decline");
 
         let mut s3 = ready_server();
         s3.parse_line("run1", line);
-        let resp3 = s3.frame_response(
+        let resp3 = s3
+            .frame_response(
+                PendingKind::Permission,
+                "0",
+                json!({"behavior":"deny", "interrupt":true}),
+            )
+            .unwrap();
+        assert_eq!(resp3.primary["result"]["decision"], "cancel");
+    }
+
+    #[test]
+    fn interactive_response_requires_known_request_and_matching_kind() {
+        let mut server = ready_server();
+        let unknown = server.frame_response(
             PendingKind::Permission,
-            "0",
-            json!({"behavior":"deny", "interrupt":true}),
+            "missing",
+            json!({"behavior":"allow"}),
         );
-        assert_eq!(resp3[0]["result"]["decision"], "cancel");
+        assert!(unknown
+            .unwrap_err()
+            .contains("unknown interactive request_id"));
+
+        server.parse_line(
+            "run1",
+            r#"{"id":7,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+        let mismatch =
+            server.frame_response(PendingKind::Permission, "7", json!({"behavior":"allow"}));
+        assert!(mismatch.unwrap_err().contains("kind mismatch"));
+        assert!(server.pending.contains_key("7"));
+    }
+
+    #[test]
+    fn interactive_responses_prepare_retry_and_commit_independently() {
+        let mut server = ready_server();
+        for id in [10, 11] {
+            server.parse_line(
+                "run1",
+                &format!(
+                    r#"{{"id":{id},"method":"mcpServer/elicitation/request","params":{{"threadId":"th-123","serverName":"srv","message":"Pick"}}}}"#
+                ),
+            );
+        }
+
+        let first = server
+            .frame_response(PendingKind::Elicitation, "10", json!({"action":"decline"}))
+            .unwrap();
+        let retry = server
+            .frame_response(PendingKind::Elicitation, "10", json!({"action":"decline"}))
+            .unwrap();
+        assert_eq!(first.primary, retry.primary);
+        assert!(server.pending.contains_key("10"));
+        assert!(server.pending.contains_key("11"));
+
+        assert!(server.commit_response("10"));
+        assert!(!server.pending.contains_key("10"));
+        assert!(server.pending.contains_key("11"));
+        assert!(!server.commit_response("10"));
+    }
+
+    #[test]
+    fn interactive_cancel_uses_raw_id_and_requires_commit() {
+        let mut server = ready_server();
+        server.parse_line(
+            "run1",
+            r#"{"id":"request-10","method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+
+        let frame = server.frame_cancel("request-10").unwrap();
+        assert_eq!(frame["jsonrpc"], "2.0");
+        assert_eq!(frame["id"], "request-10");
+        assert_eq!(frame["error"]["code"], -32000);
+        assert_eq!(
+            frame["error"]["message"],
+            "Interactive request cancelled by user"
+        );
+        assert!(server.pending.contains_key("request-10"));
+
+        assert!(server.commit_response("request-10"));
+        assert!(!server.pending.contains_key("request-10"));
+        assert!(server.frame_cancel("request-10").is_err());
+    }
+
+    #[test]
+    fn interactive_cancel_rejects_unknown_request() {
+        let server = ready_server();
+        assert!(server
+            .frame_cancel("missing")
+            .unwrap_err()
+            .contains("unknown interactive request_id"));
     }
 
     #[test]
@@ -2627,21 +2754,23 @@ mod tests {
             }
             event => panic!("expected PermissionPrompt, got {event:?}"),
         }
-        let response = allowed.frame_response(
-            PendingKind::Permission,
-            &pi.request_id,
-            json!({"behavior":"allow"}),
-        );
-        assert_eq!(response[0]["id"], 61);
+        let response = allowed
+            .frame_response(
+                PendingKind::Permission,
+                &pi.request_id,
+                json!({"behavior":"allow"}),
+            )
+            .unwrap();
+        assert_eq!(response.primary["id"], 61);
         assert_eq!(
-            response[0]["result"]["permissions"],
+            response.primary["result"]["permissions"],
             json!({
                 "fileSystem": {"write": ["/project", "/shared"]},
                 "network": {"enabled": true}
             })
         );
-        assert_eq!(response[0]["result"]["scope"], "turn");
-        assert!(response[0]["result"].get("decision").is_none());
+        assert_eq!(response.primary["result"]["scope"], "turn");
+        assert!(response.primary["result"].get("decision").is_none());
 
         let mut denied = ready_server();
         denied.parse_line(
@@ -2655,17 +2784,34 @@ mod tests {
             .expect("interactive")
             .request_id
             .clone();
-        let response = denied.frame_response(
-            PendingKind::Permission,
-            &request_id,
-            json!({"behavior":"deny", "interrupt":true}),
-        );
-        assert_eq!(response[0]["result"]["permissions"], json!({}));
-        assert_eq!(response[0]["result"]["scope"], "turn");
-        assert!(response[0]["result"].get("decision").is_none());
-        assert_eq!(response[1]["method"], "turn/interrupt");
-        assert_eq!(response[1]["params"]["threadId"], "th-123");
-        assert_eq!(response[1]["params"]["turnId"], "turn-1");
+        let next_id_before_prepare = denied.next_client_id;
+        let response = denied
+            .frame_response(
+                PendingKind::Permission,
+                &request_id,
+                json!({"behavior":"deny", "interrupt":true}),
+            )
+            .unwrap();
+        assert_eq!(denied.next_client_id, next_id_before_prepare);
+        assert_eq!(response.primary["result"]["permissions"], json!({}));
+        assert_eq!(response.primary["result"]["scope"], "turn");
+        assert!(response.primary["result"].get("decision").is_none());
+        assert!(response.interrupt_after_commit);
+        assert!(denied.pending.contains_key(&request_id));
+        assert!(denied.commit_response(&request_id));
+        assert!(!denied.pending.contains_key(&request_id));
+        let follow_up = denied.frame_interrupt();
+        assert_eq!(denied.next_client_id, next_id_before_prepare + 1);
+        assert_eq!(follow_up[0]["method"], "turn/interrupt");
+        assert_eq!(follow_up[0]["params"]["threadId"], "th-123");
+        assert_eq!(follow_up[0]["params"]["turnId"], "turn-1");
+        assert!(denied
+            .frame_response(
+                PendingKind::Permission,
+                &request_id,
+                json!({"behavior":"deny", "interrupt":true}),
+            )
+            .is_err());
     }
 
     #[test]
@@ -2696,13 +2842,18 @@ mod tests {
             e => panic!("expected ToolEnd, got {e:?}"),
         }
         // Answer "FOO" → Codex map shape {answers:{word:{answers:["FOO"]}}} on id 0.
-        let resp = s.frame_response(
-            PendingKind::UserInput,
-            "0",
-            json!({"answers": {"word": ["FOO"]}}),
+        let resp = s
+            .frame_response(
+                PendingKind::UserInput,
+                "0",
+                json!({"answers": {"word": ["FOO"]}}),
+            )
+            .unwrap();
+        assert_eq!(resp.primary["id"], 0);
+        assert_eq!(
+            resp.primary["result"]["answers"]["word"]["answers"][0],
+            "FOO"
         );
-        assert_eq!(resp[0]["id"], 0);
-        assert_eq!(resp[0]["result"]["answers"]["word"]["answers"][0], "FOO");
     }
 
     #[test]
@@ -2727,8 +2878,10 @@ mod tests {
             }
             e => panic!("expected ElicitationPrompt, got {e:?}"),
         }
-        let resp = s.frame_response(PendingKind::Elicitation, "1", json!({"action":"decline"}));
-        assert_eq!(resp[0]["result"]["action"], "decline");
+        let resp = s
+            .frame_response(PendingKind::Elicitation, "1", json!({"action":"decline"}))
+            .unwrap();
+        assert_eq!(resp.primary["result"]["action"], "decline");
     }
 
     #[test]
@@ -4188,16 +4341,18 @@ mod tests {
                         if pi.kind == PendingKind::Permission {
                             saw_approval = true;
                             assert!(matches!(parsed.events[0], BusEvent::PermissionPrompt { .. }));
-                            for msg in driver.frame_response(
-                                PendingKind::Permission,
-                                &pi.request_id,
-                                serde_json::json!({"behavior": "allow"}),
-                            ) {
-                                let mut l = serde_json::to_string(&msg).unwrap();
-                                l.push('\n');
-                                stdin.write_all(l.as_bytes()).await.unwrap();
-                            }
+                            let response = driver
+                                .frame_response(
+                                    PendingKind::Permission,
+                                    &pi.request_id,
+                                    serde_json::json!({"behavior": "allow"}),
+                                )
+                                .unwrap();
+                            let mut l = serde_json::to_string(&response.primary).unwrap();
+                            l.push('\n');
+                            stdin.write_all(l.as_bytes()).await.unwrap();
                             stdin.flush().await.unwrap();
+                            assert!(driver.commit_response(&pi.request_id));
                             accepted = true;
                         }
                     }
@@ -4305,12 +4460,14 @@ mod tests {
                                 })
                                 .expect("questions in AskUserQuestion event");
                             let answers = serde_json::json!({ "answers": { qid: [label] } });
-                            for msg in driver.frame_response(PendingKind::UserInput, &pi.request_id, answers) {
-                                let mut l = serde_json::to_string(&msg).unwrap();
-                                l.push('\n');
-                                stdin.write_all(l.as_bytes()).await.unwrap();
-                            }
+                            let response = driver
+                                .frame_response(PendingKind::UserInput, &pi.request_id, answers)
+                                .unwrap();
+                            let mut l = serde_json::to_string(&response.primary).unwrap();
+                            l.push('\n');
+                            stdin.write_all(l.as_bytes()).await.unwrap();
                             stdin.flush().await.unwrap();
+                            assert!(driver.commit_response(&pi.request_id));
                             answered = true;
                         }
                     }

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -151,6 +151,13 @@ fn build_control_response(request_id: &str, outcome: Result<Value, String>) -> V
     serde_json::json!({ "type": "control_response", "response": inner })
 }
 
+fn build_control_cancel_request(request_id: &str) -> Value {
+    serde_json::json!({
+        "type": "control_cancel_request",
+        "request_id": request_id,
+    })
+}
+
 // ── Ralph Loop types ──
 
 #[derive(Debug, Clone, PartialEq)]
@@ -515,25 +522,21 @@ impl SessionActor {
                             let _ = reply.send(r);
                         }
                         Some(ActorCommand::CancelControlRequest { request_id, reply }) => {
-                            self.clear_pending_interactive_request(&request_id);
                             let r = self.handle_cancel_control_request(&request_id).await;
                             let _ = reply.send(r);
                         }
                         Some(ActorCommand::RespondHookCallback { request_id, response, reply }) => {
                             log::debug!("[actor] RespondHookCallback: run_id={}, req_id={}", self.run_id, request_id);
-                            self.clear_pending_interactive_request(&request_id);
-                            let result = self.write_control_response(&request_id, response).await;
+                            let result = self.respond_hook_callback(&request_id, response).await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::RespondElicitation { request_id, response, reply }) => {
                             log::debug!("[actor] RespondElicitation: run_id={}, req_id={}", self.run_id, request_id);
-                            self.clear_pending_interactive_request(&request_id);
                             let result = self.write_interactive_response(PendingKind::Elicitation, &request_id, response).await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::RespondUserInput { request_id, response, reply }) => {
                             log::debug!("[actor] RespondUserInput: run_id={}, req_id={}", self.run_id, request_id);
-                            self.clear_pending_interactive_request(&request_id);
                             let result = self.write_interactive_response(PendingKind::UserInput, &request_id, response).await;
                             let _ = reply.send(result);
                         }
@@ -1794,7 +1797,6 @@ impl SessionActor {
             self.run_id,
             request_id,
         );
-        self.clear_pending_interactive_request(request_id);
         self.write_interactive_response(PendingKind::Permission, request_id, response)
             .await
     }
@@ -1807,23 +1809,140 @@ impl SessionActor {
         request_id: &str,
         response: Value,
     ) -> Result<(), String> {
-        let Some(codex) = self.codex.as_mut() else {
-            return self.write_control_response(request_id, response).await;
+        self.ensure_pending_interactive_request(request_id)?;
+        if self.codex.is_none() {
+            let delivery = self.write_control_response(request_id, response).await;
+            return Self::commit_actor_pending_after_delivery(
+                &mut self.pending_interactive_requests,
+                request_id,
+                delivery,
+            );
+        }
+
+        // Preparation keeps protocol state intact. This borrow must end before awaiting stdin.
+        let prepared = self
+            .codex
+            .as_mut()
+            .expect("codex checked above")
+            .frame_response(kind, request_id, response)?;
+        let delivery = self
+            .write_json_line(&prepared.primary, "codex interactive response")
+            .await;
+
+        // The primary JSON-RPC response resolves the request. Commit it before independent
+        // follow-up actions so an interrupt failure cannot make a delivered response retryable.
+        Self::commit_codex_pending_after_delivery(
+            self.codex.as_mut().expect("codex checked above"),
+            &mut self.pending_interactive_requests,
+            request_id,
+            delivery,
+        )?;
+        let follow_up = if prepared.interrupt_after_commit {
+            self.codex
+                .as_mut()
+                .expect("codex checked above")
+                .frame_interrupt()
+        } else {
+            Vec::new()
         };
-        let lines = codex.frame_response(kind, request_id, response);
-        for line in &lines {
-            self.write_json_line(line, "codex interactive response")
-                .await?;
+        log::debug!(
+            "[actor] interactive response committed: run_id={}, req_id={}, follow_up={}",
+            self.run_id,
+            request_id,
+            follow_up.len()
+        );
+        for frame in &follow_up {
+            let delivery = self
+                .write_json_line(frame, "codex interactive response follow-up")
+                .await;
+            if let Some(error) = Self::committed_follow_up_warning(delivery) {
+                log::error!(
+                    "[actor] interactive follow-up failed after response commit: run_id={}, req_id={}, error={}",
+                    self.run_id,
+                    request_id,
+                    error
+                );
+                self.emitter.emit_realtime(
+                    "interactive-follow-up-warning",
+                    &serde_json::json!({
+                        "run_id": self.run_id,
+                        "request_id": request_id,
+                        "error": error,
+                    }),
+                    Some(&self.run_id),
+                );
+                break;
+            }
         }
         Ok(())
     }
 
-    /// Clear pending interactive request if it matches the given request_id.
-    fn clear_pending_interactive_request(&mut self, request_id: &str) {
-        Self::clear_pending_interactive_request_map(
+    fn committed_follow_up_warning(delivery: Result<(), String>) -> Option<String> {
+        // The primary response is already committed, so return a separate warning instead of
+        // making the frontend offer a response retry that Codex must reject.
+        delivery.err()
+    }
+
+    async fn respond_hook_callback(
+        &mut self,
+        request_id: &str,
+        response: Value,
+    ) -> Result<(), String> {
+        self.ensure_pending_interactive_request(request_id)?;
+        let delivery = self.write_control_response(request_id, response).await;
+        Self::commit_actor_pending_after_delivery(
             &mut self.pending_interactive_requests,
             request_id,
-        );
+            delivery,
+        )
+    }
+
+    fn ensure_pending_interactive_request(&self, request_id: &str) -> Result<(), String> {
+        if self.pending_interactive_requests.contains_key(request_id) {
+            Ok(())
+        } else {
+            Err(format!("unknown interactive request_id: {request_id}"))
+        }
+    }
+
+    fn commit_actor_pending_after_delivery(
+        pending: &mut HashMap<String, PendingInteractiveRequest>,
+        request_id: &str,
+        delivery: Result<(), String>,
+    ) -> Result<(), String> {
+        if let Err(error) = delivery {
+            log::error!(
+                "[actor] interactive response delivery failed; pending retained: request_id={}, error={}",
+                request_id,
+                error
+            );
+            return Err(error);
+        }
+        Self::clear_pending_interactive_request_map(pending, request_id);
+        Ok(())
+    }
+
+    fn commit_codex_pending_after_delivery(
+        codex: &mut CodexAppServer,
+        pending: &mut HashMap<String, PendingInteractiveRequest>,
+        request_id: &str,
+        delivery: Result<(), String>,
+    ) -> Result<(), String> {
+        if let Err(error) = delivery {
+            log::error!(
+                "[actor] codex interactive response delivery failed; pending retained: request_id={}, error={}",
+                request_id,
+                error
+            );
+            return Err(error);
+        }
+        if !codex.commit_response(request_id) {
+            return Err(format!(
+                "interactive request disappeared before commit: {request_id}"
+            ));
+        }
+        Self::clear_pending_interactive_request_map(pending, request_id);
+        Ok(())
     }
 
     fn clear_pending_interactive_request_map(
@@ -1842,22 +1961,50 @@ impl SessionActor {
         }
     }
 
-    /// Send a control_cancel_request to CLI stdin (top-level message type).
+    /// Cancel an interactive request using the active transport's wire protocol.
     /// Used only for explicit user-initiated cancellation (ActorCommand::CancelControlRequest,
     /// e.g. the user dismisses a permission prompt). NOT for auto-declining unsupported
     /// requests — those use write_control_response_error (the CLI waits for a response).
     async fn handle_cancel_control_request(&mut self, request_id: &str) -> Result<(), String> {
-        let payload = serde_json::json!({
-            "type": "control_cancel_request",
-            "request_id": request_id,
-        });
+        self.ensure_pending_interactive_request(request_id)?;
+        if self.codex.is_some() {
+            // Codex has no transport-level cancel notification for server requests. A JSON-RPC
+            // error resolves every interactive method without inventing a method-specific value.
+            let payload = self
+                .codex
+                .as_ref()
+                .expect("codex checked above")
+                .frame_cancel(request_id)?;
+            log::debug!(
+                "[actor] cancel_codex_interactive: run_id={}, req_id={}",
+                self.run_id,
+                request_id,
+            );
+            let delivery = self
+                .write_json_line(&payload, "cancel codex interactive request")
+                .await;
+            return Self::commit_codex_pending_after_delivery(
+                self.codex.as_mut().expect("codex checked above"),
+                &mut self.pending_interactive_requests,
+                request_id,
+                delivery,
+            );
+        }
+
+        let payload = build_control_cancel_request(request_id);
         log::debug!(
             "[actor] cancel_control_request: run_id={}, req_id={}",
             self.run_id,
             request_id,
         );
-        self.write_json_line(&payload, "cancel control request")
-            .await
+        let delivery = self
+            .write_json_line(&payload, "cancel control request")
+            .await;
+        Self::commit_actor_pending_after_delivery(
+            &mut self.pending_interactive_requests,
+            request_id,
+            delivery,
+        )
     }
 
     /// Low-level helper: serialize JSON payload, write to stdin, flush.
@@ -1872,13 +2019,10 @@ impl SessionActor {
             .write_all(line.as_bytes())
             .await
             .map_err(|e| format!("{} write failed: {}", context, e))?;
-        if let Err(e) = stdin.flush().await {
-            log::warn!(
-                "[actor] stdin flush failed for run_id={}: {}",
-                self.run_id,
-                e
-            );
-        }
+        stdin
+            .flush()
+            .await
+            .map_err(|e| format!("{} flush failed: {}", context, e))?;
         Ok(())
     }
 
@@ -3275,7 +3419,12 @@ pub fn build_user_payload(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_control_response, PendingInteractiveRequest, SessionActor};
+    use super::{
+        build_control_cancel_request, build_control_response, PendingInteractiveRequest,
+        SessionActor,
+    };
+    use crate::agent::codex_appserver::CodexAppServer;
+    use crate::agent::session_protocol::{PendingKind, SessionProtocol};
     use crate::models::{max_attachment_size, BusEvent, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES};
     use serde_json::json;
     use std::collections::HashMap;
@@ -3356,6 +3505,14 @@ mod tests {
     }
 
     #[test]
+    fn claude_control_cancel_request_shape() {
+        let payload = build_control_cancel_request("r3");
+        assert_eq!(payload["type"], "control_cancel_request");
+        assert_eq!(payload["request_id"], "r3");
+        assert_eq!(payload.as_object().map(serde_json::Map::len), Some(2));
+    }
+
+    #[test]
     fn pending_interactive_requests_clear_independently() {
         let now = Instant::now();
         let mut pending = HashMap::from([
@@ -3383,6 +3540,151 @@ mod tests {
 
         assert!(pending.contains_key("first"));
         assert!(!pending.contains_key("second"));
+    }
+
+    #[test]
+    fn failed_codex_delivery_retains_both_pending_layers_for_retry() {
+        let mut codex = CodexAppServer::new();
+        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
+        codex.parse_line(
+            "run1",
+            r#"{"id":21,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+        let mut pending = HashMap::from([(
+            "21".to_string(),
+            PendingInteractiveRequest {
+                request_id: "21".to_string(),
+                subtype: "elicitation".to_string(),
+                detail: "srv".to_string(),
+                received_at: Instant::now(),
+            },
+        )]);
+
+        let result = SessionActor::commit_codex_pending_after_delivery(
+            &mut codex,
+            &mut pending,
+            "21",
+            Err("stdin closed".to_string()),
+        );
+        assert_eq!(result.unwrap_err(), "stdin closed");
+        assert!(pending.contains_key("21"));
+        assert!(codex
+            .frame_response(PendingKind::Elicitation, "21", json!({"action":"decline"}),)
+            .is_ok());
+    }
+
+    #[test]
+    fn successful_codex_delivery_commits_both_pending_layers() {
+        let mut codex = CodexAppServer::new();
+        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
+        codex.parse_line(
+            "run1",
+            r#"{"id":22,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+        let mut pending = HashMap::from([(
+            "22".to_string(),
+            PendingInteractiveRequest {
+                request_id: "22".to_string(),
+                subtype: "elicitation".to_string(),
+                detail: "srv".to_string(),
+                received_at: Instant::now(),
+            },
+        )]);
+
+        SessionActor::commit_codex_pending_after_delivery(&mut codex, &mut pending, "22", Ok(()))
+            .unwrap();
+        assert!(!pending.contains_key("22"));
+        assert!(codex
+            .frame_response(PendingKind::Elicitation, "22", json!({"action":"decline"}),)
+            .is_err());
+    }
+
+    #[test]
+    fn failed_codex_cancel_delivery_retains_both_pending_layers_for_retry() {
+        let mut codex = CodexAppServer::new();
+        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
+        codex.parse_line(
+            "run1",
+            r#"{"id":23,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+        let mut pending = HashMap::from([(
+            "23".to_string(),
+            PendingInteractiveRequest {
+                request_id: "23".to_string(),
+                subtype: "elicitation".to_string(),
+                detail: "srv".to_string(),
+                received_at: Instant::now(),
+            },
+        )]);
+
+        assert!(codex.frame_cancel("23").is_ok());
+        let result = SessionActor::commit_codex_pending_after_delivery(
+            &mut codex,
+            &mut pending,
+            "23",
+            Err("stdin closed".to_string()),
+        );
+        assert_eq!(result.unwrap_err(), "stdin closed");
+        assert!(pending.contains_key("23"));
+        assert!(codex.frame_cancel("23").is_ok());
+    }
+
+    #[test]
+    fn successful_codex_cancel_delivery_commits_both_pending_layers() {
+        let mut codex = CodexAppServer::new();
+        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
+        codex.parse_line(
+            "run1",
+            r#"{"id":24,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
+        );
+        let mut pending = HashMap::from([(
+            "24".to_string(),
+            PendingInteractiveRequest {
+                request_id: "24".to_string(),
+                subtype: "elicitation".to_string(),
+                detail: "srv".to_string(),
+                received_at: Instant::now(),
+            },
+        )]);
+
+        SessionActor::commit_codex_pending_after_delivery(&mut codex, &mut pending, "24", Ok(()))
+            .unwrap();
+        assert!(!pending.contains_key("24"));
+        assert!(codex.frame_cancel("24").is_err());
+    }
+
+    #[test]
+    fn committed_response_does_not_make_failed_follow_up_retryable() {
+        assert_eq!(
+            SessionActor::committed_follow_up_warning(Err("stdin closed".to_string())),
+            Some("stdin closed".to_string())
+        );
+        assert_eq!(SessionActor::committed_follow_up_warning(Ok(())), None);
+    }
+
+    #[test]
+    fn failed_claude_delivery_retains_actor_pending_for_retry() {
+        let mut pending = HashMap::from([(
+            "claude-1".to_string(),
+            PendingInteractiveRequest {
+                request_id: "claude-1".to_string(),
+                subtype: "can_use_tool".to_string(),
+                detail: "Bash".to_string(),
+                received_at: Instant::now(),
+            },
+        )]);
+
+        let result = SessionActor::commit_actor_pending_after_delivery(
+            &mut pending,
+            "claude-1",
+            Err("stdin closed".to_string()),
+        );
+        assert_eq!(result.unwrap_err(), "stdin closed");
+        assert!(pending.contains_key("claude-1"));
+
+        SessionActor::commit_actor_pending_after_delivery(&mut pending, "claude-1", Ok(()))
+            .unwrap();
+        assert!(!pending.contains_key("claude-1"));
     }
 
     #[test]

--- a/src-tauri/src/agent/session_protocol.rs
+++ b/src-tauri/src/agent/session_protocol.rs
@@ -80,6 +80,14 @@ pub struct PendingInteractive {
     pub kind: PendingKind,
 }
 
+/// A prepared response to a server-initiated interactive request. The primary response resolves
+/// the pending request; an optional interrupt is generated only after that response is committed.
+#[derive(Debug)]
+pub struct InteractiveResponse {
+    pub primary: Value,
+    pub interrupt_after_commit: bool,
+}
+
 /// Turn-boundary signal extracted from a wire line, mapped by the actor to `RunState` and
 /// used to release quarantine / advance the turn queue.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -116,7 +124,7 @@ pub struct ParsedLine {
 /// four seams: spawn (startup), user message (frame_user_turn), each stdout line
 /// (parse_line), and each interactive response (frame_response) / stop (frame_interrupt).
 ///
-/// Each `frame_*` returns the JSON value(s) to write as newline-delimited lines to stdin.
+/// Each `frame_*` prepares JSON values to write as newline-delimited lines to stdin.
 pub trait SessionProtocol: Send {
     /// Messages to send immediately after spawn, before the first user turn
     /// (e.g. Codex `initialize` + `thread/start`|`thread/resume`).
@@ -145,12 +153,19 @@ pub trait SessionProtocol: Send {
     /// Parse one stdout line into events + lifecycle/interactive/thread-id signals.
     fn parse_line(&mut self, run_id: &str, line: &str) -> ParsedLine;
 
-    /// Frame the user's response to a pending interactive request (Codex: a JSON-RPC
-    /// response on the stored request id). Empty = nothing to send (e.g. unknown id).
+    /// Prepare the user's response to a pending interactive request without consuming it.
+    /// The actor commits the request only after the primary frame is written and flushed.
     fn frame_response(
-        &mut self,
+        &self,
         kind: PendingKind,
         request_id: &str,
         response: Value,
-    ) -> Vec<Value>;
+    ) -> Result<InteractiveResponse, String>;
+
+    /// Prepare cancellation of a pending interactive request without consuming it.
+    /// The actor commits the request only after the cancellation frame is written and flushed.
+    fn frame_cancel(&self, request_id: &str) -> Result<Value, String>;
+
+    /// Consume a response prepared by [`SessionProtocol::frame_response`] after delivery.
+    fn commit_response(&mut self, request_id: &str) -> bool;
 }

--- a/src/lib/components/HookReviewCard.svelte
+++ b/src/lib/components/HookReviewCard.svelte
@@ -13,7 +13,7 @@
       request_id?: string;
       status?: string;
     };
-    onRespond: (requestId: string, decision: "allow" | "deny") => void;
+    onRespond: (requestId: string, decision: "allow" | "deny") => void | Promise<void>;
   } = $props();
 
   let submitting = $state(false);
@@ -26,11 +26,15 @@
     "Unknown Tool";
   const hookEventType = (data as { hook_event?: string }).hook_event ?? hookEvent.type;
 
-  function handleRespond(decision: "allow" | "deny") {
+  async function handleRespond(decision: "allow" | "deny") {
     if (!hookEvent.request_id || submitting) return;
     submitting = true;
     dbg("hook-review", "respond", { requestId: hookEvent.request_id, decision });
-    onRespond(hookEvent.request_id, decision);
+    try {
+      await onRespond(hookEvent.request_id, decision);
+    } catch {
+      submitting = false;
+    }
   }
 </script>
 

--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -57,7 +57,7 @@
     runId?: string;
     /** Callback to fetch full tool result from backend (with caching). */
     fetchToolResult?: (runId: string, toolUseId: string) => Promise<Record<string, unknown> | null>;
-    onAnswer?: (answer: string) => void;
+    onAnswer?: (answer: string) => void | Promise<void>;
     onApprove?: (toolName: string) => void;
     /** Inline permission response (--permission-prompt-tool stdio). */
     onPermissionRespond?: (
@@ -528,7 +528,7 @@
     if (submitting) return;
     submitting = true;
     try {
-      onAnswer?.(answer);
+      await onAnswer?.(answer);
     } catch {
       submitting = false;
     }
@@ -567,7 +567,7 @@
   // Multi-question submit for the ask_pending (onAnswer) path — used by Codex app-server
   // (and Claude pipe mode) where the answer goes back via onAnswer, not a permission response.
   // Encodes all answers keyed by both question id (for Codex respond_user_input) and text.
-  function submitAllAskAnswers() {
+  async function submitAllAskAnswers() {
     if (submitting || !onAnswer || !allQuestionsAnswered) return;
     submitting = true;
     const byId: Record<string, string> = {};
@@ -577,7 +577,11 @@
       byText[q.question] = ans;
       if (q.id) byId[q.id] = ans;
     }
-    onAnswer(JSON.stringify({ __askMulti: true, byId, byText }));
+    try {
+      await onAnswer(JSON.stringify({ __askMulti: true, byId, byText }));
+    } catch {
+      submitting = false;
+    }
   }
 
   // Multi-question: submit all answers at once

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -2825,9 +2825,6 @@ export class SessionStore {
           .map(([q, a]) => `${q}: ${a}`)
           .join("\n")
       : answer;
-    // Pass the per-question answers so the resolved card highlights each choice.
-    this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
-
     if (this.run.agent === "codex") {
       try {
         const answers: Record<string, string[]> = {};
@@ -2838,6 +2835,8 @@ export class SessionStore {
           answers[questions[0]?.id ?? "0"] = [answer];
         }
         await api.respondUserInput(this.run.id, toolUseId, answers);
+        // Keep the pending card actionable until the backend confirms stdin delivery.
+        this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
       } catch (e) {
         dbgWarn("store", "codex respondUserInput failed:", e);
         this.error = String(e);
@@ -2851,8 +2850,10 @@ export class SessionStore {
       // The session should be alive (idle phase) after the CLI auto-failed AskUserQuestion.
       if (this.sessionAlive) {
         await api.sendSessionMessage(this.run.id, display);
+        this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
       } else {
         dbgWarn("store", "session not alive for tool answer, skipping send");
+        throw new Error("session not alive for tool answer");
       }
     } catch (e) {
       dbgWarn("store", "tool answer failed:", e);

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -21,6 +21,7 @@ vi.mock("$lib/api", () => ({
   stopRun: vi.fn(),
   sendSessionControl: vi.fn(),
   steerSession: vi.fn(),
+  respondUserInput: vi.fn(),
   syncCliSession: vi.fn().mockResolvedValue({ newEvents: 0 }),
   renameRun: vi.fn().mockResolvedValue(undefined),
 }));
@@ -408,6 +409,60 @@ describe("SessionStore reducer", () => {
       const users = store.timeline.filter((e) => e.kind === "user");
       expect(users).toHaveLength(2); // "Create a file" + "app.js"
       expect(users[1].content).toBe("app.js");
+    });
+
+    it("keeps Codex question pending when response delivery fails", async () => {
+      const codexStore = new SessionStore();
+      codexStore.run = makeRun("run-codex-ask", { agent: "codex" });
+      codexStore.phase = "running";
+      codexStore.timeline = [
+        {
+          kind: "tool",
+          id: "ask-codex",
+          anchorId: "ask-codex",
+          ts: new Date().toISOString(),
+          tool: {
+            tool_use_id: "ask-codex",
+            tool_name: "AskUserQuestion",
+            input: { questions: [{ id: "q1", question: "Pick", options: [] }] },
+            status: "ask_pending",
+          },
+        } as TimelineEntry,
+      ];
+      vi.mocked(api.respondUserInput).mockRejectedValueOnce(new Error("stdin closed"));
+
+      await expect(codexStore.answerToolQuestion("ask-codex", "A")).rejects.toThrow("stdin closed");
+
+      const entry = codexStore.timeline[0] as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(entry.tool.status).toBe("ask_pending");
+      expect(entry.tool.output).toBeUndefined();
+    });
+
+    it("resolves Codex question only after response delivery succeeds", async () => {
+      const codexStore = new SessionStore();
+      codexStore.run = makeRun("run-codex-ask", { agent: "codex" });
+      codexStore.phase = "running";
+      codexStore.timeline = [
+        {
+          kind: "tool",
+          id: "ask-codex",
+          anchorId: "ask-codex",
+          ts: new Date().toISOString(),
+          tool: {
+            tool_use_id: "ask-codex",
+            tool_name: "AskUserQuestion",
+            input: { questions: [{ id: "q1", question: "Pick", options: [] }] },
+            status: "ask_pending",
+          },
+        } as TimelineEntry,
+      ];
+      vi.mocked(api.respondUserInput).mockResolvedValueOnce(undefined);
+
+      await codexStore.answerToolQuestion("ask-codex", "A");
+
+      const entry = codexStore.timeline[0] as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(entry.tool.status).toBe("success");
+      expect(entry.tool.output).toEqual({ answer: "A" });
     });
   });
 

--- a/src/lib/utils/resolve-permission.test.ts
+++ b/src/lib/utils/resolve-permission.test.ts
@@ -11,13 +11,14 @@ vi.mock("$lib/utils/debug", () => ({
   dbgWarn: vi.fn(),
 }));
 
-import { resolvePermissionOptimistic } from "./resolve-permission";
+import { resolvePermissionAfterDelivery, resolvePermissionOptimistic } from "./resolve-permission";
 import { markAttention, hasAttention, _resetForTest } from "$lib/stores/attention-store.svelte";
 
 function mockStore() {
   return {
     resolvePermissionAllow: vi.fn(),
     resolvePermissionDeny: vi.fn(),
+    pendingPermissionModeOverride: null as string | null,
   };
 }
 
@@ -50,15 +51,71 @@ describe("resolvePermissionOptimistic", () => {
     expect(hasAttention("run-1")).toBe(false);
   });
 
-  it("deny catch branch — same behavior as success", () => {
-    // In +page.svelte catch block, deny also calls the helper
+  it("delivery failure retains deny card and attention for retry", async () => {
     const store = mockStore();
     markAttention("run-1", "permission");
 
-    resolvePermissionOptimistic(store, "run-1", "req-1", "deny");
+    await expect(
+      resolvePermissionAfterDelivery(store, "run-1", "req-1", "deny", () =>
+        Promise.reject(new Error("stdin closed")),
+      ),
+    ).rejects.toThrow("stdin closed");
+
+    expect(store.resolvePermissionDeny).not.toHaveBeenCalled();
+    expect(hasAttention("run-1")).toBe(true);
+  });
+
+  it("delivery success resolves deny card and attention", async () => {
+    const store = mockStore();
+    markAttention("run-1", "permission");
+
+    await resolvePermissionAfterDelivery(store, "run-1", "req-1", "deny", () => Promise.resolve());
 
     expect(store.resolvePermissionDeny).toHaveBeenCalledWith("req-1");
     expect(hasAttention("run-1")).toBe(false);
+  });
+
+  it("failed mode-changing allow rolls back before a deny retry", async () => {
+    const store = mockStore();
+    store.pendingPermissionModeOverride = "default";
+
+    await expect(
+      resolvePermissionAfterDelivery(
+        store,
+        "run-1",
+        "exitplan-req",
+        "allow",
+        () => Promise.reject(new Error("stdin closed")),
+        "acceptEdits",
+      ),
+    ).rejects.toThrow("stdin closed");
+    expect(store.pendingPermissionModeOverride).toBe("default");
+
+    await resolvePermissionAfterDelivery(store, "run-1", "exitplan-req", "deny", () =>
+      Promise.resolve(),
+    );
+    expect(store.pendingPermissionModeOverride).toBe("default");
+  });
+
+  it("failed delivery does not roll back a newer mode override", async () => {
+    const store = mockStore();
+    let rejectDelivery!: (error: Error) => void;
+    const delivery = new Promise<void>((_, reject) => {
+      rejectDelivery = reject;
+    });
+    const response = resolvePermissionAfterDelivery(
+      store,
+      "run-1",
+      "exitplan-req",
+      "allow",
+      () => delivery,
+      "acceptEdits",
+    );
+    store.pendingPermissionModeOverride = "bypassPermissions";
+    rejectDelivery(new Error("stdin closed"));
+
+    await expect(response).rejects.toThrow("stdin closed");
+    expect(store.pendingPermissionModeOverride).toBe("bypassPermissions");
   });
 
   // handleExitPlanClearContext equivalent

--- a/src/lib/utils/resolve-permission.ts
+++ b/src/lib/utils/resolve-permission.ts
@@ -9,6 +9,7 @@ import { dbg } from "$lib/utils/debug";
 interface PermissionResolver {
   resolvePermissionAllow(requestId: string): void;
   resolvePermissionDeny(requestId: string): void;
+  pendingPermissionModeOverride: string | null;
 }
 
 /** Optimistic resolve + clear attention after permission respond IPC. */
@@ -31,4 +32,32 @@ export function resolvePermissionOptimistic(
     clearAttention(runId, "ask");
   }
   dbg("attention", "optimistic-clear", { runId, requestId, behavior });
+}
+
+/** Resolve the permission card only after the backend confirms primary stdin delivery. */
+export async function resolvePermissionAfterDelivery(
+  store: PermissionResolver,
+  runId: string,
+  requestId: string,
+  behavior: "allow" | "deny",
+  deliver: () => Promise<void>,
+  modeOverride?: string,
+): Promise<void> {
+  const previousModeOverride = store.pendingPermissionModeOverride;
+  if (modeOverride) {
+    // Stage before invoking IPC because the resulting tool_end event can race its reply.
+    store.pendingPermissionModeOverride = modeOverride;
+    dbg("permission", "mode-override-staged", { requestId, modeOverride });
+  }
+  try {
+    await deliver();
+  } catch (error) {
+    // Do not overwrite a newer response that changed the staged value while IPC was pending.
+    if (modeOverride && store.pendingPermissionModeOverride === modeOverride) {
+      store.pendingPermissionModeOverride = previousModeOverride;
+      dbg("permission", "mode-override-rolled-back", { requestId, modeOverride });
+    }
+    throw error;
+  }
+  resolvePermissionOptimistic(store, runId, requestId, behavior);
 }

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -86,7 +86,7 @@
     setStoredRemoteCwd,
   } from "$lib/utils/remote-cwd";
   import { shouldAutoName } from "$lib/utils/auto-name";
-  import { resolvePermissionOptimistic } from "$lib/utils/resolve-permission";
+  import { resolvePermissionAfterDelivery } from "$lib/utils/resolve-permission";
   import { getToolColor } from "$lib/utils/tool-colors";
   import { ansiToHtml, hasAnsiCodes } from "$lib/utils/ansi";
   import { randomSpinnerVerb } from "$lib/utils/spinner-verbs";
@@ -1815,6 +1815,15 @@
         promptRef?.addFiles([file]);
       },
     );
+    const interactiveFollowUpWarningUnlisten = chatTransport.listen<{
+      run_id: string;
+      request_id: string;
+      error: string;
+    }>("interactive-follow-up-warning", (payload) => {
+      if (payload.run_id !== store.run?.id) return;
+      dbgWarn("chat", "interactive follow-up failed after response delivery", payload);
+      showChatToast(t("toast_permissionInterruptFailed"));
+    });
 
     // Tauri native drag-drop listeners (dragDropEnabled: true in tauri.conf.json)
     const dragEnterUnlisten = chatTransport.listen<{ paths: string[] }>(
@@ -1879,6 +1888,7 @@
       keybindingStore.unregisterCallback("app:exportChatHtml");
       window.removeEventListener("ocv:export-html", onExportHtmlEvent);
       screenshotUnlisten.then((fn) => fn());
+      interactiveFollowUpWarningUnlisten.then((fn) => fn());
       dragEnterUnlisten.then((fn) => fn());
       dragLeaveUnlisten.then((fn) => fn());
       dragDropUnlisten.then((fn) => fn());
@@ -4108,34 +4118,32 @@
       interrupt,
     });
     try {
-      // Set pending mode override BEFORE responding (so reducer picks it up)
-      if (behavior === "allow" && updatedPermissions) {
-        const modePerm = updatedPermissions.find((p) => p.type === "setMode");
-        if (modePerm && modePerm.mode) {
-          store.pendingPermissionModeOverride = modePerm.mode;
-          dbg("chat", "set pendingPermissionModeOverride", { mode: modePerm.mode });
-        }
-      }
+      const modeOverride =
+        behavior === "allow"
+          ? updatedPermissions?.find((permission) => permission.type === "setMode")?.mode
+          : undefined;
 
-      await api.respondPermission(
+      await resolvePermissionAfterDelivery(
+        store,
         runId,
         requestId,
         behavior,
-        updatedPermissions,
-        updatedInput,
-        denyMessage,
-        interrupt,
+        () =>
+          api.respondPermission(
+            runId,
+            requestId,
+            behavior,
+            updatedPermissions,
+            updatedInput,
+            denyMessage,
+            interrupt,
+          ),
+        modeOverride,
       );
-      // Optimistic resolve + clear attention flag
-      resolvePermissionOptimistic(store, runId, requestId, behavior);
     } catch (e) {
       dbgWarn("chat", "permission respond failed:", e);
-      // If the CLI rejected the response (e.g. session already idle after interrupt),
-      // still resolve the card locally so buttons are removed.
-      if (behavior === "deny") {
-        resolvePermissionOptimistic(store, runId, requestId, "deny");
-      }
-      // allow failure: don't change status — submitting timeout auto-resets (§5)
+      // The backend retains pending state when primary delivery fails, so keep the card
+      // actionable for both allow and deny retries.
       store.error = String(e);
       throw e; // Let component-side wrapper catch and unlock buttons
     }
@@ -4238,18 +4246,24 @@
 
     try {
       // 1. Set flags BEFORE responding
-      store.pendingPermissionModeOverride = "acceptEdits";
       store.pendingClearContextPlan = "__pending__"; // marker: waiting for tool_end
 
       // 2. Allow ExitPlanMode (with setMode) — satisfies the control_response requirement
-      await api.respondPermission(
+      await resolvePermissionAfterDelivery(
+        store,
         runId,
         requestId,
         "allow",
-        [{ type: "setMode", mode: "acceptEdits", destination: "session" }],
-        exitPlanEntry.tool.input,
+        () =>
+          api.respondPermission(
+            runId,
+            requestId,
+            "allow",
+            [{ type: "setMode", mode: "acceptEdits", destination: "session" }],
+            exitPlanEntry.tool.input,
+          ),
+        "acceptEdits",
       );
-      resolvePermissionOptimistic(store, runId, requestId, "allow");
 
       // 3. Wait for tool_end to deliver plan content (via pendingClearContextPlan)
       //    Poll briefly — tool_end should arrive within a few hundred ms
@@ -4308,6 +4322,7 @@
     } catch (e) {
       dbgWarn("chat", "hook callback respond failed:", e);
       store.error = String(e);
+      throw e;
     }
   }
 </script>


### PR DESCRIPTION
## What changed

- Prepare interactive responses without consuming pending request state.
- Commit Codex and Claude pending state only after the primary stdin write and flush succeeds.
- Keep permission, elicitation, user-input, hook-review, and cancellation UI actionable when delivery fails.
- Treat deny-and-interrupt as a committed primary response plus a follow-up interrupt, with a visible warning if stopping the turn fails.
- Roll back staged ExitPlanMode permission state when delivery fails.

## Root cause

Interactive request state and frontend cards were cleared before the CLI response was confirmed written and flushed. A stdin failure therefore made the request appear resolved locally while the CLI was still waiting, preventing a valid retry.

## User impact

Failed response delivery no longer silently removes interactive prompts. Users can retry the original action, while partial success in the deny-and-interrupt path is reported without presenting an invalid response retry.

## Validation

- `npm run lint:fix` (0 errors; 1 existing warning)
- `npm run format`
- `npm run format:check`
- `npm run check` (0 errors; existing warnings only)
- `npm test` (1463 tests passed)
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- Targeted Rust transaction and cancellation tests
- `git diff --check`
