### PR TITLE
fix(history): page large sessions safely

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1820,5 +1820,19 @@
   "scheduled_tasks_cancelTimeout": "Still active — try again",
   "scheduled_tasks_waitForTurn": "Wait for current turn",
   "scheduled_tasks_oneShot": "Once",
-  "scheduled_tasks_expiryNote": "Tasks expire after 7 days (CLI managed)"
+  "scheduled_tasks_expiryNote": "Tasks expire after 7 days (CLI managed)",
+  "interaction_responsePending": "Response sent; delivery confirmation is pending.",
+  "interaction_responseFailed": "Response delivery could not be confirmed. Check the session before continuing.",
+  "historyContent_window": "Showing a bounded window from byte {offset}",
+  "historyContent_preview": "Preview shown · {bytes} bytes total",
+  "historyContent_loading": "Loading…",
+  "historyContent_loaded": "All loaded chunks shown",
+  "historyContent_retry": "Retry chunk",
+  "historyContent_loadNext": "Load next chunk",
+  "historyContent_thinking": "Full thinking",
+  "historyContent_toolInput": "Full tool input",
+  "historyContent_toolOutput": "Full tool output",
+  "historyContent_toolResult": "Full tool result",
+  "historyContent_unavailable": "Full legacy tool details are unavailable",
+  "historySub_loadEarlier": "Load earlier sub-agent history"
 }

--- a/messages/zh-CN.json
+++ b/messages/zh-CN.json
@@ -1820,5 +1820,19 @@
   "scheduled_tasks_cancelTimeout": "仍未取消，请重试",
   "scheduled_tasks_waitForTurn": "等待当前回合结束",
   "scheduled_tasks_oneShot": "单次",
-  "scheduled_tasks_expiryNote": "任务 7 天后由 CLI 自动过期"
+  "scheduled_tasks_expiryNote": "任务 7 天后由 CLI 自动过期",
+  "interaction_responsePending": "响应已发送，正在等待投递确认。",
+  "interaction_responseFailed": "无法确认响应是否成功投递，请检查会话状态后再继续。",
+  "historyContent_window": "当前显示从第 {offset} 字节开始的有界窗口",
+  "historyContent_preview": "当前为预览 · 共 {bytes} 字节",
+  "historyContent_loading": "加载中…",
+  "historyContent_loaded": "已显示全部已加载分块",
+  "historyContent_retry": "重试加载",
+  "historyContent_loadNext": "加载下一分块",
+  "historyContent_thinking": "完整思考内容",
+  "historyContent_toolInput": "完整工具输入",
+  "historyContent_toolOutput": "完整工具输出",
+  "historyContent_toolResult": "完整工具结果",
+  "historyContent_unavailable": "旧版工具详情无法完整加载",
+  "historySub_loadEarlier": "加载更早的子代理历史"
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -55,6 +55,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Storage_FileSystem",
     "Win32_System_DataExchange",
     "Win32_System_Ole",
     "Win32_UI_Shell",

--- a/src-tauri/src/agent/codex_appserver.rs
+++ b/src-tauri/src/agent/codex_appserver.rs
@@ -16,8 +16,8 @@
 
 use crate::agent::codex_parser::{codex_normalize_status, CodexToolKind};
 use crate::agent::session_protocol::{
-    CodexSkillRef, CodexTurnOverrides, InteractiveResponse, LifecycleSignal, ParsedLine,
-    PendingInteractive, PendingKind, SessionProtocol, StartupCtx,
+    CodexSkillRef, CodexTurnOverrides, LifecycleSignal, ParsedLine, PendingInteractive,
+    PendingKind, SessionProtocol, StartupCtx,
 };
 use crate::models::BusEvent;
 use serde_json::{json, Value};
@@ -50,10 +50,10 @@ struct PendingServerReq {
     /// Raw json-rpc id to echo in the response.
     raw_id: Value,
     method: String,
-    kind: PendingKind,
     /// Requested grant profile for `item/permissions/requestApproval`. Codex requires the
     /// response to echo only the subset the user granted; command/file approvals use decisions.
     requested_permissions: Option<Value>,
+    kind: PendingKind,
 }
 
 enum DeferredThreadMessage {
@@ -891,27 +891,20 @@ impl SessionProtocol for CodexAppServer {
     }
 
     fn frame_response(
-        &self,
+        &mut self,
         kind: PendingKind,
         request_id: &str,
         response: Value,
-    ) -> Result<InteractiveResponse, String> {
-        let pending = match self.pending.get(request_id) {
-            Some(p) => p,
-            None => {
-                log::warn!("[codex_appserver] frame_response: unknown request_id {request_id}");
-                return Err(format!("unknown interactive request_id: {request_id}"));
-            }
-        };
-        if pending.kind != kind {
-            log::warn!(
-                "[codex_appserver] frame_response: request kind mismatch for request_id={request_id}"
-            );
-            return Err(format!(
-                "interactive request kind mismatch for request_id: {request_id}"
-            ));
-        }
+    ) -> Result<Vec<Value>, String> {
+        self.validate_response(kind, request_id)?;
+        let pending = self
+            .pending
+            .remove(request_id)
+            .ok_or_else(|| format!("unknown Codex interactive request_id {request_id}"))?;
         let result = match kind {
+            // Codex currently has no hook callback request; the shared protocol kind exists for
+            // Claude, and validate_response prevents this branch from accepting a mismatched id.
+            PendingKind::Hook => response.clone(),
             PendingKind::Permission => {
                 let behavior = response
                     .get("behavior")
@@ -966,46 +959,34 @@ impl SessionProtocol for CodexAppServer {
                 build_user_input_result(&response)
             }
         };
-        let primary = json!({
+        let mut frames = vec![json!({
             "jsonrpc": "2.0",
             "id": pending.raw_id,
             "result": result
-        });
+        })];
         // The permission-profile response has no cancel decision. Preserve the UI's
         // deny-and-stop contract by denying the grant first, then interrupting the active turn.
-        let interrupt = pending.method == M_PERM_APPROVAL
+        if pending.method == M_PERM_APPROVAL
             && response.get("behavior").and_then(Value::as_str) != Some("allow")
-            && response.get("interrupt").and_then(Value::as_bool) == Some(true);
-        Ok(InteractiveResponse {
-            primary,
-            interrupt_after_commit: interrupt,
-        })
-    }
-
-    fn frame_cancel(&self, request_id: &str) -> Result<Value, String> {
-        let pending = self.pending.get(request_id).ok_or_else(|| {
-            log::warn!("[codex_appserver] frame_cancel: unknown request_id {request_id}");
-            format!("unknown interactive request_id: {request_id}")
-        })?;
-        Ok(json!({
-            "jsonrpc": "2.0",
-            "id": pending.raw_id,
-            "error": {
-                "code": -32000,
-                "message": "Interactive request cancelled by user"
-            }
-        }))
-    }
-
-    fn commit_response(&mut self, request_id: &str) -> bool {
-        let removed = self.pending.remove(request_id).is_some();
-        if removed {
-            log::debug!(
-                "[codex_appserver] interactive response committed: request_id={}",
-                request_id
-            );
+            && response.get("interrupt").and_then(Value::as_bool) == Some(true)
+        {
+            frames.extend(self.frame_interrupt());
         }
-        removed
+        Ok(frames)
+    }
+
+    fn validate_response(&self, kind: PendingKind, request_id: &str) -> Result<(), String> {
+        let pending = self
+            .pending
+            .get(request_id)
+            .ok_or_else(|| format!("unknown Codex interactive request_id {request_id}"))?;
+        if pending.kind != kind {
+            return Err(format!(
+                "Codex interactive request kind mismatch for {request_id}: expected {:?}, got {kind:?}",
+                pending.kind
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -2541,18 +2522,15 @@ mod tests {
         let resp = s
             .frame_response(PendingKind::Permission, "0", json!({"behavior":"allow"}))
             .unwrap();
-        assert_eq!(resp.primary["id"], 0);
-        assert_eq!(resp.primary["result"]["decision"], "accept");
-        assert!(s.pending.contains_key("0"));
-        assert!(s.commit_response("0"));
-        assert!(!s.pending.contains_key("0"));
+        assert_eq!(resp[0]["id"], 0);
+        assert_eq!(resp[0]["result"]["decision"], "accept");
         // Deny path.
         let mut s2 = ready_server();
         s2.parse_line("run1", line);
         let resp2 = s2
             .frame_response(PendingKind::Permission, "0", json!({"behavior":"deny"}))
             .unwrap();
-        assert_eq!(resp2.primary["result"]["decision"], "decline");
+        assert_eq!(resp2[0]["result"]["decision"], "decline");
 
         let mut s3 = ready_server();
         s3.parse_line("run1", line);
@@ -2563,89 +2541,7 @@ mod tests {
                 json!({"behavior":"deny", "interrupt":true}),
             )
             .unwrap();
-        assert_eq!(resp3.primary["result"]["decision"], "cancel");
-    }
-
-    #[test]
-    fn interactive_response_requires_known_request_and_matching_kind() {
-        let mut server = ready_server();
-        let unknown = server.frame_response(
-            PendingKind::Permission,
-            "missing",
-            json!({"behavior":"allow"}),
-        );
-        assert!(unknown
-            .unwrap_err()
-            .contains("unknown interactive request_id"));
-
-        server.parse_line(
-            "run1",
-            r#"{"id":7,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-        let mismatch =
-            server.frame_response(PendingKind::Permission, "7", json!({"behavior":"allow"}));
-        assert!(mismatch.unwrap_err().contains("kind mismatch"));
-        assert!(server.pending.contains_key("7"));
-    }
-
-    #[test]
-    fn interactive_responses_prepare_retry_and_commit_independently() {
-        let mut server = ready_server();
-        for id in [10, 11] {
-            server.parse_line(
-                "run1",
-                &format!(
-                    r#"{{"id":{id},"method":"mcpServer/elicitation/request","params":{{"threadId":"th-123","serverName":"srv","message":"Pick"}}}}"#
-                ),
-            );
-        }
-
-        let first = server
-            .frame_response(PendingKind::Elicitation, "10", json!({"action":"decline"}))
-            .unwrap();
-        let retry = server
-            .frame_response(PendingKind::Elicitation, "10", json!({"action":"decline"}))
-            .unwrap();
-        assert_eq!(first.primary, retry.primary);
-        assert!(server.pending.contains_key("10"));
-        assert!(server.pending.contains_key("11"));
-
-        assert!(server.commit_response("10"));
-        assert!(!server.pending.contains_key("10"));
-        assert!(server.pending.contains_key("11"));
-        assert!(!server.commit_response("10"));
-    }
-
-    #[test]
-    fn interactive_cancel_uses_raw_id_and_requires_commit() {
-        let mut server = ready_server();
-        server.parse_line(
-            "run1",
-            r#"{"id":"request-10","method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-
-        let frame = server.frame_cancel("request-10").unwrap();
-        assert_eq!(frame["jsonrpc"], "2.0");
-        assert_eq!(frame["id"], "request-10");
-        assert_eq!(frame["error"]["code"], -32000);
-        assert_eq!(
-            frame["error"]["message"],
-            "Interactive request cancelled by user"
-        );
-        assert!(server.pending.contains_key("request-10"));
-
-        assert!(server.commit_response("request-10"));
-        assert!(!server.pending.contains_key("request-10"));
-        assert!(server.frame_cancel("request-10").is_err());
-    }
-
-    #[test]
-    fn interactive_cancel_rejects_unknown_request() {
-        let server = ready_server();
-        assert!(server
-            .frame_cancel("missing")
-            .unwrap_err()
-            .contains("unknown interactive request_id"));
+        assert_eq!(resp3[0]["result"]["decision"], "cancel");
     }
 
     #[test]
@@ -2761,16 +2657,16 @@ mod tests {
                 json!({"behavior":"allow"}),
             )
             .unwrap();
-        assert_eq!(response.primary["id"], 61);
+        assert_eq!(response[0]["id"], 61);
         assert_eq!(
-            response.primary["result"]["permissions"],
+            response[0]["result"]["permissions"],
             json!({
                 "fileSystem": {"write": ["/project", "/shared"]},
                 "network": {"enabled": true}
             })
         );
-        assert_eq!(response.primary["result"]["scope"], "turn");
-        assert!(response.primary["result"].get("decision").is_none());
+        assert_eq!(response[0]["result"]["scope"], "turn");
+        assert!(response[0]["result"].get("decision").is_none());
 
         let mut denied = ready_server();
         denied.parse_line(
@@ -2784,7 +2680,6 @@ mod tests {
             .expect("interactive")
             .request_id
             .clone();
-        let next_id_before_prepare = denied.next_client_id;
         let response = denied
             .frame_response(
                 PendingKind::Permission,
@@ -2792,26 +2687,12 @@ mod tests {
                 json!({"behavior":"deny", "interrupt":true}),
             )
             .unwrap();
-        assert_eq!(denied.next_client_id, next_id_before_prepare);
-        assert_eq!(response.primary["result"]["permissions"], json!({}));
-        assert_eq!(response.primary["result"]["scope"], "turn");
-        assert!(response.primary["result"].get("decision").is_none());
-        assert!(response.interrupt_after_commit);
-        assert!(denied.pending.contains_key(&request_id));
-        assert!(denied.commit_response(&request_id));
-        assert!(!denied.pending.contains_key(&request_id));
-        let follow_up = denied.frame_interrupt();
-        assert_eq!(denied.next_client_id, next_id_before_prepare + 1);
-        assert_eq!(follow_up[0]["method"], "turn/interrupt");
-        assert_eq!(follow_up[0]["params"]["threadId"], "th-123");
-        assert_eq!(follow_up[0]["params"]["turnId"], "turn-1");
-        assert!(denied
-            .frame_response(
-                PendingKind::Permission,
-                &request_id,
-                json!({"behavior":"deny", "interrupt":true}),
-            )
-            .is_err());
+        assert_eq!(response[0]["result"]["permissions"], json!({}));
+        assert_eq!(response[0]["result"]["scope"], "turn");
+        assert!(response[0]["result"].get("decision").is_none());
+        assert_eq!(response[1]["method"], "turn/interrupt");
+        assert_eq!(response[1]["params"]["threadId"], "th-123");
+        assert_eq!(response[1]["params"]["turnId"], "turn-1");
     }
 
     #[test]
@@ -2849,11 +2730,8 @@ mod tests {
                 json!({"answers": {"word": ["FOO"]}}),
             )
             .unwrap();
-        assert_eq!(resp.primary["id"], 0);
-        assert_eq!(
-            resp.primary["result"]["answers"]["word"]["answers"][0],
-            "FOO"
-        );
+        assert_eq!(resp[0]["id"], 0);
+        assert_eq!(resp[0]["result"]["answers"]["word"]["answers"][0], "FOO");
     }
 
     #[test]
@@ -2881,7 +2759,7 @@ mod tests {
         let resp = s
             .frame_response(PendingKind::Elicitation, "1", json!({"action":"decline"}))
             .unwrap();
-        assert_eq!(resp.primary["result"]["action"], "decline");
+        assert_eq!(resp[0]["result"]["action"], "decline");
     }
 
     #[test]
@@ -4341,18 +4219,19 @@ mod tests {
                         if pi.kind == PendingKind::Permission {
                             saw_approval = true;
                             assert!(matches!(parsed.events[0], BusEvent::PermissionPrompt { .. }));
-                            let response = driver
+                            for msg in driver
                                 .frame_response(
                                     PendingKind::Permission,
                                     &pi.request_id,
                                     serde_json::json!({"behavior": "allow"}),
                                 )
-                                .unwrap();
-                            let mut l = serde_json::to_string(&response.primary).unwrap();
-                            l.push('\n');
-                            stdin.write_all(l.as_bytes()).await.unwrap();
+                                .unwrap()
+                            {
+                                let mut l = serde_json::to_string(&msg).unwrap();
+                                l.push('\n');
+                                stdin.write_all(l.as_bytes()).await.unwrap();
+                            }
                             stdin.flush().await.unwrap();
-                            assert!(driver.commit_response(&pi.request_id));
                             accepted = true;
                         }
                     }
@@ -4460,14 +4339,15 @@ mod tests {
                                 })
                                 .expect("questions in AskUserQuestion event");
                             let answers = serde_json::json!({ "answers": { qid: [label] } });
-                            let response = driver
+                            for msg in driver
                                 .frame_response(PendingKind::UserInput, &pi.request_id, answers)
-                                .unwrap();
-                            let mut l = serde_json::to_string(&response.primary).unwrap();
-                            l.push('\n');
-                            stdin.write_all(l.as_bytes()).await.unwrap();
+                                .unwrap()
+                            {
+                                let mut l = serde_json::to_string(&msg).unwrap();
+                                l.push('\n');
+                                stdin.write_all(l.as_bytes()).await.unwrap();
+                            }
                             stdin.flush().await.unwrap();
-                            assert!(driver.commit_response(&pi.request_id));
                             answered = true;
                         }
                     }

--- a/src-tauri/src/agent/session_actor.rs
+++ b/src-tauri/src/agent/session_actor.rs
@@ -30,7 +30,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStderr, ChildStdin, ChildStdout};
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -78,6 +78,45 @@ fn truncate_str(s: &str, max: usize) -> &str {
         end -= 1;
     }
     &s[..end]
+}
+
+fn pending_kind_name(kind: PendingKind) -> &'static str {
+    match kind {
+        PendingKind::Permission => "permission",
+        PendingKind::Hook => "hook",
+        PendingKind::Elicitation => "elicitation",
+        PendingKind::UserInput => "user_input",
+    }
+}
+
+fn ensure_control_cancel_supported(is_codex: bool) -> Result<(), String> {
+    if is_codex {
+        // Codex app-server has no stream-json control_cancel_request frame; emitting the Claude
+        // shape would be ignored while leaving the JSON-RPC request pending.
+        Err(
+            "[interaction:not_started] cancel_control_request is unsupported for Codex app-server"
+                .to_string(),
+        )
+    } else {
+        Ok(())
+    }
+}
+
+async fn write_json_line_to<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    payload: &Value,
+    context: &str,
+) -> Result<(), String> {
+    let mut line = serde_json::to_string(payload).map_err(|e| e.to_string())?;
+    line.push('\n');
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| format!("{} write failed: {}", context, e))?;
+    writer
+        .flush()
+        .await
+        .map_err(|e| format!("{} flush failed: {}", context, e))
 }
 
 /// Build a control_response payload for the CLI. HC#2: the `request_id` MUST be nested
@@ -151,13 +190,6 @@ fn build_control_response(request_id: &str, outcome: Result<Value, String>) -> V
     serde_json::json!({ "type": "control_response", "response": inner })
 }
 
-fn build_control_cancel_request(request_id: &str) -> Value {
-    serde_json::json!({
-        "type": "control_cancel_request",
-        "request_id": request_id,
-    })
-}
-
 // ── Ralph Loop types ──
 
 #[derive(Debug, Clone, PartialEq)]
@@ -195,6 +227,7 @@ pub struct RalphCancelResult {
 #[derive(Debug)]
 struct PendingInteractiveRequest {
     request_id: String,
+    kind: PendingKind,
     /// "can_use_tool" | "hook_callback" | "elicitation"
     subtype: String,
     /// tool_name / hook event / server name
@@ -527,17 +560,49 @@ impl SessionActor {
                         }
                         Some(ActorCommand::RespondHookCallback { request_id, response, reply }) => {
                             log::debug!("[actor] RespondHookCallback: run_id={}, req_id={}", self.run_id, request_id);
-                            let result = self.respond_hook_callback(&request_id, response).await;
+                            let resolution = response
+                                .get("decision")
+                                .and_then(Value::as_str)
+                                .map(str::to_owned);
+                            let result = self
+                                .deliver_interaction_response(
+                                    PendingKind::Hook,
+                                    &request_id,
+                                    "hook",
+                                    resolution.as_deref(),
+                                    response,
+                                )
+                                .await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::RespondElicitation { request_id, response, reply }) => {
                             log::debug!("[actor] RespondElicitation: run_id={}, req_id={}", self.run_id, request_id);
-                            let result = self.write_interactive_response(PendingKind::Elicitation, &request_id, response).await;
+                            let resolution = response
+                                .get("action")
+                                .and_then(Value::as_str)
+                                .map(str::to_owned);
+                            let result = self
+                                .deliver_interaction_response(
+                                    PendingKind::Elicitation,
+                                    &request_id,
+                                    "elicitation",
+                                    resolution.as_deref(),
+                                    response,
+                                )
+                                .await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::RespondUserInput { request_id, response, reply }) => {
                             log::debug!("[actor] RespondUserInput: run_id={}, req_id={}", self.run_id, request_id);
-                            let result = self.write_interactive_response(PendingKind::UserInput, &request_id, response).await;
+                            let result = self
+                                .deliver_interaction_response(
+                                    PendingKind::UserInput,
+                                    &request_id,
+                                    "user_input",
+                                    None,
+                                    response,
+                                )
+                                .await;
                             let _ = reply.send(result);
                         }
                         Some(ActorCommand::StartRalphLoop { prompt, max_iterations, completion_promise, reply }) => {
@@ -1797,8 +1862,122 @@ impl SessionActor {
             self.run_id,
             request_id,
         );
-        self.write_interactive_response(PendingKind::Permission, request_id, response)
-            .await
+        let resolution = response
+            .get("behavior")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        self.deliver_interaction_response(
+            PendingKind::Permission,
+            request_id,
+            "permission",
+            resolution.as_deref(),
+            response,
+        )
+        .await
+    }
+
+    async fn deliver_interaction_response(
+        &mut self,
+        kind: PendingKind,
+        request_id: &str,
+        interaction_kind: &str,
+        resolution: Option<&str>,
+        response: Value,
+    ) -> Result<(), String> {
+        if let Some(codex) = self.codex.as_ref() {
+            codex
+                .validate_response(kind, request_id)
+                .map_err(|error| format!("[interaction:not_started] {error}"))?;
+        } else {
+            let pending = self
+                .pending_interactive_requests
+                .get(request_id)
+                .ok_or_else(|| {
+                    "[interaction:not_started] no pending interactive request".to_string()
+                })?;
+            if pending.kind != kind {
+                return Err(format!(
+                    "[interaction:not_started] unknown or mismatched interactive request_id {request_id}"
+                ));
+            }
+        }
+        self.persist_interaction_started(request_id, interaction_kind, resolution)
+            .map_err(|error| format!("[interaction:not_started] {error}"))?;
+        self.clear_pending_interactive_request(request_id);
+        let wire_result = self
+            .write_interactive_response(kind, request_id, response)
+            .await;
+        if let Err(error) = wire_result {
+            let durable_error =
+                self.persist_interaction_failed(request_id, interaction_kind, &error);
+            return Err(match durable_error {
+                Ok(()) => format!("[interaction:delivery_failed] {error}"),
+                Err(persist_error) => {
+                    format!(
+                        "[interaction:delivery_failed] {error}; failed to persist response failure: {persist_error}"
+                    )
+                }
+            });
+        }
+        self.persist_interaction_resolved(request_id, interaction_kind, resolution)
+            .map_err(|error| format!("[interaction:delivery_unknown] {error}"))
+    }
+
+    fn persist_interaction_started(
+        &self,
+        request_id: &str,
+        interaction_kind: &str,
+        resolution: Option<&str>,
+    ) -> Result<(), String> {
+        self.emitter
+            .persist_and_emit_durable(
+                &self.run_id,
+                &BusEvent::InteractionResponseStarted {
+                    run_id: self.run_id.clone(),
+                    request_id: request_id.to_string(),
+                    interaction_kind: interaction_kind.to_string(),
+                    resolution: resolution.map(str::to_owned),
+                },
+            )
+            .map(|_| ())
+    }
+
+    fn persist_interaction_failed(
+        &self,
+        request_id: &str,
+        interaction_kind: &str,
+        error: &str,
+    ) -> Result<(), String> {
+        self.emitter
+            .persist_and_emit_durable(
+                &self.run_id,
+                &BusEvent::InteractionResponseFailed {
+                    run_id: self.run_id.clone(),
+                    request_id: request_id.to_string(),
+                    interaction_kind: interaction_kind.to_string(),
+                    error: truncate_str(error, 512).to_string(),
+                },
+            )
+            .map(|_| ())
+    }
+
+    fn persist_interaction_resolved(
+        &self,
+        request_id: &str,
+        interaction_kind: &str,
+        resolution: Option<&str>,
+    ) -> Result<(), String> {
+        self.emitter
+            .persist_and_emit_durable(
+                &self.run_id,
+                &BusEvent::InteractionResolved {
+                    run_id: self.run_id.clone(),
+                    request_id: request_id.to_string(),
+                    interaction_kind: Some(interaction_kind.to_string()),
+                    resolution: resolution.map(str::to_owned),
+                },
+            )
+            .map(|_| ())
     }
 
     /// Write a response to a pending interactive request. Codex frames it as a JSON-RPC
@@ -1809,140 +1988,23 @@ impl SessionActor {
         request_id: &str,
         response: Value,
     ) -> Result<(), String> {
-        self.ensure_pending_interactive_request(request_id)?;
-        if self.codex.is_none() {
-            let delivery = self.write_control_response(request_id, response).await;
-            return Self::commit_actor_pending_after_delivery(
-                &mut self.pending_interactive_requests,
-                request_id,
-                delivery,
-            );
-        }
-
-        // Preparation keeps protocol state intact. This borrow must end before awaiting stdin.
-        let prepared = self
-            .codex
-            .as_mut()
-            .expect("codex checked above")
-            .frame_response(kind, request_id, response)?;
-        let delivery = self
-            .write_json_line(&prepared.primary, "codex interactive response")
-            .await;
-
-        // The primary JSON-RPC response resolves the request. Commit it before independent
-        // follow-up actions so an interrupt failure cannot make a delivered response retryable.
-        Self::commit_codex_pending_after_delivery(
-            self.codex.as_mut().expect("codex checked above"),
-            &mut self.pending_interactive_requests,
-            request_id,
-            delivery,
-        )?;
-        let follow_up = if prepared.interrupt_after_commit {
-            self.codex
-                .as_mut()
-                .expect("codex checked above")
-                .frame_interrupt()
-        } else {
-            Vec::new()
+        let Some(codex) = self.codex.as_mut() else {
+            return self.write_control_response(request_id, response).await;
         };
-        log::debug!(
-            "[actor] interactive response committed: run_id={}, req_id={}, follow_up={}",
-            self.run_id,
-            request_id,
-            follow_up.len()
-        );
-        for frame in &follow_up {
-            let delivery = self
-                .write_json_line(frame, "codex interactive response follow-up")
-                .await;
-            if let Some(error) = Self::committed_follow_up_warning(delivery) {
-                log::error!(
-                    "[actor] interactive follow-up failed after response commit: run_id={}, req_id={}, error={}",
-                    self.run_id,
-                    request_id,
-                    error
-                );
-                self.emitter.emit_realtime(
-                    "interactive-follow-up-warning",
-                    &serde_json::json!({
-                        "run_id": self.run_id,
-                        "request_id": request_id,
-                        "error": error,
-                    }),
-                    Some(&self.run_id),
-                );
-                break;
-            }
+        let lines = codex.frame_response(kind, request_id, response)?;
+        for line in &lines {
+            self.write_json_line(line, "codex interactive response")
+                .await?;
         }
         Ok(())
     }
 
-    fn committed_follow_up_warning(delivery: Result<(), String>) -> Option<String> {
-        // The primary response is already committed, so return a separate warning instead of
-        // making the frontend offer a response retry that Codex must reject.
-        delivery.err()
-    }
-
-    async fn respond_hook_callback(
-        &mut self,
-        request_id: &str,
-        response: Value,
-    ) -> Result<(), String> {
-        self.ensure_pending_interactive_request(request_id)?;
-        let delivery = self.write_control_response(request_id, response).await;
-        Self::commit_actor_pending_after_delivery(
+    /// Clear pending interactive request if it matches the given request_id.
+    fn clear_pending_interactive_request(&mut self, request_id: &str) {
+        Self::clear_pending_interactive_request_map(
             &mut self.pending_interactive_requests,
             request_id,
-            delivery,
-        )
-    }
-
-    fn ensure_pending_interactive_request(&self, request_id: &str) -> Result<(), String> {
-        if self.pending_interactive_requests.contains_key(request_id) {
-            Ok(())
-        } else {
-            Err(format!("unknown interactive request_id: {request_id}"))
-        }
-    }
-
-    fn commit_actor_pending_after_delivery(
-        pending: &mut HashMap<String, PendingInteractiveRequest>,
-        request_id: &str,
-        delivery: Result<(), String>,
-    ) -> Result<(), String> {
-        if let Err(error) = delivery {
-            log::error!(
-                "[actor] interactive response delivery failed; pending retained: request_id={}, error={}",
-                request_id,
-                error
-            );
-            return Err(error);
-        }
-        Self::clear_pending_interactive_request_map(pending, request_id);
-        Ok(())
-    }
-
-    fn commit_codex_pending_after_delivery(
-        codex: &mut CodexAppServer,
-        pending: &mut HashMap<String, PendingInteractiveRequest>,
-        request_id: &str,
-        delivery: Result<(), String>,
-    ) -> Result<(), String> {
-        if let Err(error) = delivery {
-            log::error!(
-                "[actor] codex interactive response delivery failed; pending retained: request_id={}, error={}",
-                request_id,
-                error
-            );
-            return Err(error);
-        }
-        if !codex.commit_response(request_id) {
-            return Err(format!(
-                "interactive request disappeared before commit: {request_id}"
-            ));
-        }
-        Self::clear_pending_interactive_request_map(pending, request_id);
-        Ok(())
+        );
     }
 
     fn clear_pending_interactive_request_map(
@@ -1961,50 +2023,56 @@ impl SessionActor {
         }
     }
 
-    /// Cancel an interactive request using the active transport's wire protocol.
+    /// Send a control_cancel_request to CLI stdin (top-level message type).
     /// Used only for explicit user-initiated cancellation (ActorCommand::CancelControlRequest,
     /// e.g. the user dismisses a permission prompt). NOT for auto-declining unsupported
     /// requests — those use write_control_response_error (the CLI waits for a response).
     async fn handle_cancel_control_request(&mut self, request_id: &str) -> Result<(), String> {
-        self.ensure_pending_interactive_request(request_id)?;
-        if self.codex.is_some() {
-            // Codex has no transport-level cancel notification for server requests. A JSON-RPC
-            // error resolves every interactive method without inventing a method-specific value.
-            let payload = self
-                .codex
-                .as_ref()
-                .expect("codex checked above")
-                .frame_cancel(request_id)?;
-            log::debug!(
-                "[actor] cancel_codex_interactive: run_id={}, req_id={}",
-                self.run_id,
-                request_id,
-            );
-            let delivery = self
-                .write_json_line(&payload, "cancel codex interactive request")
-                .await;
-            return Self::commit_codex_pending_after_delivery(
-                self.codex.as_mut().expect("codex checked above"),
-                &mut self.pending_interactive_requests,
-                request_id,
-                delivery,
-            );
-        }
-
-        let payload = build_control_cancel_request(request_id);
+        ensure_control_cancel_supported(self.codex.is_some())?;
+        let kind = self
+            .pending_interactive_requests
+            .get(request_id)
+            .map(|pending| pending.kind)
+            .ok_or_else(|| {
+                format!("[interaction:not_started] unknown interactive request_id {request_id}")
+            })?;
+        let interaction_kind = pending_kind_name(kind);
+        self.persist_interaction_started(request_id, interaction_kind, Some("cancel"))
+            .map_err(|error| format!("[interaction:not_started] {error}"))?;
+        let payload = serde_json::json!({
+            "type": "control_cancel_request",
+            "request_id": request_id,
+        });
         log::debug!(
             "[actor] cancel_control_request: run_id={}, req_id={}",
             self.run_id,
             request_id,
         );
-        let delivery = self
+        if let Err(error) = self
             .write_json_line(&payload, "cancel control request")
-            .await;
-        Self::commit_actor_pending_after_delivery(
-            &mut self.pending_interactive_requests,
-            request_id,
-            delivery,
-        )
+            .await
+        {
+            self.clear_pending_interactive_request(request_id);
+            let durable_error =
+                self.persist_interaction_failed(request_id, interaction_kind, &error);
+            return Err(match durable_error {
+                Ok(()) => format!("[interaction:delivery_failed] {error}"),
+                Err(persist_error) => format!(
+                    "[interaction:delivery_failed] {error}; failed to persist response failure: {persist_error}"
+                ),
+            });
+        }
+        self.clear_pending_interactive_request(request_id);
+        self.emitter
+            .persist_and_emit_durable(
+                &self.run_id,
+                &BusEvent::ControlCancelled {
+                    run_id: self.run_id.clone(),
+                    request_id: request_id.to_string(),
+                },
+            )
+            .map(|_| ())
+            .map_err(|error| format!("[interaction:delivery_unknown] {error}"))
     }
 
     /// Low-level helper: serialize JSON payload, write to stdin, flush.
@@ -2013,17 +2081,7 @@ impl SessionActor {
             .stdin
             .as_mut()
             .ok_or_else(|| "stdin closed".to_string())?;
-        let mut line = serde_json::to_string(payload).map_err(|e| e.to_string())?;
-        line.push('\n');
-        stdin
-            .write_all(line.as_bytes())
-            .await
-            .map_err(|e| format!("{} write failed: {}", context, e))?;
-        stdin
-            .flush()
-            .await
-            .map_err(|e| format!("{} flush failed: {}", context, e))?;
-        Ok(())
+        write_json_line_to(stdin, payload, context).await
     }
 
     /// Shared helper: write a success control_response JSON to CLI stdin.
@@ -2142,6 +2200,7 @@ impl SessionActor {
         for pi in parsed.interactive {
             let subtype = match pi.kind {
                 PendingKind::Permission => "can_use_tool",
+                PendingKind::Hook => "hook_callback",
                 PendingKind::Elicitation => "elicitation",
                 PendingKind::UserInput => "request_user_input",
             };
@@ -2149,6 +2208,7 @@ impl SessionActor {
                 pi.request_id.clone(),
                 PendingInteractiveRequest {
                     request_id: pi.request_id,
+                    kind: pi.kind,
                     subtype: subtype.to_string(),
                     detail: String::new(),
                     received_at: Instant::now(),
@@ -2654,6 +2714,7 @@ impl SessionActor {
                     request_id.clone(),
                     PendingInteractiveRequest {
                         request_id: request_id.clone(),
+                        kind: PendingKind::Hook,
                         subtype: "hook_callback".to_string(),
                         detail: format!("PreToolUse:{}", hook_label),
                         received_at: Instant::now(),
@@ -2735,6 +2796,7 @@ impl SessionActor {
                 request_id.clone(),
                 PendingInteractiveRequest {
                     request_id: request_id.clone(),
+                    kind: PendingKind::Elicitation,
                     subtype: "elicitation".to_string(),
                     detail: mcp_server_name.clone(),
                     received_at: Instant::now(),
@@ -2806,6 +2868,7 @@ impl SessionActor {
                 request_id.clone(),
                 PendingInteractiveRequest {
                     request_id,
+                    kind: PendingKind::Permission,
                     subtype: "can_use_tool".to_string(),
                     detail: tool_label.clone(),
                     received_at: Instant::now(),
@@ -3420,15 +3483,63 @@ pub fn build_user_payload(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_control_cancel_request, build_control_response, PendingInteractiveRequest,
-        SessionActor,
+        build_control_response, ensure_control_cancel_supported, pending_kind_name,
+        write_json_line_to, PendingInteractiveRequest, SessionActor,
     };
-    use crate::agent::codex_appserver::CodexAppServer;
-    use crate::agent::session_protocol::{PendingKind, SessionProtocol};
+    use crate::agent::session_protocol::PendingKind;
     use crate::models::{max_attachment_size, BusEvent, ALLOWED_DOC_TYPES, ALLOWED_IMAGE_TYPES};
     use serde_json::json;
     use std::collections::HashMap;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
     use std::time::{Duration, Instant};
+    use tokio::io::AsyncWrite;
+
+    struct FlushFailWriter(Vec<u8>);
+
+    impl AsyncWrite for FlushFailWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.0.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "flush rejected",
+            )))
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[tokio::test]
+    async fn json_line_flush_failure_is_not_reported_as_success() {
+        let mut writer = FlushFailWriter(Vec::new());
+        let error = write_json_line_to(&mut writer, &json!({"type":"response"}), "response")
+            .await
+            .unwrap_err();
+        assert!(error.contains("response flush failed"));
+        assert!(writer.0.ends_with(b"\n"));
+    }
+
+    #[test]
+    fn control_cancel_rejects_codex_before_wire_delivery() {
+        let error = ensure_control_cancel_supported(true).unwrap_err();
+        assert!(error.contains("[interaction:not_started]"));
+        assert!(error.contains("unsupported for Codex"));
+        assert!(ensure_control_cancel_supported(false).is_ok());
+        assert_eq!(pending_kind_name(PendingKind::Permission), "permission");
+        assert_eq!(pending_kind_name(PendingKind::Hook), "hook");
+        assert_eq!(pending_kind_name(PendingKind::Elicitation), "elicitation");
+        assert_eq!(pending_kind_name(PendingKind::UserInput), "user_input");
+    }
 
     /// Helper: build a multimodal content array the same way handle_send_message does,
     /// including size validation (base64 len * 3/4 vs max_attachment_size).
@@ -3505,14 +3616,6 @@ mod tests {
     }
 
     #[test]
-    fn claude_control_cancel_request_shape() {
-        let payload = build_control_cancel_request("r3");
-        assert_eq!(payload["type"], "control_cancel_request");
-        assert_eq!(payload["request_id"], "r3");
-        assert_eq!(payload.as_object().map(serde_json::Map::len), Some(2));
-    }
-
-    #[test]
     fn pending_interactive_requests_clear_independently() {
         let now = Instant::now();
         let mut pending = HashMap::from([
@@ -3520,6 +3623,7 @@ mod tests {
                 "first".to_string(),
                 PendingInteractiveRequest {
                     request_id: "first".to_string(),
+                    kind: PendingKind::Permission,
                     subtype: "can_use_tool".to_string(),
                     detail: "Bash".to_string(),
                     received_at: now - Duration::from_secs(2),
@@ -3529,6 +3633,7 @@ mod tests {
                 "second".to_string(),
                 PendingInteractiveRequest {
                     request_id: "second".to_string(),
+                    kind: PendingKind::UserInput,
                     subtype: "request_user_input".to_string(),
                     detail: String::new(),
                     received_at: now,
@@ -3543,148 +3648,42 @@ mod tests {
     }
 
     #[test]
-    fn failed_codex_delivery_retains_both_pending_layers_for_retry() {
-        let mut codex = CodexAppServer::new();
-        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
-        codex.parse_line(
-            "run1",
-            r#"{"id":21,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-        let mut pending = HashMap::from([(
-            "21".to_string(),
-            PendingInteractiveRequest {
-                request_id: "21".to_string(),
-                subtype: "elicitation".to_string(),
-                detail: "srv".to_string(),
-                received_at: Instant::now(),
-            },
-        )]);
-
-        let result = SessionActor::commit_codex_pending_after_delivery(
-            &mut codex,
-            &mut pending,
-            "21",
-            Err("stdin closed".to_string()),
-        );
-        assert_eq!(result.unwrap_err(), "stdin closed");
-        assert!(pending.contains_key("21"));
-        assert!(codex
-            .frame_response(PendingKind::Elicitation, "21", json!({"action":"decline"}),)
-            .is_ok());
-    }
-
-    #[test]
-    fn successful_codex_delivery_commits_both_pending_layers() {
-        let mut codex = CodexAppServer::new();
-        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
-        codex.parse_line(
-            "run1",
-            r#"{"id":22,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-        let mut pending = HashMap::from([(
-            "22".to_string(),
-            PendingInteractiveRequest {
-                request_id: "22".to_string(),
-                subtype: "elicitation".to_string(),
-                detail: "srv".to_string(),
-                received_at: Instant::now(),
-            },
-        )]);
-
-        SessionActor::commit_codex_pending_after_delivery(&mut codex, &mut pending, "22", Ok(()))
-            .unwrap();
-        assert!(!pending.contains_key("22"));
-        assert!(codex
-            .frame_response(PendingKind::Elicitation, "22", json!({"action":"decline"}),)
-            .is_err());
-    }
-
-    #[test]
-    fn failed_codex_cancel_delivery_retains_both_pending_layers_for_retry() {
-        let mut codex = CodexAppServer::new();
-        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
-        codex.parse_line(
-            "run1",
-            r#"{"id":23,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-        let mut pending = HashMap::from([(
-            "23".to_string(),
-            PendingInteractiveRequest {
-                request_id: "23".to_string(),
-                subtype: "elicitation".to_string(),
-                detail: "srv".to_string(),
-                received_at: Instant::now(),
-            },
-        )]);
-
-        assert!(codex.frame_cancel("23").is_ok());
-        let result = SessionActor::commit_codex_pending_after_delivery(
-            &mut codex,
-            &mut pending,
-            "23",
-            Err("stdin closed".to_string()),
-        );
-        assert_eq!(result.unwrap_err(), "stdin closed");
-        assert!(pending.contains_key("23"));
-        assert!(codex.frame_cancel("23").is_ok());
-    }
-
-    #[test]
-    fn successful_codex_cancel_delivery_commits_both_pending_layers() {
-        let mut codex = CodexAppServer::new();
-        codex.parse_line("run1", r#"{"id":2,"result":{"thread":{"id":"th-123"}}}"#);
-        codex.parse_line(
-            "run1",
-            r#"{"id":24,"method":"mcpServer/elicitation/request","params":{"threadId":"th-123","serverName":"srv","message":"Pick"}}"#,
-        );
-        let mut pending = HashMap::from([(
-            "24".to_string(),
-            PendingInteractiveRequest {
-                request_id: "24".to_string(),
-                subtype: "elicitation".to_string(),
-                detail: "srv".to_string(),
-                received_at: Instant::now(),
-            },
-        )]);
-
-        SessionActor::commit_codex_pending_after_delivery(&mut codex, &mut pending, "24", Ok(()))
-            .unwrap();
-        assert!(!pending.contains_key("24"));
-        assert!(codex.frame_cancel("24").is_err());
-    }
-
-    #[test]
-    fn committed_response_does_not_make_failed_follow_up_retryable() {
-        assert_eq!(
-            SessionActor::committed_follow_up_warning(Err("stdin closed".to_string())),
-            Some("stdin closed".to_string())
-        );
-        assert_eq!(SessionActor::committed_follow_up_warning(Ok(())), None);
-    }
-
-    #[test]
-    fn failed_claude_delivery_retains_actor_pending_for_retry() {
-        let mut pending = HashMap::from([(
-            "claude-1".to_string(),
-            PendingInteractiveRequest {
-                request_id: "claude-1".to_string(),
-                subtype: "can_use_tool".to_string(),
-                detail: "Bash".to_string(),
-                received_at: Instant::now(),
-            },
-        )]);
-
-        let result = SessionActor::commit_actor_pending_after_delivery(
-            &mut pending,
-            "claude-1",
-            Err("stdin closed".to_string()),
-        );
-        assert_eq!(result.unwrap_err(), "stdin closed");
-        assert!(pending.contains_key("claude-1"));
-
-        SessionActor::commit_actor_pending_after_delivery(&mut pending, "claude-1", Ok(()))
-            .unwrap();
-        assert!(!pending.contains_key("claude-1"));
+    fn interaction_response_events_use_contract_tags() {
+        let events = [
+            (
+                BusEvent::InteractionResponseStarted {
+                    run_id: "run-1".to_string(),
+                    request_id: "request-1".to_string(),
+                    interaction_kind: "permission".to_string(),
+                    resolution: Some("allow".to_string()),
+                },
+                "interaction_response_started",
+            ),
+            (
+                BusEvent::InteractionResponseFailed {
+                    run_id: "run-1".to_string(),
+                    request_id: "request-1".to_string(),
+                    interaction_kind: "permission".to_string(),
+                    error: "closed".to_string(),
+                },
+                "interaction_response_failed",
+            ),
+            (
+                BusEvent::InteractionResolved {
+                    run_id: "run-1".to_string(),
+                    request_id: "request-1".to_string(),
+                    interaction_kind: Some("permission".to_string()),
+                    resolution: Some("allow".to_string()),
+                },
+                "interaction_resolved",
+            ),
+        ];
+        for (event, expected) in events {
+            let value = serde_json::to_value(&event).unwrap();
+            assert_eq!(value["type"], expected);
+            assert!(crate::storage::events::is_replayable(&event));
+            assert!(crate::agent::claude_protocol::validate_bus_event(&event).is_none());
+        }
     }
 
     #[test]

--- a/src-tauri/src/agent/session_protocol.rs
+++ b/src-tauri/src/agent/session_protocol.rs
@@ -65,6 +65,8 @@ pub struct CodexSkillRef {
 pub enum PendingKind {
     /// Command / file / permission approval → `respond_permission`.
     Permission,
+    /// Claude hook callback approval. Codex does not currently emit this request kind.
+    Hook,
     /// MCP elicitation → `respond_elicitation`.
     Elicitation,
     /// Multiple-choice `request_user_input` → `respond_user_input`.
@@ -78,14 +80,6 @@ pub enum PendingKind {
 pub struct PendingInteractive {
     pub request_id: String,
     pub kind: PendingKind,
-}
-
-/// A prepared response to a server-initiated interactive request. The primary response resolves
-/// the pending request; an optional interrupt is generated only after that response is committed.
-#[derive(Debug)]
-pub struct InteractiveResponse {
-    pub primary: Value,
-    pub interrupt_after_commit: bool,
 }
 
 /// Turn-boundary signal extracted from a wire line, mapped by the actor to `RunState` and
@@ -115,8 +109,10 @@ pub struct ParsedLine {
     /// where `request_id` is the frontend control request id and `value` is the JSON-RPC
     /// `result` (or `error`). The actor routes it to the matching `control_waiter`.
     pub control_response: Option<(String, Value)>,
-    /// JSON-RPC frames the protocol must send immediately without waiting for frontend input.
-    /// Codex uses this for autonomous metadata reads such as spawned-thread identity lookup.
+    /// Wire frames the transport wants written back to the child immediately, without a user
+    /// in the loop — e.g. a JSON-RPC error reply to an unknown server-request, or
+    /// an autonomous `thread/read`. The actor flushes these to stdin after parse_line. The
+    /// Claude transport never sets this.
     pub outbound: Vec<Value>,
 }
 
@@ -124,7 +120,7 @@ pub struct ParsedLine {
 /// four seams: spawn (startup), user message (frame_user_turn), each stdout line
 /// (parse_line), and each interactive response (frame_response) / stop (frame_interrupt).
 ///
-/// Each `frame_*` prepares JSON values to write as newline-delimited lines to stdin.
+/// Each `frame_*` returns the JSON value(s) to write as newline-delimited lines to stdin.
 pub trait SessionProtocol: Send {
     /// Messages to send immediately after spawn, before the first user turn
     /// (e.g. Codex `initialize` + `thread/start`|`thread/resume`).
@@ -153,19 +149,16 @@ pub trait SessionProtocol: Send {
     /// Parse one stdout line into events + lifecycle/interactive/thread-id signals.
     fn parse_line(&mut self, run_id: &str, line: &str) -> ParsedLine;
 
-    /// Prepare the user's response to a pending interactive request without consuming it.
-    /// The actor commits the request only after the primary frame is written and flushed.
+    /// Frame the user's response to a pending interactive request. Unknown or mismatched
+    /// request ids are errors, never empty success.
     fn frame_response(
-        &self,
+        &mut self,
         kind: PendingKind,
         request_id: &str,
         response: Value,
-    ) -> Result<InteractiveResponse, String>;
+    ) -> Result<Vec<Value>, String>;
 
-    /// Prepare cancellation of a pending interactive request without consuming it.
-    /// The actor commits the request only after the cancellation frame is written and flushed.
-    fn frame_cancel(&self, request_id: &str) -> Result<Value, String>;
-
-    /// Consume a response prepared by [`SessionProtocol::frame_response`] after delivery.
-    fn commit_response(&mut self, request_id: &str) -> bool;
+    /// Validate an interactive response without consuming its pending request. The actor calls
+    /// this before persisting durable intent so a persistence failure remains safely retryable.
+    fn validate_response(&self, kind: PendingKind, request_id: &str) -> Result<(), String>;
 }

--- a/src-tauri/src/commands/history_pages.rs
+++ b/src-tauri/src/commands/history_pages.rs
@@ -1,0 +1,87 @@
+use crate::storage::{self, history};
+
+#[tauri::command]
+pub async fn get_history_summary(
+    run_id: String,
+    refresh: Option<bool>,
+) -> Result<history::HistorySummary, String> {
+    storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {run_id} not found"))?;
+    let refresh = refresh.unwrap_or(false);
+    log::debug!(
+        "[history] get_summary: run_id={}, refresh={}",
+        run_id,
+        refresh
+    );
+    tokio::task::spawn_blocking(move || history::get_summary(&run_id, refresh))
+        .await
+        .map_err(|e| format!("history build task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn get_history_page(
+    run_id: String,
+    generation_id: Option<String>,
+    before_cursor: Option<String>,
+) -> Result<history::HistoryPage, String> {
+    storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {run_id} not found"))?;
+    log::debug!(
+        "[history] get_page: run_id={}, before_cursor={:?}",
+        run_id,
+        before_cursor
+    );
+    tokio::task::spawn_blocking(move || {
+        history::get_page(&run_id, generation_id.as_deref(), before_cursor.as_deref())
+    })
+    .await
+    .map_err(|e| format!("history page task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn get_history_content_chunk(
+    run_id: String,
+    generation_id: String,
+    content_id: String,
+    offset: u64,
+    max_bytes: usize,
+) -> Result<history::ContentChunk, String> {
+    storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {run_id} not found"))?;
+    log::debug!(
+        "[history] get_content_chunk: run_id={}, generation={}, content={}, offset={}, max_bytes={}",
+        run_id,
+        generation_id,
+        content_id,
+        offset,
+        max_bytes
+    );
+    tokio::task::spawn_blocking(move || {
+        history::get_content_chunk(&run_id, &generation_id, &content_id, offset, max_bytes)
+    })
+    .await
+    .map_err(|e| format!("history content task failed: {e}"))?
+}
+
+#[tauri::command]
+pub async fn get_subhistory_page(
+    run_id: String,
+    generation_id: String,
+    sub_history_id: String,
+    before_cursor: Option<String>,
+) -> Result<history::SubHistoryPage, String> {
+    storage::runs::get_run(&run_id).ok_or_else(|| format!("Run {run_id} not found"))?;
+    log::debug!(
+        "[history] get_subhistory_page: run_id={}, generation={}, subhistory={}",
+        run_id,
+        generation_id,
+        sub_history_id
+    );
+    tokio::task::spawn_blocking(move || {
+        history::get_subhistory_page(
+            &run_id,
+            &generation_id,
+            &sub_history_id,
+            before_cursor.as_deref(),
+        )
+    })
+    .await
+    .map_err(|e| format!("subhistory page task failed: {e}"))?
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ pub mod files;
 pub mod fs;
 pub mod git;
 pub mod history;
+pub mod history_pages;
 pub mod mcp;
 pub mod onboarding;
 pub mod plugins;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1048,6 +1048,16 @@ pub fn get_bus_events(
     Ok(storage::events::list_bus_events(&id, since_seq))
 }
 
+#[tauri::command]
+pub fn get_bus_events_page(
+    id: String,
+    since_seq: u64,
+    offset: Option<u64>,
+) -> Result<storage::events::BusEventPage, String> {
+    storage::runs::get_run(&id).ok_or_else(|| format!("Run {} not found", id))?;
+    storage::events::list_bus_events_page(&id, since_seq, offset)
+}
+
 pub(crate) async fn fork_session_impl(
     emitter: &Arc<BroadcastEmitter>,
     sessions: &ActorSessionMap,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,6 +79,14 @@ pub fn run() {
 
     log::info!("OpenCovibe Desktop starting");
 
+    // All storage modules use process-local writer locks. Hold the OS lock before any startup
+    // reconciliation touches data so a second backend cannot allocate duplicate event sequences
+    // or clean a history generation that this process is serving.
+    let data_dir_lock = storage::DataDirLock::acquire().unwrap_or_else(|error| {
+        log::error!("[app] data writer lock failed: {error}");
+        panic!("{error}");
+    });
+
     // Set up Windows Job Object so child processes are killed on crash/force-quit.
     // No-op on non-Windows.
     process_ext::setup_job_kill_on_close();
@@ -131,6 +139,7 @@ pub fn run() {
         .manage(crate::storage::events::global_writer())
         .manage(SpawnLocks::new())
         .manage(ShutdownGate::new())
+        .manage(data_dir_lock)
         .manage(cancel_token)
         .manage(ws_shutdown_sender)
         .manage(shared_token_version)
@@ -207,6 +216,11 @@ pub fn run() {
             commands::session::send_session_control,
             commands::session::broadcast_mcp_toggle,
             commands::session::get_bus_events,
+            commands::session::get_bus_events_page,
+            commands::history_pages::get_history_summary,
+            commands::history_pages::get_history_page,
+            commands::history_pages::get_history_content_chunk,
+            commands::history_pages::get_subhistory_page,
             commands::session::fork_session,
             commands::session::side_question,
             commands::session::start_ralph_loop,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1447,6 +1447,32 @@ pub enum BusEvent {
     },
     /// CLI cancelled a pending control_request (e.g. cancelled permission prompt).
     ControlCancelled { run_id: String, request_id: String },
+    /// Durable intent written before an interactive response is sent to the CLI.
+    /// Recovery treats this as non-retryable because a process can die after the wire write.
+    InteractionResponseStarted {
+        run_id: String,
+        request_id: String,
+        interaction_kind: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        resolution: Option<String>,
+    },
+    /// The CLI response write failed after its durable intent was recorded.
+    InteractionResponseFailed {
+        run_id: String,
+        request_id: String,
+        interaction_kind: String,
+        error: String,
+    },
+    /// The app successfully delivered a response for an interactive control request.
+    /// Persisted separately from cancellation so history rebuilds do not restore answered cards.
+    InteractionResolved {
+        run_id: String,
+        request_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        interaction_kind: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        resolution: Option<String>,
+    },
     /// Output from a CLI slash command (e.g. /context, /cost).
     /// Extracted from `<local-command-stdout>` tags in user messages.
     CommandOutput { run_id: String, content: String },

--- a/src-tauri/src/storage/events.rs
+++ b/src-tauri/src/storage/events.rs
@@ -2,7 +2,7 @@ use crate::models::{now_iso, BusEvent, ModelUsageSummary, RawRunUsage, RunEvent,
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
-use std::io::{BufReader, Read, Seek, SeekFrom, Write};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 
 /// Event types the frontend reducer actually handles during replay.
 /// "raw" events (CLI stream data) are 90%+ of the file but the frontend drops them,
@@ -26,6 +26,9 @@ pub const REPLAY_TYPES: &[&str] = &[
     "hook_started",
     "hook_response",
     "control_cancelled",
+    "interaction_response_started",
+    "interaction_response_failed",
+    "interaction_resolved",
     "task_notification",
     "tool_progress",
     "tool_use_summary",
@@ -36,6 +39,8 @@ pub const REPLAY_TYPES: &[&str] = &[
     "elicitation_prompt",
     "rate_limit_event",
     "codex_hook_run",
+    // Replayed so a loaded run (e.g. the /agents Active scope) can label Codex sub-agent nodes
+    // with their resolved nickname/role instead of a raw thread id.
     "codex_agent_info",
 ];
 
@@ -156,11 +161,130 @@ pub fn list_events(run_id: &str, since_seq: u64) -> Vec<RunEvent> {
 
 use std::sync::{Arc, Mutex};
 
+const BUS_EVENT_PAGE_ENTRY_LIMIT: usize = 100;
+const BUS_EVENT_PAGE_BYTE_LIMIT: usize = 1024 * 1024;
+const BUS_EVENT_LINE_LIMIT: usize = 2 * 1024 * 1024;
+pub const HISTORY_PROJECTION_REQUIRED: &str = "HISTORY_PROJECTION_REQUIRED";
+
+fn history_projection_required(detail: impl std::fmt::Display) -> String {
+    format!("{HISTORY_PROJECTION_REQUIRED}: {detail}")
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BusEventPage {
+    pub events: Vec<serde_json::Value>,
+    pub last_seq: u64,
+    pub has_more: bool,
+    pub next_offset: u64,
+}
+
 /// Atomic seq allocation + file write under per-run locks.
 /// Each run_id gets its own Mutex so different runs never block each other.
 /// The outer Mutex is only held briefly to get/create the per-run Arc.
 pub struct EventWriter {
-    inner: Mutex<HashMap<String, Arc<Mutex<u64>>>>, // run_id → Arc<Mutex<next_seq>>
+    inner: Mutex<HashMap<String, Arc<Mutex<RunWriterState>>>>,
+}
+
+struct RunWriterState {
+    next_seq: u64,
+    tail_repaired: bool,
+}
+
+pub(crate) struct EventLogSnapshot {
+    pub file: fs::File,
+    pub metadata: fs::Metadata,
+}
+
+fn repair_incomplete_tail(path: &std::path::Path) -> Result<u64, String> {
+    if let Some(parent) = path.parent() {
+        super::ensure_dir(parent).map_err(|e| {
+            format!(
+                "create event log directory {} failed: {e}",
+                parent.display()
+            )
+        })?;
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .map_err(|e| format!("open {} failed: {e}", path.display()))?;
+    let len = file.metadata().map_err(|e| e.to_string())?.len();
+    if len == 0 {
+        return Ok(0);
+    }
+    file.seek(SeekFrom::End(-1)).map_err(|e| e.to_string())?;
+    let mut last = [0u8; 1];
+    file.read_exact(&mut last).map_err(|e| e.to_string())?;
+    if last[0] == b'\n' {
+        return Ok(len);
+    }
+
+    let mut cursor = len;
+    let mut buffer = vec![0u8; 64 * 1024];
+    let line_start = loop {
+        let start = cursor.saturating_sub(buffer.len() as u64);
+        let count = (cursor - start) as usize;
+        file.seek(SeekFrom::Start(start))
+            .map_err(|e| e.to_string())?;
+        file.read_exact(&mut buffer[..count])
+            .map_err(|e| e.to_string())?;
+        if let Some(index) = buffer[..count].iter().rposition(|byte| *byte == b'\n') {
+            break start + index as u64 + 1;
+        }
+        if start == 0 {
+            break 0;
+        }
+        cursor = start;
+    };
+    file.seek(SeekFrom::Start(line_start))
+        .map_err(|e| e.to_string())?;
+    let mut deserializer =
+        serde_json::Deserializer::from_reader(BufReader::new((&mut file).take(len - line_start)));
+    let complete_json =
+        <serde::de::IgnoredAny as serde::Deserialize>::deserialize(&mut deserializer)
+            .and_then(|_| deserializer.end())
+            .is_ok();
+    if complete_json {
+        file.seek(SeekFrom::End(0)).map_err(|e| e.to_string())?;
+        file.write_all(b"\n").map_err(|e| {
+            format!(
+                "commit final event newline in {} failed: {e}",
+                path.display()
+            )
+        })?;
+        log::debug!(
+            "[storage/events] normalized complete final event: path={}",
+            path.display()
+        );
+        return Ok(len + 1);
+    }
+
+    file.set_len(line_start).map_err(|e| {
+        format!(
+            "truncate incomplete event tail in {} failed: {e}",
+            path.display()
+        )
+    })?;
+    log::warn!(
+        "[storage/events] repaired incomplete tail: path={}, removed_bytes={}",
+        path.display(),
+        len - line_start
+    );
+    Ok(line_start)
+}
+
+fn capture_event_log_snapshot(path: &std::path::Path) -> Result<EventLogSnapshot, String> {
+    repair_incomplete_tail(path)?;
+    let file = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .map_err(|e| format!("open {} failed: {e}", path.display()))?;
+    let metadata = file.metadata().map_err(|e| e.to_string())?;
+    Ok(EventLogSnapshot { file, metadata })
 }
 
 impl Default for EventWriter {
@@ -176,28 +300,58 @@ impl EventWriter {
         }
     }
 
+    fn run_lock(&self, run_id: &str) -> Arc<Mutex<RunWriterState>> {
+        let mut map = self.inner.lock().unwrap();
+        if map.len() > 50 {
+            map.retain(|_, value| Arc::strong_count(value) > 1);
+        }
+        map.entry(run_id.to_string())
+            .or_insert_with(|| {
+                Arc::new(Mutex::new(RunWriterState {
+                    next_seq: next_seq(run_id),
+                    tail_repaired: false,
+                }))
+            })
+            .clone()
+    }
+
+    fn ensure_tail_repaired(run_id: &str, state: &mut RunWriterState) -> Result<(), String> {
+        if state.tail_repaired {
+            return Ok(());
+        }
+        repair_incomplete_tail(&events_path(run_id))?;
+        // Repair can remove the only occurrence of the highest sequence when it was part of the
+        // interrupted record, so seed again from the committed file before allocating a value.
+        state.next_seq = next_seq(run_id);
+        state.tail_repaired = true;
+        Ok(())
+    }
+
+    /// Capture a fixed prefix that ends after a complete JSONL record. Appends may resume as soon
+    /// as this method returns; the cloned file handle and length keep the history scan bounded.
+    pub(crate) fn snapshot(&self, run_id: &str) -> Result<EventLogSnapshot, String> {
+        let run_lock = self.run_lock(run_id);
+        let mut state = run_lock.lock().unwrap();
+        let dir = super::run_dir(run_id);
+        super::ensure_dir(&dir).map_err(|e| format!("ensure_dir failed: {e}"))?;
+        let path = events_path(run_id);
+        Self::ensure_tail_repaired(run_id, &mut state)?;
+        capture_event_log_snapshot(&path)
+    }
+
     /// Atomically assign seq + write to events.jsonl (both under the same per-run lock).
     /// Returns `Err` if any step fails (dir creation, serialization, file I/O).
     pub fn write_bus_event(&self, run_id: &str, event: &BusEvent) -> Result<(), String> {
         log::trace!("[storage/events] write_bus_event: run_id={}", run_id);
 
         // Get or create the per-run lock (brief global lock, then release)
-        let run_lock = {
-            let mut map = self.inner.lock().unwrap();
-            // GC: drop entries whose per-run Arc has no other holders (session ended)
-            if map.len() > 50 {
-                map.retain(|_, v| Arc::strong_count(v) > 1);
-            }
-            map.entry(run_id.to_string())
-                .or_insert_with(|| Arc::new(Mutex::new(next_seq(run_id))))
-                .clone()
-        };
+        let run_lock = self.run_lock(run_id);
         // Global lock released here — other runs proceed in parallel
 
         // Per-run lock: seq allocation + file write are atomic
-        let mut seq_guard = run_lock.lock().unwrap();
-        let current = *seq_guard;
-        *seq_guard = current + 1;
+        let mut state = run_lock.lock().unwrap();
+        Self::ensure_tail_repaired(run_id, &mut state)?;
+        let current = state.next_seq;
 
         let dir = super::run_dir(run_id);
         super::ensure_dir(&dir).map_err(|e| format!("ensure_dir failed: {}", e))?;
@@ -216,8 +370,11 @@ impl EventWriter {
             .append(true)
             .open(&path)
             .map_err(|e| format!("open {} failed: {}", path.display(), e))?;
-        writeln!(file, "{}", line)
-            .map_err(|e| format!("write to {} failed: {}", path.display(), e))?;
+        if let Err(error) = writeln!(file, "{}", line) {
+            state.tail_repaired = false;
+            return Err(format!("write to {} failed: {}", path.display(), error));
+        }
+        state.next_seq = current + 1;
 
         Ok(())
     }
@@ -235,19 +392,11 @@ impl EventWriter {
             ts
         );
 
-        let run_lock = {
-            let mut map = self.inner.lock().unwrap();
-            if map.len() > 50 {
-                map.retain(|_, v| Arc::strong_count(v) > 1);
-            }
-            map.entry(run_id.to_string())
-                .or_insert_with(|| Arc::new(Mutex::new(next_seq(run_id))))
-                .clone()
-        };
+        let run_lock = self.run_lock(run_id);
 
-        let mut seq_guard = run_lock.lock().unwrap();
-        let current = *seq_guard;
-        *seq_guard = current + 1;
+        let mut state = run_lock.lock().unwrap();
+        Self::ensure_tail_repaired(run_id, &mut state)?;
+        let current = state.next_seq;
 
         let dir = super::run_dir(run_id);
         super::ensure_dir(&dir).map_err(|e| format!("ensure_dir failed: {}", e))?;
@@ -266,8 +415,11 @@ impl EventWriter {
             .append(true)
             .open(&path)
             .map_err(|e| format!("open {} failed: {}", path.display(), e))?;
-        writeln!(file, "{}", line)
-            .map_err(|e| format!("write to {} failed: {}", path.display(), e))?;
+        if let Err(error) = writeln!(file, "{}", line) {
+            state.tail_repaired = false;
+            return Err(format!("write to {} failed: {}", path.display(), error));
+        }
+        state.next_seq = current + 1;
 
         Ok(current)
     }
@@ -281,19 +433,11 @@ impl EventWriter {
         event_type: RunEventType,
         payload: serde_json::Value,
     ) -> Result<RunEvent, String> {
-        let run_lock = {
-            let mut map = self.inner.lock().unwrap();
-            if map.len() > 50 {
-                map.retain(|_, v| Arc::strong_count(v) > 1);
-            }
-            map.entry(run_id.to_string())
-                .or_insert_with(|| Arc::new(Mutex::new(next_seq(run_id))))
-                .clone()
-        };
+        let run_lock = self.run_lock(run_id);
 
-        let mut seq_guard = run_lock.lock().unwrap();
-        let current = *seq_guard;
-        *seq_guard = current + 1;
+        let mut state = run_lock.lock().unwrap();
+        Self::ensure_tail_repaired(run_id, &mut state)?;
+        let current = state.next_seq;
 
         let dir = super::run_dir(run_id);
         super::ensure_dir(&dir).map_err(|e| e.to_string())?;
@@ -313,9 +457,41 @@ impl EventWriter {
             .append(true)
             .open(&path)
             .map_err(|e| e.to_string())?;
-        writeln!(file, "{}", line).map_err(|e| e.to_string())?;
+        if let Err(error) = writeln!(file, "{}", line) {
+            state.tail_repaired = false;
+            return Err(error.to_string());
+        }
+        state.next_seq = current + 1;
 
         Ok(event)
+    }
+
+    /// Copy a fork's replayable conversation from a committed source prefix while holding the
+    /// target run lock for publication. The source actor may continue appending after snapshot.
+    pub fn copy_bus_events(&self, from_run_id: &str, to_run_id: &str) -> Result<(), String> {
+        let snapshot = self.snapshot(from_run_id)?;
+        let source = BufReader::new(snapshot.file.take(snapshot.metadata.len()));
+
+        let target_lock = self.run_lock(to_run_id);
+        let mut target_state = target_lock.lock().unwrap();
+        target_state.tail_repaired = false;
+        let dst_dir = super::run_dir(to_run_id);
+        super::ensure_dir(&dst_dir).map_err(|e| format!("ensure_dir failed: {e}"))?;
+        let dst = events_path(to_run_id);
+        let target =
+            fs::File::create(&dst).map_err(|e| format!("create fork events failed: {e}"))?;
+        let (copied, skipped) = copy_bus_events_from_reader(source, target, to_run_id)?;
+        target_state.next_seq = copied + 1;
+        target_state.tail_repaired = true;
+        log::debug!(
+            "[storage/events] copy_bus_events: {} → {} (copied {} content events, skipped {} lifecycle, new max_seq={})",
+            from_run_id,
+            to_run_id,
+            copied,
+            skipped,
+            copied
+        );
+        Ok(())
     }
 }
 
@@ -347,21 +523,14 @@ pub fn persist_bus_event(
 /// Copied events get their `run_id` rewritten to `to_run_id` and `seq` renumbered
 /// from 1 so the fork run's events.jsonl is fully self-consistent.
 pub fn copy_bus_events(from_run_id: &str, to_run_id: &str) -> Result<(), String> {
-    let src = events_path(from_run_id);
-    if !src.exists() {
-        log::debug!(
-            "[storage/events] copy_bus_events: source {} has no events",
-            from_run_id
-        );
-        return Ok(());
-    }
-    let dst_dir = super::run_dir(to_run_id);
-    super::ensure_dir(&dst_dir).map_err(|e| format!("ensure_dir failed: {}", e))?;
-    let dst = events_path(to_run_id);
+    EVENT_WRITER.copy_bus_events(from_run_id, to_run_id)
+}
 
-    let content =
-        fs::read_to_string(&src).map_err(|e| format!("read source events failed: {}", e))?;
-
+fn copy_bus_events_from_reader<R: BufRead, W: Write>(
+    source: R,
+    target: W,
+    to_run_id: &str,
+) -> Result<(u64, u64), String> {
     // Content event types to copy (conversation history).
     const CONTENT_TYPES: &[&str] = &[
         "message_delta",
@@ -371,15 +540,16 @@ pub fn copy_bus_events(from_run_id: &str, to_run_id: &str) -> Result<(), String>
         "user_message",
     ];
 
-    let mut out = String::new();
+    let mut output = std::io::BufWriter::new(target);
     let mut copied = 0u64;
     let mut skipped = 0u64;
 
-    for line in content.lines() {
+    for line in source.lines() {
+        let line = line.map_err(|e| format!("read source events failed: {e}"))?;
         if line.trim().is_empty() {
             continue;
         }
-        let Ok(mut envelope) = serde_json::from_str::<serde_json::Value>(line) else {
+        let Ok(mut envelope) = serde_json::from_str::<serde_json::Value>(&line) else {
             continue;
         };
 
@@ -408,21 +578,20 @@ pub fn copy_bus_events(from_run_id: &str, to_run_id: &str) -> Result<(), String>
             copied += 1;
             envelope["seq"] = serde_json::Value::Number(copied.into());
 
-            let serialized =
-                serde_json::to_string(&envelope).map_err(|e| format!("serialize failed: {}", e))?;
-            out.push_str(&serialized);
-            out.push('\n');
+            serde_json::to_writer(&mut output, &envelope)
+                .map_err(|e| format!("serialize failed: {e}"))?;
+            output
+                .write_all(b"\n")
+                .map_err(|e| format!("write fork events failed: {e}"))?;
         } else {
             skipped += 1;
         }
     }
 
-    fs::write(&dst, &out).map_err(|e| format!("write fork events failed: {}", e))?;
-    log::debug!(
-        "[storage/events] copy_bus_events: {} → {} (copied {} content events, skipped {} lifecycle, new max_seq={})",
-        from_run_id, to_run_id, copied, skipped, copied
-    );
-    Ok(())
+    output
+        .flush()
+        .map_err(|e| format!("write fork events failed: {e}"))?;
+    Ok((copied, skipped))
 }
 
 /// Extract aggregated usage from bus-events for a single run.
@@ -706,18 +875,19 @@ pub fn list_bus_events(run_id: &str, since_seq: Option<u64>) -> Vec<serde_json::
     if !path.exists() {
         return vec![];
     }
-    let content = match fs::read_to_string(&path) {
-        Ok(c) => c,
+    let file = match fs::File::open(&path) {
+        Ok(file) => file,
         Err(_) => return vec![],
     };
 
     let min_seq = since_seq.unwrap_or(0);
-
-    content
+    let reader = BufReader::new(file);
+    reader
         .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter_map(|l| {
-            let v: serde_json::Value = serde_json::from_str(l).ok()?;
+        .map_while(Result::ok)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let v: serde_json::Value = serde_json::from_str(&line).ok()?;
             // Only process bus events
             if v.get("_bus")?.as_bool()? {
                 let seq = v.get("seq")?.as_u64()?;
@@ -745,10 +915,195 @@ pub fn list_bus_events(run_id: &str, since_seq: Option<u64>) -> Vec<serde_json::
         .collect()
 }
 
+/// Return a replay page whose encoded event payload stays bounded. The caller advances with
+/// `last_seq`; this avoids ever materializing an arbitrarily large catch-up array in Rust or JS.
+pub fn list_bus_events_page(
+    run_id: &str,
+    since_seq: u64,
+    offset: Option<u64>,
+) -> Result<BusEventPage, String> {
+    log::debug!(
+        "[storage/events] list_bus_events_page: run_id={}, since_seq={}",
+        run_id,
+        since_seq
+    );
+    let path = events_path(run_id);
+    if !path.exists() {
+        return Ok(BusEventPage {
+            events: vec![],
+            last_seq: since_seq,
+            has_more: false,
+            next_offset: offset.unwrap_or(0),
+        });
+    }
+    let mut file = fs::File::open(&path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    let start_offset = offset.unwrap_or(0);
+    let length = file.metadata().map_err(|e| e.to_string())?.len();
+    if start_offset > length {
+        return Err(history_projection_required(
+            "bus event offset is outside the current event log",
+        ));
+    }
+    file.seek(SeekFrom::Start(start_offset))
+        .map_err(|e| e.to_string())?;
+    let page = list_bus_events_page_from_reader(BufReader::new(file), since_seq, start_offset)?;
+    log::debug!(
+        "[storage/events] list_bus_events_page complete: run_id={}, events={}, last_seq={}, has_more={}",
+        run_id,
+        page.events.len(),
+        page.last_seq,
+        page.has_more
+    );
+    Ok(page)
+}
+
+fn list_bus_events_page_from_reader<R: BufRead>(
+    mut reader: R,
+    since_seq: u64,
+    start_offset: u64,
+) -> Result<BusEventPage, String> {
+    let mut events = Vec::new();
+    let mut encoded_bytes = 2usize;
+    let mut last_seq = since_seq;
+    let mut has_more = false;
+    let mut consumed_bytes = 0u64;
+
+    loop {
+        let line_start_offset = consumed_bytes;
+        let mut line = Vec::with_capacity(16 * 1024);
+        let mut oversized = false;
+        // Keep only a bounded prefix after the line crosses the hard limit. The envelope seq is
+        // serialized before the event payload, so this is enough to decide whether an old large
+        // event is already behind the caller's watermark without retaining the whole line.
+        let mut prefix = Vec::with_capacity(64 * 1024);
+        let mut sequence_scan = Vec::with_capacity(128);
+        let mut oversized_seq = None;
+        loop {
+            let available = reader
+                .fill_buf()
+                .map_err(|e| format!("read bus event page: {e}"))?;
+            if available.is_empty() {
+                break;
+            }
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let data_len = newline.unwrap_or(available.len());
+            if prefix.len() < 64 * 1024 {
+                let take = (64 * 1024 - prefix.len()).min(data_len);
+                prefix.extend_from_slice(&available[..take]);
+            }
+            sequence_scan.extend_from_slice(&available[..data_len]);
+            if let Some(seq) = envelope_seq_from_bytes(&sequence_scan) {
+                oversized_seq = Some(seq);
+            }
+            if sequence_scan.len() > 128 {
+                sequence_scan.drain(..sequence_scan.len() - 128);
+            }
+            if !oversized && line.len().saturating_add(data_len) <= BUS_EVENT_LINE_LIMIT {
+                line.extend_from_slice(&available[..data_len]);
+            } else {
+                oversized = true;
+                line.clear();
+            }
+            let consumed = data_len + usize::from(newline.is_some());
+            reader.consume(consumed);
+            consumed_bytes += consumed as u64;
+            if newline.is_some() {
+                break;
+            }
+        }
+        if line.is_empty() && !oversized {
+            break;
+        }
+        if oversized {
+            if oversized_seq
+                .or_else(|| envelope_seq_from_bytes(&prefix))
+                .is_some_and(|seq| seq <= since_seq)
+            {
+                continue;
+            }
+            return Err(history_projection_required(
+                "bus event exceeds bounded catch-up line limit",
+            ));
+        }
+        let line = std::str::from_utf8(&line)
+            .map_err(|e| format!("invalid UTF-8 in bus event page: {e}"))?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(envelope) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if envelope.get("_bus").and_then(|v| v.as_bool()) != Some(true) {
+            continue;
+        }
+        let Some(seq) = envelope.get("seq").and_then(|v| v.as_u64()) else {
+            continue;
+        };
+        if seq <= since_seq {
+            continue;
+        }
+        let Some(raw_event) = envelope.get("event") else {
+            continue;
+        };
+        let Some(event_type) = raw_event.get("type").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !REPLAY_TYPES.contains(&event_type) {
+            continue;
+        }
+        let mut event = raw_event.clone();
+        if let Some(object) = event.as_object_mut() {
+            if let Some(ts) = envelope.get("ts") {
+                object.insert("ts".to_string(), ts.clone());
+            }
+            object.insert("_seq".to_string(), serde_json::Value::Number(seq.into()));
+        }
+        let event_bytes = serde_json::to_vec(&event).map_err(|e| e.to_string())?.len();
+        if event_bytes.saturating_add(2) > BUS_EVENT_PAGE_BYTE_LIMIT {
+            return Err(history_projection_required(format!(
+                "bus event {seq} exceeds catch-up page limit: {event_bytes} bytes"
+            )));
+        }
+        if !events.is_empty()
+            && (events.len() >= BUS_EVENT_PAGE_ENTRY_LIMIT
+                || encoded_bytes.saturating_add(event_bytes + 1) > BUS_EVENT_PAGE_BYTE_LIMIT)
+        {
+            has_more = true;
+            consumed_bytes = line_start_offset;
+            break;
+        }
+        encoded_bytes += event_bytes + 1;
+        last_seq = seq;
+        events.push(event);
+    }
+
+    Ok(BusEventPage {
+        events,
+        last_seq,
+        has_more,
+        next_offset: start_offset + consumed_bytes,
+    })
+}
+
+fn envelope_seq_from_bytes(prefix: &[u8]) -> Option<u64> {
+    let text = std::str::from_utf8(prefix).ok()?;
+    let marker = "\"seq\":";
+    let start = text.find(marker)? + marker.len();
+    let digits: String = text[start..]
+        .chars()
+        .skip_while(|ch| ch.is_ascii_whitespace())
+        .take_while(|ch| ch.is_ascii_digit())
+        .collect();
+    digits.parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{max_seq_in_tail, scan_max_seq};
-    use std::io::Write as _;
+    use super::{
+        copy_bus_events_from_reader, list_bus_events_page_from_reader, max_seq_in_tail,
+        repair_incomplete_tail, scan_max_seq, BUS_EVENT_PAGE_ENTRY_LIMIT,
+    };
+    use std::io::{BufReader, Read as _, Write as _};
 
     #[test]
     fn scan_max_seq_picks_highest_and_ignores_junk() {
@@ -785,5 +1140,190 @@ mod tests {
         // The full-scan fallback path still recovers the true max.
         let content = std::fs::read_to_string(f.path()).unwrap();
         assert_eq!(scan_max_seq(&content), Some(2));
+    }
+
+    #[test]
+    fn incomplete_tail_is_truncated_to_last_committed_newline() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{{\"seq\":1}}\n{{\"seq\":2").unwrap();
+        file.flush().unwrap();
+
+        let committed = repair_incomplete_tail(file.path()).unwrap();
+        assert_eq!(committed, 10);
+        assert_eq!(
+            std::fs::read_to_string(file.path()).unwrap(),
+            "{\"seq\":1}\n"
+        );
+    }
+
+    #[test]
+    fn repair_creates_missing_run_directory_before_first_write() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join("new-run").join("events.jsonl");
+
+        assert_eq!(repair_incomplete_tail(&path).unwrap(), 0);
+        assert!(path.is_file());
+    }
+
+    #[test]
+    fn complete_tail_is_preserved() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{{\"seq\":1}}\n{{\"seq\":2}}\n").unwrap();
+        file.flush().unwrap();
+        let before = std::fs::read(file.path()).unwrap();
+
+        assert_eq!(
+            repair_incomplete_tail(file.path()).unwrap(),
+            before.len() as u64
+        );
+        assert_eq!(std::fs::read(file.path()).unwrap(), before);
+    }
+
+    #[test]
+    fn complete_legacy_tail_without_newline_is_committed_not_deleted() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{{\"seq\":1}}").unwrap();
+        file.flush().unwrap();
+
+        assert_eq!(repair_incomplete_tail(file.path()).unwrap(), 10);
+        assert_eq!(
+            std::fs::read_to_string(file.path()).unwrap(),
+            "{\"seq\":1}\n"
+        );
+    }
+
+    #[test]
+    fn snapshot_prefix_never_ends_inside_an_appended_record() {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        write!(file, "{{\"seq\":1}}\n{{\"seq\":2").unwrap();
+        file.flush().unwrap();
+
+        let snapshot = super::capture_event_log_snapshot(file.path()).unwrap();
+        assert_eq!(snapshot.metadata.len(), 10);
+        let mut body = String::new();
+        BufReader::new(snapshot.file)
+            .take(snapshot.metadata.len())
+            .read_to_string(&mut body)
+            .unwrap();
+        assert_eq!(body, "{\"seq\":1}\n");
+    }
+
+    #[test]
+    fn fork_copy_reads_only_committed_snapshot_prefix() {
+        let committed = serde_json::json!({
+            "_bus": true,
+            "seq": 1,
+            "event": {"type":"user_message","run_id":"source","text":"hello"}
+        })
+        .to_string();
+        let partial = r#"{"_bus":true,"seq":2,"event":{"type":"message_complete""#;
+        let body = format!("{committed}\n{partial}");
+        let committed_len = committed.len() + 1;
+        let mut output = Vec::new();
+
+        let (copied, skipped) = copy_bus_events_from_reader(
+            std::io::Cursor::new(body).take(committed_len as u64),
+            &mut output,
+            "fork",
+        )
+        .unwrap();
+
+        assert_eq!((copied, skipped), (1, 0));
+        let line: serde_json::Value =
+            serde_json::from_slice(output.strip_suffix(b"\n").unwrap()).unwrap();
+        assert_eq!(line["seq"], 1);
+        assert_eq!(line["event"]["run_id"], "fork");
+    }
+
+    #[test]
+    fn bus_event_catchup_is_paged_and_advances_monotonically() {
+        let mut data = Vec::new();
+        for seq in 1..=(BUS_EVENT_PAGE_ENTRY_LIMIT as u64 + 5) {
+            writeln!(
+                data,
+                "{}",
+                serde_json::json!({
+                    "_bus": true,
+                    "seq": seq,
+                    "ts": "t",
+                    "event": {"type": "user_message", "run_id": "run-test", "text": seq.to_string()}
+                })
+            )
+            .unwrap();
+        }
+
+        let first = list_bus_events_page_from_reader(std::io::Cursor::new(&data), 0, 0).unwrap();
+        assert_eq!(first.events.len(), BUS_EVENT_PAGE_ENTRY_LIMIT);
+        assert_eq!(first.last_seq, BUS_EVENT_PAGE_ENTRY_LIMIT as u64);
+        assert!(first.has_more);
+        let second = list_bus_events_page_from_reader(
+            std::io::Cursor::new(&data[first.next_offset as usize..]),
+            first.last_seq,
+            first.next_offset,
+        )
+        .unwrap();
+        assert_eq!(second.events.len(), 5);
+        assert_eq!(second.last_seq, BUS_EVENT_PAGE_ENTRY_LIMIT as u64 + 5);
+        assert!(!second.has_more);
+    }
+
+    #[test]
+    fn bus_event_catchup_rejects_oversized_line_without_buffering_it() {
+        let data = format!("{}\n", "x".repeat(super::BUS_EVENT_LINE_LIMIT + 1));
+        let error = list_bus_events_page_from_reader(std::io::Cursor::new(data), 0, 0).unwrap_err();
+        assert!(error.contains(super::HISTORY_PROJECTION_REQUIRED));
+        assert!(error.contains("bounded catch-up line limit"));
+    }
+
+    #[test]
+    fn bus_event_catchup_requests_projection_for_event_larger_than_page() {
+        let envelope = serde_json::json!({
+            "_bus": true,
+            "seq": 1,
+            "ts": "t",
+            "event": {
+                "type": "message_complete",
+                "run_id": "run-test",
+                "message_id": "large-message",
+                "text": "x".repeat(super::BUS_EVENT_PAGE_BYTE_LIMIT + 1024)
+            }
+        });
+        let data = format!("{envelope}\n");
+        assert!(data.len() < super::BUS_EVENT_LINE_LIMIT);
+
+        let error = list_bus_events_page_from_reader(std::io::Cursor::new(data), 0, 0).unwrap_err();
+        assert!(error.contains(super::HISTORY_PROJECTION_REQUIRED));
+        assert!(error.contains("exceeds catch-up page limit"));
+    }
+
+    #[test]
+    fn oversized_line_before_watermark_is_skipped_but_new_one_requests_rebuild() {
+        let oversized = serde_json::json!({
+            "_bus": true,
+            "seq": 7,
+            "ts": "t",
+            "event": {
+                "type": "message_complete",
+                "run_id": "run-test",
+                "text": "x".repeat(super::BUS_EVENT_LINE_LIMIT + 1)
+            }
+        })
+        .to_string();
+        let next = serde_json::json!({
+            "_bus": true,
+            "seq": 8,
+            "ts": "t",
+            "event": {"type": "user_message", "run_id": "run-test", "text": "next"}
+        });
+        let data = format!("{oversized}\n{next}\n");
+
+        let page = list_bus_events_page_from_reader(std::io::Cursor::new(&data), 7, 0).unwrap();
+        assert_eq!(page.last_seq, 8);
+        assert_eq!(page.events.len(), 1);
+
+        let error =
+            list_bus_events_page_from_reader(std::io::Cursor::new(&data), 6, 0).unwrap_err();
+        assert!(error.contains(super::HISTORY_PROJECTION_REQUIRED));
+        assert!(error.contains("bounded catch-up line limit"));
     }
 }

--- a/src-tauri/src/storage/history.rs
+++ b/src-tauri/src/storage/history.rs
@@ -1,0 +1,5280 @@
+//! Bounded, rebuildable history projection for large runs.
+//!
+//! `events.jsonl` remains the source of truth. This module builds immutable generations whose
+//! pages are small enough to cross Tauri/WebSocket IPC without materializing the complete run.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+
+const FORMAT_VERSION: u32 = 1;
+const BUILDER_VERSION: u32 = 9;
+const PAGE_ENTRY_LIMIT: usize = 100;
+const PAGE_BYTE_LIMIT: usize = 1024 * 1024;
+const ENTRY_BYTE_LIMIT: usize = 256 * 1024;
+const CONTENT_INLINE_LIMIT: usize = 64 * 1024;
+const CONTENT_CHUNK_LIMIT: usize = 256 * 1024;
+const PARSE_LINE_LIMIT: usize = 2 * 1024 * 1024;
+const PREVIEW_HEAD_BYTES: usize = 24 * 1024;
+const PREVIEW_TAIL_BYTES: usize = 8 * 1024;
+const MAX_OPEN_TOOLS: usize = 256;
+const MAX_SUBHISTORIES: usize = 64;
+const MAX_PENDING_INTERACTIONS: usize = 64;
+const MAX_JSON_NESTING_DEPTH: usize = 512;
+const MAX_JSON_SCALAR_BYTES: usize = 64 * 1024;
+
+static BUILD_LOCKS: Lazy<Vec<Mutex<()>>> = Lazy::new(|| (0..64).map(|_| Mutex::new(())).collect());
+static GLOBAL_BUILD_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static PROCESS_RETENTION_ID: Lazy<String> = Lazy::new(|| uuid::Uuid::new_v4().simple().to_string());
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryContent {
+    pub preview: String,
+    pub byte_length: u64,
+    pub truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_id: Option<String>,
+    pub encoding: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+// Pages cap this enum at 100 entries; keeping the tagged IPC shape flat avoids wrapper-only
+// allocation and matching complexity while the in-memory upper bound remains below one page.
+#[allow(clippy::large_enum_variant)]
+pub enum HistoryEntry {
+    User {
+        id: String,
+        #[serde(rename = "anchorId")]
+        anchor_id: String,
+        ts: String,
+        content: HistoryContent,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "cliUuid")]
+        cli_uuid: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        attachments: Vec<Value>,
+        #[serde(rename = "firstSeq")]
+        first_seq: u64,
+        #[serde(rename = "lastSeq")]
+        last_seq: u64,
+    },
+    Assistant {
+        id: String,
+        #[serde(rename = "anchorId")]
+        anchor_id: String,
+        ts: String,
+        content: HistoryContent,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thinking: Option<HistoryContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
+        #[serde(rename = "firstSeq")]
+        first_seq: u64,
+        #[serde(rename = "lastSeq")]
+        last_seq: u64,
+    },
+    Tool {
+        id: String,
+        #[serde(rename = "anchorId")]
+        anchor_id: String,
+        ts: String,
+        #[serde(rename = "toolUseId")]
+        tool_use_id: String,
+        #[serde(rename = "toolName")]
+        tool_name: String,
+        status: String,
+        input: Value,
+        output: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "toolUseResult")]
+        tool_use_result: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "inputContent")]
+        input_content: Option<HistoryContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "outputContent")]
+        output_content: Option<HistoryContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "resultContent")]
+        result_content: Option<HistoryContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "durationMs")]
+        duration_ms: Option<u64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(rename = "subHistoryId")]
+        sub_history_id: Option<String>,
+        #[serde(rename = "firstSeq")]
+        first_seq: u64,
+        #[serde(rename = "lastSeq")]
+        last_seq: u64,
+    },
+    CommandOutput {
+        id: String,
+        #[serde(rename = "anchorId")]
+        anchor_id: String,
+        ts: String,
+        content: HistoryContent,
+        #[serde(rename = "firstSeq")]
+        first_seq: u64,
+        #[serde(rename = "lastSeq")]
+        last_seq: u64,
+    },
+    Placeholder {
+        id: String,
+        #[serde(rename = "anchorId")]
+        anchor_id: String,
+        ts: String,
+        content: HistoryContent,
+        #[serde(rename = "firstSeq")]
+        first_seq: u64,
+        #[serde(rename = "lastSeq")]
+        last_seq: u64,
+    },
+}
+
+impl HistoryEntry {
+    fn last_seq(&self) -> u64 {
+        match self {
+            Self::User { last_seq, .. }
+            | Self::Assistant { last_seq, .. }
+            | Self::Tool { last_seq, .. }
+            | Self::CommandOutput { last_seq, .. }
+            | Self::Placeholder { last_seq, .. } => *last_seq,
+        }
+    }
+
+    fn first_seq(&self) -> u64 {
+        match self {
+            Self::User { first_seq, .. }
+            | Self::Assistant { first_seq, .. }
+            | Self::Tool { first_seq, .. }
+            | Self::CommandOutput { first_seq, .. }
+            | Self::Placeholder { first_seq, .. } => *first_seq,
+        }
+    }
+}
+
+fn flush_entries_page(
+    page: &mut Vec<HistoryEntry>,
+    page_bytes: &mut usize,
+    page_count: &mut u64,
+    pages_dir: &Path,
+) -> Result<(), String> {
+    if page.is_empty() {
+        return Ok(());
+    }
+    *page_count += 1;
+    let path = pages_dir.join(format!("{:08}.json", *page_count));
+    let body = serde_json::to_vec(page).map_err(|e| e.to_string())?;
+    if body.len() > PAGE_BYTE_LIMIT {
+        return Err(format!("history page exceeds hard limit: {}", body.len()));
+    }
+    fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))?;
+    page.clear();
+    *page_bytes = 2;
+    Ok(())
+}
+
+fn update_tool_page<F>(
+    pages_dir: &Path,
+    page_number: u64,
+    tool_use_id: &str,
+    update: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&mut HistoryEntry) -> Result<(), String>,
+{
+    let path = pages_dir.join(format!("{page_number:08}.json"));
+    let body = fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    if body.len() > PAGE_BYTE_LIMIT {
+        return Err(format!("history page exceeds hard limit: {}", body.len()));
+    }
+    let mut entries: Vec<HistoryEntry> =
+        serde_json::from_slice(&body).map_err(|e| e.to_string())?;
+    let entry = entries
+        .iter_mut()
+        .find(|entry| matches!(entry, HistoryEntry::Tool { tool_use_id: id, .. } if id == tool_use_id))
+        .ok_or_else(|| format!("history tool page is missing tool {tool_use_id}"))?;
+    update(entry)?;
+    let updated = serde_json::to_vec(&entries).map_err(|e| e.to_string())?;
+    if updated.len() > PAGE_BYTE_LIMIT {
+        return Err(format!(
+            "history page exceeds hard limit: {}",
+            updated.len()
+        ));
+    }
+    let temporary = pages_dir.join(format!("{page_number:08}.tmp"));
+    fs::write(&temporary, updated).map_err(|e| format!("write {}: {e}", temporary.display()))?;
+    replace_file(&temporary, &path).map_err(|e| format!("replace {}: {e}", path.display()))
+}
+
+impl SubHistoryState {
+    fn new(
+        root: &Path,
+        parent_tool_use_id: &str,
+        run_id: &str,
+        generation_id: &str,
+        blobs_dir: &Path,
+    ) -> Result<Self, String> {
+        let id = sanitize_id(parent_tool_use_id);
+        let dir = root.join(&id);
+        let pages_dir = dir.join("pages");
+        let spools_dir = dir.join("spools");
+        super::ensure_dir(&pages_dir).map_err(|e| e.to_string())?;
+        super::ensure_dir(&spools_dir).map_err(|e| e.to_string())?;
+        Ok(Self {
+            id,
+            run_id: run_id.to_string(),
+            generation_id: generation_id.to_string(),
+            blobs_dir: blobs_dir.to_path_buf(),
+            pages_dir,
+            pending_message: SpoolText::new(spools_dir.join("message.bin")),
+            pending_thinking: SpoolText::new(spools_dir.join("thinking.bin")),
+            spools_dir,
+            page: Vec::new(),
+            page_bytes: 2,
+            page_count: 0,
+            last_seq: 0,
+            pending_message_seq: None,
+            pending_thinking_seq: None,
+            open_tools: HashMap::new(),
+        })
+    }
+
+    fn push(&mut self, entry: HistoryEntry) -> Result<(), String> {
+        let bytes = serde_json::to_vec(&entry).map_err(|e| e.to_string())?.len();
+        if bytes > ENTRY_BYTE_LIMIT {
+            return Err("subhistory entry exceeds hard limit".to_string());
+        }
+        if !self.page.is_empty()
+            && (self.page.len() >= PAGE_ENTRY_LIMIT
+                || self.page_bytes.saturating_add(bytes + 1) > PAGE_BYTE_LIMIT)
+        {
+            flush_entries_page(
+                &mut self.page,
+                &mut self.page_bytes,
+                &mut self.page_count,
+                &self.pages_dir,
+            )?;
+        }
+        self.page_bytes += bytes + 1;
+        self.last_seq = self.last_seq.max(entry.last_seq());
+        self.page.push(entry);
+        Ok(())
+    }
+
+    fn reset_pending_streams(&mut self) -> Result<(), String> {
+        self.pending_message.discard()?;
+        self.pending_thinking.discard()?;
+        self.pending_message_seq = None;
+        self.pending_thinking_seq = None;
+        Ok(())
+    }
+
+    fn settle_interrupted_work(&mut self, last_seq: u64, tool_error: &str) -> Result<(), String> {
+        if !self.pending_message.is_empty() || !self.pending_thinking.is_empty() {
+            let seq = match (self.pending_message_seq, self.pending_thinking_seq) {
+                (Some(message), Some(thinking)) => message.min(thinking),
+                (Some(seq), None) | (None, Some(seq)) => seq,
+                (None, None) => last_seq,
+            };
+            let id = format!("sub-assistant-incomplete-{seq}");
+            let content = if self.pending_message.is_empty() {
+                HistoryContent {
+                    preview: String::new(),
+                    byte_length: 0,
+                    truncated: false,
+                    content_id: None,
+                    encoding: "text".to_string(),
+                }
+            } else {
+                content_from_spool_at(
+                    &self.run_id,
+                    &self.generation_id,
+                    &self.blobs_dir,
+                    &format!("sub:{}:{id}:text", self.id),
+                    std::mem::replace(
+                        &mut self.pending_message,
+                        SpoolText::new(self.spools_dir.join("message-next.bin")),
+                    ),
+                )?
+            };
+            let thinking = if self.pending_thinking.is_empty() {
+                None
+            } else {
+                Some(content_from_spool_at(
+                    &self.run_id,
+                    &self.generation_id,
+                    &self.blobs_dir,
+                    &format!("sub:{}:{id}:thinking", self.id),
+                    std::mem::replace(
+                        &mut self.pending_thinking,
+                        SpoolText::new(self.spools_dir.join("thinking-next.bin")),
+                    ),
+                )?)
+            };
+            self.pending_message_seq = None;
+            self.pending_thinking_seq = None;
+            self.push(HistoryEntry::Assistant {
+                id: id.clone(),
+                anchor_id: id,
+                ts: String::new(),
+                content,
+                thinking,
+                model: None,
+                first_seq: seq,
+                last_seq,
+            })?;
+        }
+        for (tool_use_id, open) in std::mem::take(&mut self.open_tools) {
+            update_tool_page(&self.pages_dir, open.page_number, &tool_use_id, |entry| {
+                if let HistoryEntry::Tool {
+                    status,
+                    output,
+                    last_seq: entry_last_seq,
+                    ..
+                } = entry
+                {
+                    *status = "error".to_string();
+                    *output = json!({"error":tool_error});
+                    *entry_last_seq = last_seq;
+                }
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self) -> Result<(), String> {
+        self.settle_interrupted_work(self.last_seq, "Session ended before tool result")?;
+        flush_entries_page(
+            &mut self.page,
+            &mut self.page_bytes,
+            &mut self.page_count,
+            &self.pages_dir,
+        )?;
+        fs::write(
+            self.pages_dir.parent().unwrap().join("manifest.json"),
+            serde_json::to_vec(&json!({"pageCount": self.page_count}))
+                .map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistorySummary {
+    pub run_id: String,
+    pub generation_id: String,
+    pub page_count: u64,
+    pub total_entries: u64,
+    pub total_turns: u64,
+    pub last_seq: u64,
+    pub source_size: u64,
+    pub source_mtime_ns: u128,
+    pub latest_cursor: Option<String>,
+    #[serde(default)]
+    pub state_events: Vec<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryPage {
+    pub run_id: String,
+    pub generation_id: String,
+    pub entries: Vec<HistoryEntry>,
+    pub page_cursor: String,
+    pub previous_cursor: Option<String>,
+    pub has_more: bool,
+    pub first_seq: u64,
+    pub last_seq: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentChunk {
+    pub run_id: String,
+    pub generation_id: String,
+    pub content_id: String,
+    pub offset: u64,
+    pub next_offset: u64,
+    pub total_bytes: u64,
+    pub eof: bool,
+    pub data_base64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubHistoryPage {
+    pub run_id: String,
+    pub generation_id: String,
+    pub sub_history_id: String,
+    pub entries: Vec<HistoryEntry>,
+    pub page_cursor: String,
+    pub previous_cursor: Option<String>,
+    pub has_more: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CurrentPointer {
+    generation_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HistoryManifest {
+    format_version: u32,
+    builder_version: u32,
+    generation_id: String,
+    source_size: u64,
+    source_mtime_ns: u128,
+    source_prefix_hash: String,
+    last_seq: u64,
+    page_count: u64,
+    total_entries: u64,
+    total_turns: u64,
+    complete: bool,
+}
+
+#[derive(Debug)]
+struct OpenTool {
+    page_number: u64,
+    input_stream: Option<SpoolText>,
+    output_stream: Option<SpoolText>,
+}
+
+#[derive(Debug, Clone)]
+enum OpenToolScope {
+    Main,
+    Subhistory(String),
+}
+
+#[derive(Debug)]
+struct SubHistoryState {
+    id: String,
+    run_id: String,
+    generation_id: String,
+    blobs_dir: PathBuf,
+    pages_dir: PathBuf,
+    spools_dir: PathBuf,
+    page: Vec<HistoryEntry>,
+    page_bytes: usize,
+    page_count: u64,
+    last_seq: u64,
+    pending_message: SpoolText,
+    pending_message_seq: Option<u64>,
+    pending_thinking_seq: Option<u64>,
+    pending_thinking: SpoolText,
+    open_tools: HashMap<String, OpenTool>,
+}
+
+#[derive(Debug)]
+struct SpoolText {
+    inline: String,
+    file: Option<File>,
+    path: PathBuf,
+    byte_length: u64,
+}
+
+impl SpoolText {
+    fn new(path: PathBuf) -> Self {
+        Self {
+            inline: String::new(),
+            file: None,
+            path,
+            byte_length: 0,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.byte_length == 0
+    }
+
+    fn append(&mut self, value: &str) -> Result<(), String> {
+        if value.is_empty() {
+            return Ok(());
+        }
+        if self.file.is_none()
+            && self.inline.len().saturating_add(value.len()) <= CONTENT_INLINE_LIMIT
+        {
+            self.inline.push_str(value);
+            self.byte_length += value.len() as u64;
+            return Ok(());
+        }
+        if self.file.is_none() {
+            let mut file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&self.path)
+                .map_err(|e| format!("create history spool: {e}"))?;
+            file.write_all(self.inline.as_bytes())
+                .map_err(|e| format!("write history spool: {e}"))?;
+            self.inline.clear();
+            self.file = Some(file);
+        }
+        self.file
+            .as_mut()
+            .expect("spool file initialized")
+            .write_all(value.as_bytes())
+            .map_err(|e| format!("append history spool: {e}"))?;
+        self.byte_length += value.len() as u64;
+        Ok(())
+    }
+
+    fn discard(&mut self) -> Result<(), String> {
+        let path = self.path.clone();
+        *self = Self::new(path.clone());
+        if let Err(e) = fs::remove_file(&path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                return Err(format!("remove history spool: {e}"));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct BuildState {
+    run_id: String,
+    generation_id: String,
+    generation_dir: PathBuf,
+    pages_dir: PathBuf,
+    blobs_dir: PathBuf,
+    spools_dir: PathBuf,
+    page: Vec<HistoryEntry>,
+    page_bytes: usize,
+    page_count: u64,
+    total_entries: u64,
+    total_turns: u64,
+    last_seq: u64,
+    state_events: HashMap<String, Value>,
+    pending_interactions: HashMap<String, Value>,
+    pending_user_inputs: HashMap<String, u64>,
+    pending_message: SpoolText,
+    pending_message_seq: Option<u64>,
+    pending_thinking_seq: Option<u64>,
+    pending_thinking: SpoolText,
+    seen_message_ids: HashSet<String>,
+    seen_tool_ids: HashSet<String>,
+    open_tools: HashMap<String, OpenTool>,
+    subhistories: HashMap<String, SubHistoryState>,
+}
+
+fn history_root(run_id: &str) -> PathBuf {
+    super::run_dir(run_id).join("history-v1")
+}
+
+fn source_path(run_id: &str) -> PathBuf {
+    super::run_dir(run_id).join("events.jsonl")
+}
+
+fn modified_ns(meta: &fs::Metadata) -> u128 {
+    meta.modified()
+        .ok()
+        .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos())
+        .unwrap_or(0)
+}
+
+fn hash_prefix(path: &Path, source_size: u64) -> Result<String, String> {
+    let file = File::open(path).map_err(|e| format!("open {}: {e}", path.display()))?;
+    hash_file_prefix(&file, source_size)
+}
+
+fn hash_file_prefix(file: &File, source_size: u64) -> Result<String, String> {
+    let mut file = file.try_clone().map_err(|e| e.to_string())?;
+    file.seek(SeekFrom::Start(0)).map_err(|e| e.to_string())?;
+    let mut remaining = source_size;
+    let mut digest = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let take = remaining.min(buffer.len() as u64) as usize;
+        file.read_exact(&mut buffer[..take])
+            .map_err(|e| format!("hash event prefix: {e}"))?;
+        digest.update(&buffer[..take]);
+        remaining -= take as u64;
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn cursor(generation_id: &str, page: u64) -> String {
+    format!("{generation_id}:{page}")
+}
+
+fn parse_cursor(raw: &str) -> Result<(&str, u64), String> {
+    let (generation, page) = raw
+        .split_once(':')
+        .ok_or_else(|| "invalid history cursor".to_string())?;
+    if !is_hex_id(generation, 32) {
+        return Err("invalid history cursor generation".to_string());
+    }
+    let page = page
+        .parse::<u64>()
+        .map_err(|_| "invalid history cursor page".to_string())?;
+    if page == 0 {
+        return Err("invalid history cursor page".to_string());
+    }
+    Ok((generation, page))
+}
+
+fn is_hex_id(value: &str, length: usize) -> bool {
+    value.len() == length && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[derive(Debug)]
+enum ScannedLine {
+    Eof,
+    Inline {
+        data: Vec<u8>,
+        source_bytes: u64,
+    },
+    External {
+        path: PathBuf,
+        byte_length: u64,
+        source_bytes: u64,
+    },
+}
+
+#[derive(Default)]
+struct SemanticBoundaryTracker {
+    streaming_scopes: HashSet<String>,
+    open_tools: HashSet<(String, String)>,
+}
+
+fn normalized_parent_tool_use_id(event: &Value) -> Option<&str> {
+    event
+        .get("parent_tool_use_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+}
+
+impl SemanticBoundaryTracker {
+    fn observe(&mut self, envelope: &Value) {
+        if envelope.get("_bus").and_then(Value::as_bool) != Some(true) {
+            return;
+        }
+        let Some(event) = envelope.get("event") else {
+            return;
+        };
+        let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
+        let scope = normalized_parent_tool_use_id(event)
+            .unwrap_or("__main")
+            .to_string();
+        if kind == "user_message" && scope == "__main" {
+            self.streaming_scopes.clear();
+            self.open_tools.clear();
+            return;
+        }
+        if kind == "run_state"
+            && matches!(
+                event.get("state").and_then(Value::as_str),
+                Some("spawning" | "running" | "idle" | "completed" | "failed" | "stopped")
+            )
+        {
+            self.streaming_scopes.clear();
+            self.open_tools.clear();
+            return;
+        }
+        match kind {
+            "message_delta" | "thinking_delta" => {
+                self.streaming_scopes.insert(scope);
+            }
+            "message_complete" => {
+                self.streaming_scopes.remove(&scope);
+            }
+            "tool_start" => {
+                if let Some(tool_use_id) = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                {
+                    self.open_tools.insert((scope, tool_use_id.to_string()));
+                }
+            }
+            "tool_end" => {
+                if let Some(tool_use_id) = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.is_empty())
+                {
+                    let exact = (scope, tool_use_id.to_string());
+                    if !self.open_tools.remove(&exact) {
+                        // Some upstream tool_end events omit parent_tool_use_id. Tool IDs are
+                        // globally unique within a run, so match the frontend's recursive fallback.
+                        self.open_tools.retain(|(_, id)| id != tool_use_id);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn is_closed(&self) -> bool {
+        self.streaming_scopes.is_empty() && self.open_tools.is_empty()
+    }
+}
+
+fn safe_projection_size(file: &File, source_size: u64, spools_dir: &Path) -> Result<u64, String> {
+    let mut reader = BufReader::new(
+        file.try_clone()
+            .map_err(|e| e.to_string())?
+            .take(source_size),
+    );
+    let mut tracker = SemanticBoundaryTracker::default();
+    let mut offset = 0u64;
+    let mut safe_offset = 0u64;
+    let mut line_no = 0usize;
+    loop {
+        line_no += 1;
+        let external_path = spools_dir.join(format!("boundary-line-{line_no}.bin"));
+        let (value, source_bytes) = match read_bounded_line(&mut reader, &external_path)? {
+            ScannedLine::Eof => break,
+            ScannedLine::Inline { data, source_bytes } => {
+                let value = std::str::from_utf8(&data)
+                    .ok()
+                    .and_then(|line| serde_json::from_str::<Value>(line).ok());
+                (value, source_bytes)
+            }
+            ScannedLine::External {
+                path, source_bytes, ..
+            } => {
+                let metadata = oversized_metadata(&path).ok().map(|event| {
+                    let seq = event.get("seq").cloned().unwrap_or(Value::Null);
+                    json!({"_bus":true,"seq":seq,"event":event})
+                });
+                fs::remove_file(path).map_err(|e| e.to_string())?;
+                (metadata, source_bytes)
+            }
+        };
+        offset = offset.saturating_add(source_bytes);
+        if let Some(value) = value.as_ref() {
+            tracker.observe(value);
+        }
+        if tracker.is_closed() {
+            safe_offset = offset;
+        }
+    }
+    Ok(safe_offset)
+}
+
+fn read_bounded_line<R: BufRead>(
+    reader: &mut R,
+    external_path: &Path,
+) -> Result<ScannedLine, String> {
+    let mut inline = Vec::with_capacity(16 * 1024);
+    let mut external: Option<File> = None;
+    let mut byte_length = 0u64;
+    loop {
+        let available = reader
+            .fill_buf()
+            .map_err(|e| format!("read history line: {e}"))?;
+        if available.is_empty() {
+            return if byte_length == 0 {
+                Ok(ScannedLine::Eof)
+            } else if let Some(mut file) = external {
+                file.flush().map_err(|e| e.to_string())?;
+                Ok(ScannedLine::External {
+                    path: external_path.to_path_buf(),
+                    byte_length,
+                    source_bytes: byte_length,
+                })
+            } else {
+                Ok(ScannedLine::Inline {
+                    data: inline,
+                    source_bytes: byte_length,
+                })
+            };
+        }
+        let newline = available.iter().position(|byte| *byte == b'\n');
+        let data_len = newline.unwrap_or(available.len());
+        let data = &available[..data_len];
+        if external.is_none() && inline.len().saturating_add(data.len()) > PARSE_LINE_LIMIT {
+            let mut file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(external_path)
+                .map_err(|e| format!("create oversized history event: {e}"))?;
+            file.write_all(&inline).map_err(|e| e.to_string())?;
+            inline.clear();
+            external = Some(file);
+        }
+        if let Some(file) = external.as_mut() {
+            file.write_all(data).map_err(|e| e.to_string())?;
+        } else {
+            inline.extend_from_slice(data);
+        }
+        byte_length += data.len() as u64;
+        let consumed = data_len + usize::from(newline.is_some());
+        reader.consume(consumed);
+        if newline.is_some() {
+            if let Some(mut file) = external {
+                file.flush().map_err(|e| e.to_string())?;
+                return Ok(ScannedLine::External {
+                    path: external_path.to_path_buf(),
+                    byte_length,
+                    source_bytes: byte_length + 1,
+                });
+            }
+            if inline.last() == Some(&b'\r') {
+                inline.pop();
+            }
+            return Ok(ScannedLine::Inline {
+                data: inline,
+                source_bytes: byte_length + 1,
+            });
+        }
+    }
+}
+
+fn safe_utf8_prefix(value: &str, max: usize) -> &str {
+    &value[..value.floor_char_boundary(max.min(value.len()))]
+}
+
+fn safe_utf8_suffix(value: &str, max: usize) -> &str {
+    let start = value.len().saturating_sub(max);
+    &value[value.ceil_char_boundary(start)..]
+}
+
+fn oversized_metadata(path: &Path) -> Result<Value, String> {
+    let file = File::open(path).map_err(|e| e.to_string())?;
+    let mut scanner = JsonMetadataScanner::new(file);
+    let mut metadata = serde_json::Map::new();
+    scanner.scan_envelope(&mut metadata)?;
+    Ok(Value::Object(metadata))
+}
+
+struct JsonMetadataScanner<R: Read> {
+    reader: BufReader<R>,
+    pushed: Option<u8>,
+}
+
+impl<R: Read> JsonMetadataScanner<R> {
+    fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            pushed: None,
+        }
+    }
+
+    fn byte(&mut self) -> Result<Option<u8>, String> {
+        if let Some(byte) = self.pushed.take() {
+            return Ok(Some(byte));
+        }
+        let available = self.reader.fill_buf().map_err(|e| e.to_string())?;
+        let byte = available.first().copied();
+        if byte.is_some() {
+            self.reader.consume(1);
+        }
+        Ok(byte)
+    }
+
+    fn non_whitespace(&mut self) -> Result<Option<u8>, String> {
+        loop {
+            match self.byte()? {
+                Some(byte) if byte.is_ascii_whitespace() => {}
+                other => return Ok(other),
+            }
+        }
+    }
+
+    fn unread(&mut self, byte: u8) -> Result<(), String> {
+        if self.pushed.replace(byte).is_some() {
+            return Err("oversized JSON scanner pushback overflow".to_string());
+        }
+        Ok(())
+    }
+
+    fn string(&mut self, label: &str) -> Result<String, String> {
+        let mut encoded = vec![b'"'];
+        let mut escaped = false;
+        loop {
+            let byte = self
+                .byte()?
+                .ok_or_else(|| format!("unterminated oversized JSON {label}"))?;
+            encoded.push(byte);
+            if encoded.len() > MAX_JSON_SCALAR_BYTES {
+                return Err(format!(
+                    "oversized JSON {label} exceeds hard limit: {MAX_JSON_SCALAR_BYTES}"
+                ));
+            }
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                return serde_json::from_slice(&encoded)
+                    .map_err(|e| format!("invalid oversized JSON {label}: {e}"));
+            }
+        }
+    }
+
+    fn skip_string(&mut self) -> Result<(), String> {
+        let mut escaped = false;
+        loop {
+            let byte = self
+                .byte()?
+                .ok_or_else(|| "unterminated oversized JSON string".to_string())?;
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                return Ok(());
+            }
+        }
+    }
+
+    fn scalar(&mut self, first: u8) -> Result<Value, String> {
+        let mut encoded = vec![first];
+        loop {
+            match self.byte()? {
+                Some(byte) if matches!(byte, b',' | b'}' | b']') => {
+                    self.unread(byte)?;
+                    break;
+                }
+                Some(byte) => {
+                    encoded.push(byte);
+                    if encoded.len() > MAX_JSON_SCALAR_BYTES {
+                        return Err(format!(
+                            "oversized JSON scalar exceeds hard limit: {MAX_JSON_SCALAR_BYTES}"
+                        ));
+                    }
+                }
+                None => break,
+            }
+        }
+        while encoded.last().is_some_and(u8::is_ascii_whitespace) {
+            encoded.pop();
+        }
+        serde_json::from_slice(&encoded).map_err(|e| format!("invalid oversized JSON scalar: {e}"))
+    }
+
+    fn skip_value(&mut self, first: u8) -> Result<(), String> {
+        if first == b'"' {
+            return self.skip_string();
+        }
+        if !matches!(first, b'{' | b'[') {
+            self.scalar(first)?;
+            return Ok(());
+        }
+        let mut stack = vec![if first == b'{' { b'}' } else { b']' }];
+        let mut in_string = false;
+        let mut escaped = false;
+        while let Some(byte) = self.byte()? {
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if byte == b'\\' {
+                    escaped = true;
+                } else if byte == b'"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            match byte {
+                b'"' => in_string = true,
+                b'{' | b'[' => {
+                    if stack.len() >= MAX_JSON_NESTING_DEPTH {
+                        return Err(format!(
+                            "oversized JSON metadata nesting exceeds hard limit: {MAX_JSON_NESTING_DEPTH}"
+                        ));
+                    }
+                    stack.push(if byte == b'{' { b'}' } else { b']' });
+                }
+                b'}' | b']' => {
+                    if stack.pop() != Some(byte) {
+                        return Err("mismatched oversized JSON metadata delimiter".to_string());
+                    }
+                    if stack.is_empty() {
+                        return Ok(());
+                    }
+                }
+                _ => {}
+            }
+        }
+        Err("unterminated oversized JSON metadata value".to_string())
+    }
+
+    fn string_or_skip(&mut self, first: u8, label: &str) -> Result<Option<String>, String> {
+        if first == b'"' {
+            return self.string(label).map(Some);
+        }
+        self.skip_value(first)?;
+        Ok(None)
+    }
+
+    fn bounded_value(&mut self, first: u8, label: &str) -> Result<Value, String> {
+        if !matches!(first, b'{' | b'[') {
+            return self.scalar(first);
+        }
+        let mut encoded = vec![first];
+        let mut stack = vec![if first == b'{' { b'}' } else { b']' }];
+        let mut in_string = false;
+        let mut escaped = false;
+        while let Some(byte) = self.byte()? {
+            encoded.push(byte);
+            if encoded.len() > ENTRY_BYTE_LIMIT {
+                return Err(format!(
+                    "oversized JSON {label} exceeds hard limit: {ENTRY_BYTE_LIMIT}"
+                ));
+            }
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if byte == b'\\' {
+                    escaped = true;
+                } else if byte == b'"' {
+                    in_string = false;
+                }
+                continue;
+            }
+            match byte {
+                b'"' => in_string = true,
+                b'{' | b'[' => {
+                    if stack.len() >= MAX_JSON_NESTING_DEPTH {
+                        return Err(format!(
+                            "oversized JSON metadata nesting exceeds hard limit: {MAX_JSON_NESTING_DEPTH}"
+                        ));
+                    }
+                    stack.push(if byte == b'{' { b'}' } else { b']' });
+                }
+                b'}' | b']' => {
+                    if stack.pop() != Some(byte) {
+                        return Err("mismatched oversized JSON metadata delimiter".to_string());
+                    }
+                    if stack.is_empty() {
+                        return serde_json::from_slice(&encoded)
+                            .map_err(|e| format!("invalid oversized JSON {label}: {e}"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        Err(format!("unterminated oversized JSON {label}"))
+    }
+
+    fn scan_event(
+        &mut self,
+        first: u8,
+        metadata: &mut serde_json::Map<String, Value>,
+    ) -> Result<(), String> {
+        if first != b'{' {
+            return self.skip_value(first);
+        }
+        loop {
+            let first = self
+                .non_whitespace()?
+                .ok_or_else(|| "unterminated oversized event object".to_string())?;
+            if first == b'}' {
+                return Ok(());
+            }
+            if first != b'"' {
+                return Err("invalid oversized event metadata key".to_string());
+            }
+            let key = self.string("event metadata key")?;
+            if self.non_whitespace()? != Some(b':') {
+                return Err("invalid oversized event metadata separator".to_string());
+            }
+            let value_first = self
+                .non_whitespace()?
+                .ok_or_else(|| "missing oversized event metadata value".to_string())?;
+            if matches!(
+                key.as_str(),
+                "type"
+                    | "message_id"
+                    | "tool_use_id"
+                    | "tool_name"
+                    | "status"
+                    | "parent_tool_use_id"
+                    | "uuid"
+                    | "client_uuid"
+                    | "model"
+            ) {
+                if let Some(value) = self.string_or_skip(value_first, "event metadata string")? {
+                    metadata.insert(key, Value::String(value));
+                }
+            } else if key == "duration_ms" {
+                if matches!(value_first, b'{' | b'[') {
+                    self.skip_value(value_first)?;
+                } else {
+                    let value = self.scalar(value_first)?;
+                    if let Some(duration_ms) = value.as_u64() {
+                        metadata.insert(key, Value::Number(duration_ms.into()));
+                    }
+                }
+            } else if key == "attachments" && value_first == b'[' {
+                let value = self.bounded_value(value_first, "event attachments")?;
+                metadata.insert(key, value);
+            } else {
+                self.skip_value(value_first)?;
+            }
+            match self.non_whitespace()? {
+                Some(b',') => {}
+                Some(b'}') => return Ok(()),
+                _ => return Err("invalid oversized event metadata delimiter".to_string()),
+            }
+        }
+    }
+
+    fn scan_envelope(
+        &mut self,
+        metadata: &mut serde_json::Map<String, Value>,
+    ) -> Result<(), String> {
+        if self.non_whitespace()? != Some(b'{') {
+            return Err("oversized event envelope must be an object".to_string());
+        }
+        loop {
+            let first = self
+                .non_whitespace()?
+                .ok_or_else(|| "unterminated oversized event envelope".to_string())?;
+            if first == b'}' {
+                return Ok(());
+            }
+            if first != b'"' {
+                return Err("invalid oversized event envelope key".to_string());
+            }
+            let key = self.string("envelope key")?;
+            if self.non_whitespace()? != Some(b':') {
+                return Err("invalid oversized event envelope separator".to_string());
+            }
+            let value_first = self
+                .non_whitespace()?
+                .ok_or_else(|| "missing oversized event envelope value".to_string())?;
+            match key.as_str() {
+                "seq" => {
+                    let value = self.scalar(value_first)?;
+                    if let Some(seq) = value.as_u64() {
+                        metadata.insert("seq".to_string(), Value::Number(seq.into()));
+                    }
+                }
+                "ts" => {
+                    if let Some(value) = self.string_or_skip(value_first, "timestamp")? {
+                        metadata.insert("ts".to_string(), Value::String(value));
+                    }
+                }
+                "event" => self.scan_event(value_first, metadata)?,
+                _ => self.skip_value(value_first)?,
+            }
+            match self.non_whitespace()? {
+                Some(b',') => {}
+                Some(b'}') => return Ok(()),
+                _ => return Err("invalid oversized event envelope delimiter".to_string()),
+            }
+        }
+    }
+}
+
+fn extract_json_string_field(
+    path: &Path,
+    key: &str,
+    spool_path: PathBuf,
+) -> Result<Option<SpoolText>, String> {
+    let mut bytes = BufReader::new(File::open(path).map_err(|e| e.to_string())?).bytes();
+    let mut candidate = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut stack = Vec::new();
+    #[allow(clippy::while_let_on_iterator)]
+    while let Some(byte) = bytes.next() {
+        let byte = byte.map_err(|e| e.to_string())?;
+        if in_string {
+            if escaped {
+                escaped = false;
+                if candidate.len() < 128 {
+                    candidate.push(byte);
+                }
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+                if stack.len() == 2 && candidate == key.as_bytes() {
+                    let mut separator = bytes
+                        .by_ref()
+                        .map(|value| value.map_err(|e| e.to_string()))
+                        .find(|value| {
+                            value.as_ref().is_err()
+                                || !value.as_ref().unwrap().is_ascii_whitespace()
+                        })
+                        .transpose()?;
+                    if separator == Some(b':') {
+                        separator = bytes
+                            .by_ref()
+                            .map(|value| value.map_err(|e| e.to_string()))
+                            .find(|value| {
+                                value.as_ref().is_err()
+                                    || !value.as_ref().unwrap().is_ascii_whitespace()
+                            })
+                            .transpose()?;
+                    }
+                    if separator == Some(b'"') {
+                        return capture_json_string(&mut bytes, spool_path).map(Some);
+                    }
+                }
+                candidate.clear();
+            } else if candidate.len() < 128 {
+                candidate.push(byte);
+            }
+        } else if byte == b'"' {
+            candidate.clear();
+            in_string = true;
+        } else if matches!(byte, b'{' | b'[') {
+            if stack.len() >= MAX_JSON_NESTING_DEPTH {
+                return Err(format!(
+                    "oversized JSON envelope nesting exceeds hard limit: {}",
+                    MAX_JSON_NESTING_DEPTH
+                ));
+            }
+            stack.push(if byte == b'{' { b'}' } else { b']' });
+        } else if matches!(byte, b'}' | b']') && stack.pop() != Some(byte) {
+            return Err("mismatched oversized JSON envelope delimiter".to_string());
+        }
+    }
+    Ok(None)
+}
+
+fn extract_json_value_field(
+    path: &Path,
+    key: &str,
+    spool_path: PathBuf,
+) -> Result<Option<SpoolText>, String> {
+    let mut bytes = BufReader::new(File::open(path).map_err(|e| e.to_string())?).bytes();
+    let mut candidate = Vec::new();
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut stack = Vec::new();
+    #[allow(clippy::while_let_on_iterator)]
+    while let Some(byte) = bytes.next() {
+        let byte = byte.map_err(|e| e.to_string())?;
+        if in_string {
+            if escaped {
+                escaped = false;
+                if candidate.len() < 128 {
+                    candidate.push(byte);
+                }
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+                if stack.len() == 2 && candidate == key.as_bytes() {
+                    let separator = bytes
+                        .by_ref()
+                        .map(|value| value.map_err(|e| e.to_string()))
+                        .find(|value| {
+                            value.as_ref().is_err()
+                                || !value.as_ref().unwrap().is_ascii_whitespace()
+                        })
+                        .transpose()?;
+                    if separator == Some(b':') {
+                        let first = bytes
+                            .by_ref()
+                            .map(|value| value.map_err(|e| e.to_string()))
+                            .find(|value| {
+                                value.as_ref().is_err()
+                                    || !value.as_ref().unwrap().is_ascii_whitespace()
+                            })
+                            .transpose()?;
+                        if let Some(first) = first {
+                            return capture_json_value(&mut bytes, first, spool_path).map(Some);
+                        }
+                    }
+                }
+                candidate.clear();
+            } else if candidate.len() < 128 {
+                candidate.push(byte);
+            }
+        } else if byte == b'"' {
+            candidate.clear();
+            in_string = true;
+        } else if matches!(byte, b'{' | b'[') {
+            if stack.len() >= MAX_JSON_NESTING_DEPTH {
+                return Err(format!(
+                    "oversized JSON envelope nesting exceeds hard limit: {}",
+                    MAX_JSON_NESTING_DEPTH
+                ));
+            }
+            stack.push(if byte == b'{' { b'}' } else { b']' });
+        } else if matches!(byte, b'}' | b']') && stack.pop() != Some(byte) {
+            return Err("mismatched oversized JSON envelope delimiter".to_string());
+        }
+    }
+    Ok(None)
+}
+
+fn capture_json_value<I>(bytes: &mut I, first: u8, spool_path: PathBuf) -> Result<SpoolText, String>
+where
+    I: Iterator<Item = std::io::Result<u8>>,
+{
+    let mut spool = SpoolText::new(spool_path);
+    let mut output = Vec::with_capacity(16 * 1024);
+    output.push(first);
+    let mut stack = match first {
+        b'{' => vec![b'}'],
+        b'[' => vec![b']'],
+        _ => Vec::new(),
+    };
+    let mut in_string = first == b'"';
+    let mut escaped = false;
+    let scalar = stack.is_empty() && !in_string;
+    let mut scalar_bytes = usize::from(scalar);
+    for byte in bytes.by_ref() {
+        let byte = byte.map_err(|e| e.to_string())?;
+        if in_string {
+            output.push(byte);
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+                if stack.is_empty() {
+                    flush_utf8_bytes(&mut spool, &mut output, true)?;
+                    return Ok(spool);
+                }
+            }
+        } else if byte == b'"' {
+            in_string = true;
+            output.push(byte);
+        } else if matches!(byte, b'{' | b'[') {
+            if stack.len() >= MAX_JSON_NESTING_DEPTH {
+                return Err(format!(
+                    "oversized JSON value nesting exceeds hard limit: {}",
+                    MAX_JSON_NESTING_DEPTH
+                ));
+            }
+            stack.push(if byte == b'{' { b'}' } else { b']' });
+            output.push(byte);
+        } else if matches!(byte, b'}' | b']') {
+            if stack.is_empty() {
+                if scalar {
+                    flush_utf8_bytes(&mut spool, &mut output, true)?;
+                    return Ok(spool);
+                }
+                return Err("unbalanced oversized JSON value".to_string());
+            }
+            if stack.pop() != Some(byte) {
+                return Err("mismatched oversized JSON value delimiter".to_string());
+            }
+            output.push(byte);
+            if stack.is_empty() {
+                flush_utf8_bytes(&mut spool, &mut output, true)?;
+                return Ok(spool);
+            }
+        } else if scalar && matches!(byte, b',' | b'}' | b']') {
+            while output.last().is_some_and(u8::is_ascii_whitespace) {
+                output.pop();
+            }
+            validate_json_scalar(&output)?;
+            flush_utf8_bytes(&mut spool, &mut output, true)?;
+            return Ok(spool);
+        } else {
+            output.push(byte);
+            if scalar {
+                scalar_bytes += 1;
+                if scalar_bytes > MAX_JSON_SCALAR_BYTES {
+                    return Err(format!(
+                        "oversized JSON scalar exceeds hard limit: {}",
+                        MAX_JSON_SCALAR_BYTES
+                    ));
+                }
+            }
+        }
+        if !scalar && output.len() >= 16 * 1024 {
+            flush_utf8_bytes(&mut spool, &mut output, false)?;
+        }
+    }
+    if scalar {
+        while output.last().is_some_and(u8::is_ascii_whitespace) {
+            output.pop();
+        }
+        validate_json_scalar(&output)?;
+        flush_utf8_bytes(&mut spool, &mut output, true)?;
+        return Ok(spool);
+    }
+    Err("unterminated oversized JSON value".to_string())
+}
+
+fn validate_json_scalar(bytes: &[u8]) -> Result<(), String> {
+    let text = std::str::from_utf8(bytes)
+        .map_err(|e| format!("invalid UTF-8 in oversized JSON scalar: {e}"))?;
+    let value: Value =
+        serde_json::from_str(text).map_err(|e| format!("invalid oversized JSON scalar: {e}"))?;
+    if value.is_array() || value.is_object() || value.is_string() {
+        return Err("invalid oversized JSON scalar".to_string());
+    }
+    Ok(())
+}
+
+fn capture_json_string<I>(bytes: &mut I, spool_path: PathBuf) -> Result<SpoolText, String>
+where
+    I: Iterator<Item = std::io::Result<u8>>,
+{
+    let mut spool = SpoolText::new(spool_path);
+    let mut output = Vec::with_capacity(16 * 1024);
+    let mut escaped = false;
+    let mut unicode: Option<String> = None;
+    let mut high_surrogate = None;
+    for byte in bytes.by_ref() {
+        let byte = byte.map_err(|e| e.to_string())?;
+        if let Some(digits) = unicode.as_mut() {
+            digits.push(byte as char);
+            if digits.len() == 4 {
+                let value = u16::from_str_radix(digits, 16)
+                    .map_err(|e| format!("decode oversized JSON string: {e}"))?;
+                append_json_utf16_unit(&mut output, &mut high_surrogate, value)?;
+                unicode = None;
+                escaped = false;
+            }
+        } else if escaped {
+            if high_surrogate.is_some() && byte != b'u' {
+                return Err("unpaired high surrogate in oversized JSON string".to_string());
+            }
+            match byte {
+                b'"' | b'\\' | b'/' => output.push(byte),
+                b'b' => output.push(8),
+                b'f' => output.push(12),
+                b'n' => output.push(b'\n'),
+                b'r' => output.push(b'\r'),
+                b't' => output.push(b'\t'),
+                b'u' => unicode = Some(String::with_capacity(4)),
+                _ => return Err("invalid escape in oversized JSON string".to_string()),
+            }
+            if byte != b'u' {
+                escaped = false;
+            }
+        } else if byte == b'\\' {
+            escaped = true;
+        } else if byte == b'"' {
+            if high_surrogate.is_some() {
+                return Err("unpaired high surrogate in oversized JSON string".to_string());
+            }
+            flush_utf8_bytes(&mut spool, &mut output, true)?;
+            return Ok(spool);
+        } else {
+            if high_surrogate.is_some() {
+                return Err("unpaired high surrogate in oversized JSON string".to_string());
+            }
+            output.push(byte);
+        }
+        if output.len() >= 16 * 1024 {
+            flush_utf8_bytes(&mut spool, &mut output, false)?;
+        }
+    }
+    Err("unterminated oversized JSON string".to_string())
+}
+
+fn append_json_utf16_unit(
+    output: &mut Vec<u8>,
+    high_surrogate: &mut Option<u16>,
+    value: u16,
+) -> Result<(), String> {
+    if (0xD800..=0xDBFF).contains(&value) {
+        if high_surrogate.replace(value).is_some() {
+            return Err("consecutive high surrogates in oversized JSON string".to_string());
+        }
+        return Ok(());
+    }
+    let scalar = if (0xDC00..=0xDFFF).contains(&value) {
+        let high = high_surrogate
+            .take()
+            .ok_or_else(|| "unpaired low surrogate in oversized JSON string".to_string())?;
+        0x10000 + (((high as u32 - 0xD800) << 10) | (value as u32 - 0xDC00))
+    } else {
+        if high_surrogate.is_some() {
+            return Err("unpaired high surrogate in oversized JSON string".to_string());
+        }
+        value as u32
+    };
+    let ch = char::from_u32(scalar)
+        .ok_or_else(|| "invalid Unicode scalar in oversized JSON string".to_string())?;
+    let mut encoded = [0u8; 4];
+    output.extend_from_slice(ch.encode_utf8(&mut encoded).as_bytes());
+    Ok(())
+}
+
+fn flush_utf8_bytes(
+    spool: &mut SpoolText,
+    output: &mut Vec<u8>,
+    final_chunk: bool,
+) -> Result<(), String> {
+    let valid = match std::str::from_utf8(output) {
+        Ok(_) => output.len(),
+        Err(error) if !final_chunk && error.error_len().is_none() => error.valid_up_to(),
+        Err(error) => return Err(format!("invalid UTF-8 in oversized JSON string: {error}")),
+    };
+    if valid > 0 {
+        let text = std::str::from_utf8(&output[..valid]).map_err(|e| e.to_string())?;
+        spool.append(text)?;
+        output.drain(..valid);
+    }
+    Ok(())
+}
+
+fn preview_file(path: &Path, byte_length: u64) -> Result<String, String> {
+    use std::io::{Seek, SeekFrom};
+
+    let mut file = File::open(path).map_err(|e| format!("open history content preview: {e}"))?;
+    let mut head_bytes = vec![0u8; PREVIEW_HEAD_BYTES.saturating_add(4)];
+    let head_len = file
+        .read(&mut head_bytes)
+        .map_err(|e| format!("read history content preview: {e}"))?;
+    head_bytes.truncate(head_len);
+    let head_text = String::from_utf8_lossy(&head_bytes);
+    let head = safe_utf8_prefix(&head_text, PREVIEW_HEAD_BYTES).to_string();
+
+    let tail_offset = byte_length.saturating_sub((PREVIEW_TAIL_BYTES + 4) as u64);
+    file.seek(SeekFrom::Start(tail_offset))
+        .map_err(|e| format!("seek history content preview: {e}"))?;
+    let mut tail_bytes = Vec::with_capacity((byte_length - tail_offset) as usize);
+    file.read_to_end(&mut tail_bytes)
+        .map_err(|e| format!("read history content preview: {e}"))?;
+    let tail_text = String::from_utf8_lossy(&tail_bytes);
+    let tail = safe_utf8_suffix(&tail_text, PREVIEW_TAIL_BYTES).to_string();
+    let omitted = byte_length.saturating_sub((head.len() + tail.len()) as u64);
+    Ok(format!("{head}\n… {omitted} bytes omitted …\n{tail}"))
+}
+
+fn sanitize_id(value: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn content_from_text_at(
+    run_id: &str,
+    generation_id: &str,
+    blobs_dir: &Path,
+    key: &str,
+    value: &str,
+) -> Result<HistoryContent, String> {
+    if value.len() <= CONTENT_INLINE_LIMIT {
+        return Ok(HistoryContent {
+            preview: value.to_string(),
+            byte_length: value.len() as u64,
+            truncated: false,
+            content_id: None,
+            encoding: "text".to_string(),
+        });
+    }
+    let content_id = sanitize_id(&format!("{run_id}:{generation_id}:{key}"));
+    fs::write(
+        blobs_dir.join(format!("{content_id}.bin")),
+        value.as_bytes(),
+    )
+    .map_err(|e| format!("write history content: {e}"))?;
+    let head = safe_utf8_prefix(value, PREVIEW_HEAD_BYTES);
+    let tail_start = value
+        .ceil_char_boundary(value.len().saturating_sub(PREVIEW_TAIL_BYTES))
+        .max(head.len());
+    Ok(HistoryContent {
+        preview: format!(
+            "{}\n… {} bytes omitted …\n{}",
+            head,
+            tail_start.saturating_sub(head.len()),
+            &value[tail_start..]
+        ),
+        byte_length: value.len() as u64,
+        truncated: true,
+        content_id: Some(content_id),
+        encoding: "text".to_string(),
+    })
+}
+
+fn content_from_spool_at(
+    run_id: &str,
+    generation_id: &str,
+    blobs_dir: &Path,
+    key: &str,
+    mut spool: SpoolText,
+) -> Result<HistoryContent, String> {
+    if spool.file.is_none() {
+        return content_from_text_at(run_id, generation_id, blobs_dir, key, &spool.inline);
+    }
+    if let Some(mut file) = spool.file.take() {
+        file.flush()
+            .map_err(|e| format!("flush history spool: {e}"))?;
+        file.sync_data()
+            .map_err(|e| format!("sync history spool: {e}"))?;
+    }
+    let content_id = sanitize_id(&format!("{run_id}:{generation_id}:{key}"));
+    let blob_path = blobs_dir.join(format!("{content_id}.bin"));
+    fs::rename(&spool.path, &blob_path).map_err(|e| format!("publish history spool: {e}"))?;
+    Ok(HistoryContent {
+        preview: preview_file(&blob_path, spool.byte_length)?,
+        byte_length: spool.byte_length,
+        truncated: true,
+        content_id: Some(content_id),
+        encoding: "text".to_string(),
+    })
+}
+
+fn publish_external_content(
+    run_id: &str,
+    generation_id: &str,
+    blobs_dir: &Path,
+    key: &str,
+    path: &Path,
+    byte_length: u64,
+) -> Result<HistoryContent, String> {
+    let content_id = sanitize_id(&format!("{run_id}:{generation_id}:{key}"));
+    let blob_path = blobs_dir.join(format!("{content_id}.bin"));
+    fs::rename(path, &blob_path).map_err(|e| format!("publish history content: {e}"))?;
+    Ok(HistoryContent {
+        preview: preview_file(&blob_path, byte_length)?,
+        byte_length,
+        truncated: true,
+        content_id: Some(content_id),
+        encoding: "json".to_string(),
+    })
+}
+
+fn bounded_json_at(
+    run_id: &str,
+    generation_id: &str,
+    blobs_dir: &Path,
+    key: &str,
+    value: &Value,
+) -> Result<(Value, Option<HistoryContent>), String> {
+    let encoded = serde_json::to_vec(value).map_err(|e| e.to_string())?;
+    if encoded.len() <= CONTENT_INLINE_LIMIT {
+        return Ok((value.clone(), None));
+    }
+    let content_id = sanitize_id(&format!("{run_id}:{generation_id}:{key}"));
+    fs::write(blobs_dir.join(format!("{content_id}.bin")), &encoded)
+        .map_err(|e| format!("write history json content: {e}"))?;
+    let text = String::from_utf8_lossy(&encoded);
+    let preview = safe_utf8_prefix(&text, PREVIEW_HEAD_BYTES).to_string();
+    Ok((
+        json!({"_truncated": true, "preview": preview}),
+        Some(HistoryContent {
+            preview,
+            byte_length: encoded.len() as u64,
+            truncated: true,
+            content_id: Some(content_id),
+            encoding: "json".to_string(),
+        }),
+    ))
+}
+
+fn bounded_json_spool_at(
+    run_id: &str,
+    generation_id: &str,
+    blobs_dir: &Path,
+    key: &str,
+    spool: SpoolText,
+) -> Result<(Value, Option<HistoryContent>), String> {
+    if spool.file.is_none() {
+        let value = serde_json::from_str(&spool.inline)
+            .map_err(|e| format!("parse extracted oversized JSON value: {e}"))?;
+        return Ok((value, None));
+    }
+    let mut content = content_from_spool_at(run_id, generation_id, blobs_dir, key, spool)?;
+    content.encoding = "json".to_string();
+    Ok((
+        json!({"_truncated":true,"preview":content.preview}),
+        Some(content),
+    ))
+}
+
+#[cfg(not(windows))]
+fn replace_file(source: &Path, destination: &Path) -> Result<(), String> {
+    fs::rename(source, destination).map_err(|e| e.to_string())
+}
+
+#[cfg(windows)]
+fn replace_file(source: &Path, destination: &Path) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+    use windows::core::PCWSTR;
+    use windows::Win32::Storage::FileSystem::{
+        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+    };
+
+    let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+    let destination: Vec<u16> = destination
+        .as_os_str()
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+    unsafe {
+        MoveFileExW(
+            PCWSTR(source.as_ptr()),
+            PCWSTR(destination.as_ptr()),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+        .map_err(|e| e.to_string())
+    }
+}
+
+impl BuildState {
+    fn open_tool_scope(&self, tool_use_id: &str) -> Option<OpenToolScope> {
+        if self.open_tools.contains_key(tool_use_id) {
+            return Some(OpenToolScope::Main);
+        }
+        self.subhistories
+            .iter()
+            .find_map(|(parent_id, subhistory)| {
+                subhistory
+                    .open_tools
+                    .contains_key(tool_use_id)
+                    .then(|| OpenToolScope::Subhistory(parent_id.clone()))
+            })
+    }
+
+    fn open_tool_page(&self, scope: &OpenToolScope, tool_use_id: &str) -> Option<u64> {
+        match scope {
+            OpenToolScope::Main => self.open_tools.get(tool_use_id),
+            OpenToolScope::Subhistory(parent_id) => self
+                .subhistories
+                .get(parent_id)
+                .and_then(|subhistory| subhistory.open_tools.get(tool_use_id)),
+        }
+        .map(|open| open.page_number)
+    }
+
+    fn new(run_id: &str, generation_id: &str, generation_dir: PathBuf) -> Result<Self, String> {
+        let pages_dir = generation_dir.join("pages");
+        let blobs_dir = generation_dir.join("blobs");
+        let spools_dir = generation_dir.join("spools");
+        super::ensure_dir(&pages_dir).map_err(|e| e.to_string())?;
+        super::ensure_dir(&blobs_dir).map_err(|e| e.to_string())?;
+        super::ensure_dir(&spools_dir).map_err(|e| e.to_string())?;
+        Ok(Self {
+            run_id: run_id.to_string(),
+            generation_id: generation_id.to_string(),
+            generation_dir,
+            pages_dir,
+            blobs_dir,
+            pending_message: SpoolText::new(spools_dir.join("assistant-message.bin")),
+            pending_thinking: SpoolText::new(spools_dir.join("assistant-thinking.bin")),
+            spools_dir,
+            page: Vec::new(),
+            page_bytes: 2,
+            page_count: 0,
+            total_entries: 0,
+            total_turns: 0,
+            last_seq: 0,
+            state_events: HashMap::new(),
+            pending_interactions: HashMap::new(),
+            pending_user_inputs: HashMap::new(),
+            pending_message_seq: None,
+            pending_thinking_seq: None,
+            seen_message_ids: HashSet::new(),
+            seen_tool_ids: HashSet::new(),
+            open_tools: HashMap::new(),
+            subhistories: HashMap::new(),
+        })
+    }
+
+    fn reset_pending_streams(&mut self) -> Result<(), String> {
+        self.pending_message.discard()?;
+        self.pending_thinking.discard()?;
+        self.pending_message_seq = None;
+        self.pending_thinking_seq = None;
+        Ok(())
+    }
+
+    fn settle_interrupted_work(&mut self, last_seq: u64, tool_error: &str) -> Result<(), String> {
+        if !self.pending_message.is_empty() || !self.pending_thinking.is_empty() {
+            let seq = match (self.pending_message_seq, self.pending_thinking_seq) {
+                (Some(message), Some(thinking)) => message.min(thinking),
+                (Some(seq), None) | (None, Some(seq)) => seq,
+                (None, None) => last_seq,
+            };
+            log::debug!(
+                "[history] settle interrupted assistant: run_id={}, first_seq={}, last_seq={}",
+                self.run_id,
+                seq,
+                last_seq
+            );
+            let id = format!("assistant-incomplete-{seq}");
+            let content = if self.pending_message.is_empty() {
+                HistoryContent {
+                    preview: String::new(),
+                    byte_length: 0,
+                    truncated: false,
+                    content_id: None,
+                    encoding: "text".to_string(),
+                }
+            } else {
+                let pending = std::mem::replace(
+                    &mut self.pending_message,
+                    SpoolText::new(self.spools_dir.join("assistant-message-next.bin")),
+                );
+                self.content_from_spool(&format!("{id}:text"), pending)?
+            };
+            let thinking = if self.pending_thinking.is_empty() {
+                None
+            } else {
+                let pending = std::mem::replace(
+                    &mut self.pending_thinking,
+                    SpoolText::new(self.spools_dir.join("assistant-thinking-next.bin")),
+                );
+                Some(self.content_from_spool(&format!("{id}:thinking"), pending)?)
+            };
+            self.pending_message_seq = None;
+            self.pending_thinking_seq = None;
+            self.push(HistoryEntry::Assistant {
+                id: id.clone(),
+                anchor_id: id,
+                ts: String::new(),
+                content,
+                thinking,
+                model: None,
+                first_seq: seq,
+                last_seq,
+            })?;
+        }
+        if !self.open_tools.is_empty() {
+            log::debug!(
+                "[history] settle interrupted tools: run_id={}, count={}, last_seq={}",
+                self.run_id,
+                self.open_tools.len(),
+                last_seq
+            );
+        }
+        for (tool_use_id, open) in std::mem::take(&mut self.open_tools) {
+            update_tool_page(&self.pages_dir, open.page_number, &tool_use_id, |entry| {
+                if let HistoryEntry::Tool {
+                    status,
+                    output,
+                    last_seq: entry_last_seq,
+                    ..
+                } = entry
+                {
+                    *status = "error".to_string();
+                    *output = json!({"error":tool_error});
+                    *entry_last_seq = last_seq;
+                }
+                Ok(())
+            })?;
+        }
+        for subhistory in self.subhistories.values_mut() {
+            subhistory.settle_interrupted_work(last_seq, tool_error)?;
+        }
+        Ok(())
+    }
+
+    fn content_from_text(&self, key: &str, value: &str) -> Result<HistoryContent, String> {
+        content_from_text_at(
+            &self.run_id,
+            &self.generation_id,
+            &self.blobs_dir,
+            key,
+            value,
+        )
+    }
+
+    fn content_from_spool(&self, key: &str, spool: SpoolText) -> Result<HistoryContent, String> {
+        content_from_spool_at(
+            &self.run_id,
+            &self.generation_id,
+            &self.blobs_dir,
+            key,
+            spool,
+        )
+    }
+
+    fn bounded_json(
+        &self,
+        key: &str,
+        value: &Value,
+    ) -> Result<(Value, Option<HistoryContent>), String> {
+        bounded_json_at(
+            &self.run_id,
+            &self.generation_id,
+            &self.blobs_dir,
+            key,
+            value,
+        )
+    }
+
+    fn push(&mut self, mut entry: HistoryEntry) -> Result<(), String> {
+        let mut encoded = serde_json::to_vec(&entry).map_err(|e| e.to_string())?;
+        if encoded.len() > ENTRY_BYTE_LIMIT {
+            let first_seq = entry.first_seq();
+            let last_seq = entry.last_seq();
+            let id = format!("oversized-entry-{first_seq}-{last_seq}");
+            let content_id = sanitize_id(&format!("{}:{}:{}", self.run_id, self.generation_id, id));
+            fs::write(self.blobs_dir.join(format!("{content_id}.bin")), &encoded)
+                .map_err(|e| format!("write oversized history entry: {e}"))?;
+            let text = String::from_utf8_lossy(&encoded);
+            entry = HistoryEntry::Placeholder {
+                id: id.clone(),
+                anchor_id: id,
+                ts: String::new(),
+                content: HistoryContent {
+                    preview: safe_utf8_prefix(&text, PREVIEW_HEAD_BYTES).to_string(),
+                    byte_length: encoded.len() as u64,
+                    truncated: true,
+                    content_id: Some(content_id),
+                    encoding: "json".to_string(),
+                },
+                first_seq,
+                last_seq,
+            };
+            encoded = serde_json::to_vec(&entry).map_err(|e| e.to_string())?;
+            log::warn!(
+                "[history] entry projected as placeholder: run_id={}, first_seq={}, last_seq={}, bytes={}",
+                self.run_id,
+                first_seq,
+                last_seq,
+                encoded.len()
+            );
+        }
+        let entry_bytes = encoded.len();
+        if !self.page.is_empty()
+            && (self.page.len() >= PAGE_ENTRY_LIMIT
+                || self.page_bytes.saturating_add(entry_bytes + 1) > PAGE_BYTE_LIMIT)
+        {
+            self.flush_page()?;
+        }
+        self.page_bytes += entry_bytes + 1;
+        self.last_seq = self.last_seq.max(entry.last_seq());
+        self.page.push(entry);
+        self.total_entries += 1;
+        Ok(())
+    }
+
+    fn is_duplicate_identity(&self, kind: &str, event: &Value) -> bool {
+        match kind {
+            "message_complete" => event
+                .get("message_id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| !id.is_empty() && self.seen_message_ids.contains(id)),
+            "tool_start" => event
+                .get("tool_use_id")
+                .and_then(Value::as_str)
+                .is_some_and(|id| !id.is_empty() && self.seen_tool_ids.contains(id)),
+            _ => false,
+        }
+    }
+
+    fn record_identity(&mut self, kind: &str, event: &Value) -> bool {
+        match kind {
+            "message_complete" => event
+                .get("message_id")
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .is_none_or(|id| self.seen_message_ids.insert(id.to_string())),
+            "tool_start" => event
+                .get("tool_use_id")
+                .and_then(Value::as_str)
+                .filter(|id| !id.is_empty())
+                .is_none_or(|id| self.seen_tool_ids.insert(id.to_string())),
+            _ => true,
+        }
+    }
+
+    fn flush_page(&mut self) -> Result<(), String> {
+        if self.page.is_empty() {
+            return Ok(());
+        }
+        self.page_count += 1;
+        let path = self.pages_dir.join(format!("{:08}.json", self.page_count));
+        let body = serde_json::to_vec(&self.page).map_err(|e| e.to_string())?;
+        if body.len() > PAGE_BYTE_LIMIT {
+            return Err(format!("history page exceeds hard limit: {}", body.len()));
+        }
+        fs::write(&path, body).map_err(|e| format!("write {}: {e}", path.display()))?;
+        self.page.clear();
+        self.page_bytes = 2;
+        Ok(())
+    }
+
+    fn handle_event(&mut self, envelope: &Value) -> Result<(), String> {
+        if envelope.get("_bus").and_then(Value::as_bool) != Some(true) {
+            return self.handle_legacy_event(envelope);
+        }
+        let seq = envelope.get("seq").and_then(Value::as_u64).unwrap_or(0);
+        let ts = envelope
+            .get("ts")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let Some(event) = envelope.get("event") else {
+            return Ok(());
+        };
+        let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
+        self.last_seq = self.last_seq.max(seq);
+        let closes_previous_turn = (kind == "user_message"
+            && normalized_parent_tool_use_id(event).is_none())
+            || (kind == "run_state"
+                && matches!(
+                    event.get("state").and_then(Value::as_str),
+                    Some("spawning" | "running" | "idle" | "completed" | "failed" | "stopped")
+                ));
+        if closes_previous_turn {
+            self.settle_interrupted_work(seq, "Turn ended before tool result")?;
+        }
+        // The live reducer treats upstream assistant/tool IDs as idempotency keys. Preserve that
+        // contract across page boundaries so projection entries remain valid Svelte keyed-list
+        // identities even when CLI import appends an overlapping event range.
+        if !self.record_identity(kind, event) {
+            if kind == "message_complete" {
+                if let Some(parent_tool_use_id) = normalized_parent_tool_use_id(event) {
+                    if let Some(subhistory) = self.subhistories.get_mut(parent_tool_use_id) {
+                        subhistory.reset_pending_streams()?;
+                    }
+                } else {
+                    self.reset_pending_streams()?;
+                }
+            }
+            log::debug!(
+                "[history] duplicate event omitted: run_id={}, type={}, seq={}",
+                self.run_id,
+                kind,
+                seq
+            );
+            return Ok(());
+        }
+        if let Some(parent_tool_use_id) = normalized_parent_tool_use_id(event) {
+            return self.handle_subhistory_event(parent_tool_use_id, seq, ts, event);
+        }
+        if kind == "tool_end" {
+            let tool_use_id = event
+                .get("tool_use_id")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if let Some(OpenToolScope::Subhistory(parent_tool_use_id)) =
+                self.open_tool_scope(tool_use_id)
+            {
+                log::debug!(
+                    "[history] route tool_end with missing parent: run_id={}, tool_use_id={}, parent_tool_use_id={}",
+                    self.run_id,
+                    tool_use_id,
+                    parent_tool_use_id
+                );
+                return self.handle_subhistory_event(&parent_tool_use_id, seq, ts, event);
+            }
+        }
+        match kind {
+            "user_message" => {
+                self.total_turns += 1;
+                let text = event.get("text").and_then(Value::as_str).unwrap_or("");
+                let cli_uuid = event
+                    .get("uuid")
+                    .and_then(Value::as_str)
+                    .map(str::to_string);
+                let anchor_id = cli_uuid
+                    .clone()
+                    .or_else(|| {
+                        event
+                            .get("client_uuid")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                    })
+                    .unwrap_or_else(|| format!("user-{seq}"));
+                // A CLI UUID is a rewind anchor, not a render identity: imported overlap can
+                // legitimately repeat it. Sequence-derived IDs retain both user events while
+                // keeping the paged timeline's keyed-list identity globally unique.
+                let id = format!("user-{seq}");
+                let content = self.content_from_text(&format!("user:{id}"), text)?;
+                self.push(HistoryEntry::User {
+                    anchor_id,
+                    id,
+                    ts,
+                    content,
+                    cli_uuid,
+                    attachments: event
+                        .get("attachments")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default(),
+                    first_seq: seq,
+                    last_seq: seq,
+                })?;
+            }
+            "message_delta" if normalized_parent_tool_use_id(event).is_none() => {
+                if self.pending_message_seq.is_none() {
+                    self.pending_message_seq = Some(seq);
+                }
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    self.pending_message.append(text)?;
+                }
+            }
+            "thinking_delta" if normalized_parent_tool_use_id(event).is_none() => {
+                self.pending_thinking_seq.get_or_insert(seq);
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    self.pending_thinking.append(text)?;
+                }
+            }
+            "message_complete" if normalized_parent_tool_use_id(event).is_none() => {
+                let id = event
+                    .get("message_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("assistant-{seq}"));
+                let content = if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    self.content_from_text(&format!("assistant:{id}:text"), text)?
+                } else {
+                    let pending = std::mem::replace(
+                        &mut self.pending_message,
+                        SpoolText::new(self.spools_dir.join("assistant-message.bin")),
+                    );
+                    self.content_from_spool(&format!("assistant:{id}:text"), pending)?
+                };
+                let thinking = if self.pending_thinking.is_empty() {
+                    None
+                } else {
+                    let pending = std::mem::replace(
+                        &mut self.pending_thinking,
+                        SpoolText::new(self.spools_dir.join("assistant-thinking.bin")),
+                    );
+                    Some(self.content_from_spool(&format!("assistant:{id}:thinking"), pending)?)
+                };
+                self.push(HistoryEntry::Assistant {
+                    anchor_id: id.clone(),
+                    id,
+                    ts,
+                    content,
+                    thinking,
+                    model: event
+                        .get("model")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    first_seq: match (self.pending_message_seq, self.pending_thinking_seq) {
+                        (Some(message), Some(thinking)) => message.min(thinking),
+                        (Some(first), None) | (None, Some(first)) => first,
+                        (None, None) => seq,
+                    },
+                    last_seq: seq,
+                })?;
+                self.reset_pending_streams()?;
+            }
+            "tool_start" if normalized_parent_tool_use_id(event).is_none() => {
+                let tool_use_id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if tool_use_id.is_empty() {
+                    return Ok(());
+                }
+                let input_raw = event.get("input").cloned().unwrap_or(Value::Null);
+                let (input, input_content) =
+                    self.bounded_json(&format!("tool:{tool_use_id}:input"), &input_raw)?;
+                let entry = HistoryEntry::Tool {
+                    id: tool_use_id.clone(),
+                    anchor_id: tool_use_id.clone(),
+                    ts,
+                    tool_use_id: tool_use_id.clone(),
+                    tool_name: event
+                        .get("tool_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    status: "running".to_string(),
+                    input,
+                    output: Value::Null,
+                    tool_use_result: None,
+                    input_content,
+                    output_content: None,
+                    result_content: None,
+                    duration_ms: None,
+                    sub_history_id: None,
+                    first_seq: seq,
+                    last_seq: seq,
+                };
+                if self.open_tools.len() >= MAX_OPEN_TOOLS {
+                    return Err(format!(
+                        "history open tool limit exceeded: {}",
+                        MAX_OPEN_TOOLS
+                    ));
+                }
+                let input_stream = event
+                    .get("input")
+                    .filter(|value| !value.is_null())
+                    .is_none()
+                    .then(|| {
+                        SpoolText::new(
+                            self.spools_dir
+                                .join(format!("tool-input-{tool_use_id}.bin")),
+                        )
+                    });
+                // A tool owns its page so completion can atomically patch a bounded record while
+                // preserving tool-start order even when tools finish out of order.
+                self.flush_page()?;
+                self.push(entry)?;
+                self.flush_page()?;
+                self.open_tools.insert(
+                    tool_use_id,
+                    OpenTool {
+                        page_number: self.page_count,
+                        input_stream,
+                        output_stream: None,
+                    },
+                );
+            }
+            "tool_input_delta" if normalized_parent_tool_use_id(event).is_none() => {
+                let tool_use_id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(open) = self.open_tools.get_mut(tool_use_id) {
+                    if open.input_stream.is_none() {
+                        open.input_stream = Some(SpoolText::new(
+                            self.spools_dir
+                                .join(format!("tool-input-{tool_use_id}.bin")),
+                        ));
+                    }
+                    if let Some(partial) = event.get("partial_json").and_then(Value::as_str) {
+                        open.input_stream.as_mut().unwrap().append(partial)?;
+                    }
+                }
+            }
+            "tool_output_delta" if normalized_parent_tool_use_id(event).is_none() => {
+                let tool_use_id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(open) = self.open_tools.get_mut(tool_use_id) {
+                    if open.output_stream.is_none() {
+                        open.output_stream = Some(SpoolText::new(
+                            self.spools_dir
+                                .join(format!("tool-output-{tool_use_id}.bin")),
+                        ));
+                    }
+                    if let Some(delta) = event.get("delta").and_then(Value::as_str) {
+                        open.output_stream.as_mut().unwrap().append(delta)?;
+                    }
+                }
+            }
+            "tool_end" if normalized_parent_tool_use_id(event).is_none() => {
+                let tool_use_id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(mut open) = self.open_tools.remove(tool_use_id) {
+                    let mut streamed_input = None;
+                    if let Some(input_stream) = open.input_stream.take() {
+                        if !input_stream.is_empty() {
+                            let parsed = if input_stream.file.is_none() {
+                                serde_json::from_str::<Value>(&input_stream.inline).ok()
+                            } else {
+                                None
+                            };
+                            let mut input_content = self.content_from_spool(
+                                &format!("tool:{tool_use_id}:input-stream"),
+                                input_stream,
+                            )?;
+                            input_content.encoding = "json".to_string();
+                            let input = parsed.unwrap_or_else(
+                                || json!({"_truncated": true, "preview": input_content.preview}),
+                            );
+                            streamed_input =
+                                Some((input, input_content.truncated.then_some(input_content)));
+                        }
+                    }
+                    let streamed_output =
+                        open.output_stream.take().filter(|spool| !spool.is_empty());
+                    let output_raw = event.get("output").cloned().unwrap_or(Value::Null);
+                    let result_raw = event.get("tool_use_result").cloned();
+                    let (output, output_content) = if output_raw.is_null() {
+                        if let Some(output_stream) = streamed_output {
+                            let content = self.content_from_spool(
+                                &format!("tool:{tool_use_id}:output-stream"),
+                                output_stream,
+                            )?;
+                            (
+                                Value::String(content.preview.clone()),
+                                content.truncated.then_some(content),
+                            )
+                        } else {
+                            (Value::Null, None)
+                        }
+                    } else {
+                        self.bounded_json(&format!("tool:{tool_use_id}:output"), &output_raw)?
+                    };
+                    let (tool_use_result, result_content) = if let Some(result) = result_raw {
+                        let (bounded, content) =
+                            self.bounded_json(&format!("tool:{tool_use_id}:result"), &result)?;
+                        (Some(bounded), content)
+                    } else {
+                        (None, None)
+                    };
+                    update_tool_page(&self.pages_dir, open.page_number, tool_use_id, |entry| {
+                        if let HistoryEntry::Tool {
+                            status,
+                            input,
+                            output: old_output,
+                            tool_use_result: old_result,
+                            input_content,
+                            output_content: old_output_content,
+                            result_content: old_result_content,
+                            duration_ms,
+                            last_seq,
+                            tool_name,
+                            ..
+                        } = entry
+                        {
+                            if let Some((stream_input, stream_content)) = streamed_input {
+                                *input = stream_input;
+                                *input_content = stream_content;
+                            }
+                            *status = event
+                                .get("status")
+                                .and_then(Value::as_str)
+                                .unwrap_or("success")
+                                .to_string();
+                            *old_output = output;
+                            *old_result = tool_use_result;
+                            *old_output_content = output_content;
+                            *old_result_content = result_content;
+                            *duration_ms = event.get("duration_ms").and_then(Value::as_u64);
+                            *last_seq = seq;
+                            if let Some(name) = event.get("tool_name").and_then(Value::as_str) {
+                                if !name.is_empty() {
+                                    *tool_name = name.to_string();
+                                }
+                            }
+                        }
+                        Ok(())
+                    })?;
+                    if event.get("tool_name").and_then(Value::as_str) == Some("AskUserQuestion")
+                        && event.get("status").and_then(Value::as_str) == Some("error")
+                    {
+                        if self.pending_user_inputs.len() >= MAX_PENDING_INTERACTIONS
+                            && !self.pending_user_inputs.contains_key(tool_use_id)
+                        {
+                            return Err(format!(
+                                "history pending user input limit exceeded: {}",
+                                MAX_PENDING_INTERACTIONS
+                            ));
+                        }
+                        self.pending_user_inputs
+                            .insert(tool_use_id.to_string(), open.page_number);
+                    }
+                }
+            }
+            "command_output" => {
+                let text = event.get("content").and_then(Value::as_str).unwrap_or("");
+                let id = format!("command-{seq}");
+                let content = self.content_from_text(&format!("command:{seq}"), text)?;
+                self.push(HistoryEntry::CommandOutput {
+                    anchor_id: id.clone(),
+                    id,
+                    ts,
+                    content,
+                    first_seq: seq,
+                    last_seq: seq,
+                })?;
+            }
+            "session_init" | "run_state" | "usage_update" | "compact_boundary"
+            | "system_status" | "auth_status" | "rate_limit_event" => {
+                let mut bounded = event.clone();
+                bounded["_seq"] = Value::Number(seq.into());
+                bounded["ts"] = Value::String(ts);
+                let encoded = serde_json::to_vec(&bounded).map_err(|e| e.to_string())?;
+                if encoded.len() <= CONTENT_INLINE_LIMIT {
+                    self.state_events.insert(kind.to_string(), bounded);
+                } else {
+                    log::warn!(
+                        "[history] state event omitted from summary: run_id={}, type={}, bytes={}",
+                        self.run_id,
+                        kind,
+                        encoded.len()
+                    );
+                }
+            }
+            "permission_prompt" | "elicitation_prompt" | "hook_callback" => {
+                if kind == "hook_callback"
+                    && event.get("hook_event").and_then(Value::as_str) != Some("PreToolUse")
+                {
+                    return Ok(());
+                }
+                let request_id = event
+                    .get("request_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if !request_id.is_empty() {
+                    let mut bounded = event.clone();
+                    bounded["_seq"] = Value::Number(seq.into());
+                    bounded["ts"] = Value::String(ts);
+                    let encoded = serde_json::to_vec(&bounded).map_err(|e| e.to_string())?;
+                    if encoded.len() <= CONTENT_INLINE_LIMIT {
+                        if self.pending_interactions.len() >= MAX_PENDING_INTERACTIONS
+                            && !self.pending_interactions.contains_key(request_id)
+                        {
+                            return Err(format!(
+                                "history pending interaction limit exceeded: {}",
+                                MAX_PENDING_INTERACTIONS
+                            ));
+                        }
+                        self.pending_interactions
+                            .insert(request_id.to_string(), bounded);
+                    } else {
+                        return Err(format!(
+                            "pending interaction exceeds hard limit: {}",
+                            encoded.len()
+                        ));
+                    }
+                }
+            }
+            // A started response is intentionally non-retryable on recovery: the process can die
+            // after writing to CLI stdin but before recording the resolved/failure terminal fact.
+            "control_cancelled"
+            | "interaction_response_started"
+            | "interaction_response_failed"
+            | "interaction_resolved" => {
+                if let Some(request_id) = event.get("request_id").and_then(Value::as_str) {
+                    let lifecycle_key = format!("interaction:{request_id}");
+                    if (kind == "interaction_response_started"
+                        || kind == "interaction_response_failed")
+                        && self.pending_interactions.contains_key(request_id)
+                    {
+                        let mut bounded = event.clone();
+                        bounded["_seq"] = Value::Number(seq.into());
+                        bounded["ts"] = Value::String(ts.clone());
+                        let encoded = serde_json::to_vec(&bounded).map_err(|e| e.to_string())?;
+                        if encoded.len() > CONTENT_INLINE_LIMIT {
+                            return Err(format!(
+                                "interaction lifecycle event exceeds hard limit: {}",
+                                encoded.len()
+                            ));
+                        }
+                        // Keep the original prompt in pending_interactions so summary replay can
+                        // render a visible non-retryable terminal card before applying this fact.
+                        self.state_events.insert(lifecycle_key, bounded);
+                    } else {
+                        self.pending_interactions.remove(request_id);
+                        self.state_events.remove(&lifecycle_key);
+                    }
+                    let page_number = if kind == "interaction_response_started" {
+                        self.pending_user_inputs.get(request_id).copied()
+                    } else {
+                        self.pending_user_inputs.remove(request_id)
+                    };
+                    if let Some(page_number) = page_number {
+                        let target_status = match kind {
+                            "interaction_response_started" => "response_pending",
+                            "interaction_response_failed" => "response_failed",
+                            "interaction_resolved" => "success",
+                            _ => "error",
+                        };
+                        update_tool_page(&self.pages_dir, page_number, request_id, |entry| {
+                            if let HistoryEntry::Tool { status, .. } = entry {
+                                *status = target_status.to_string();
+                            }
+                            Ok(())
+                        })?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_oversized_event(
+        &mut self,
+        path: PathBuf,
+        byte_length: u64,
+        line_no: usize,
+    ) -> Result<(), String> {
+        let metadata = oversized_metadata(&path)?;
+        let seq = metadata
+            .get("seq")
+            .and_then(Value::as_u64)
+            .unwrap_or(self.last_seq);
+        let ts = metadata
+            .get("ts")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let kind = metadata
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let parent = normalized_parent_tool_use_id(&metadata).map(str::to_string);
+        let mut event = metadata;
+        event["run_id"] = Value::String(self.run_id.clone());
+        let envelope = json!({"_bus":true,"seq":seq,"ts":ts,"event":event});
+        let duplicate_identity = self.is_duplicate_identity(kind.as_str(), &envelope["event"]);
+        if duplicate_identity {
+            // Let the normal handler advance last_seq and emit the omission log, but do not
+            // extract multi-megabyte content into a spool that no projected entry will own.
+            self.handle_event(&envelope)?;
+            fs::remove_file(path).map_err(|e| e.to_string())?;
+            return Ok(());
+        }
+
+        match kind.as_str() {
+            "message_complete" | "user_message" | "command_output" => {
+                let field = if kind == "command_output" {
+                    "content"
+                } else {
+                    "text"
+                };
+                let text = extract_json_string_field(
+                    &path,
+                    field,
+                    self.spools_dir
+                        .join(format!("oversized-text-{line_no}.bin")),
+                )?
+                .ok_or_else(|| format!("oversized {kind} is missing {field}"))?;
+                self.handle_event(&envelope)?;
+                let key = format!("oversized:{kind}:{seq}:text");
+                let content = self.content_from_spool(&key, text)?;
+                let target = if let Some(parent_id) = parent.as_deref() {
+                    self.subhistories
+                        .get_mut(parent_id)
+                        .and_then(|sub| sub.page.last_mut())
+                } else {
+                    self.page.last_mut()
+                };
+                match target {
+                    Some(HistoryEntry::Assistant { content: old, .. })
+                    | Some(HistoryEntry::User { content: old, .. })
+                    | Some(HistoryEntry::CommandOutput { content: old, .. }) => *old = content,
+                    _ => {
+                        return Err(format!(
+                            "oversized {kind} did not create its semantic entry"
+                        ))
+                    }
+                }
+                fs::remove_file(path).map_err(|e| e.to_string())?;
+            }
+            "tool_start" | "tool_end" => {
+                let tool_use_id = envelope["event"]
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| format!("oversized {kind} is missing tool_use_id"))?
+                    .to_string();
+                let input_value = if kind == "tool_start" {
+                    extract_json_value_field(
+                        &path,
+                        "input",
+                        self.spools_dir
+                            .join(format!("oversized-tool-input-{line_no}.bin")),
+                    )?
+                } else {
+                    None
+                };
+                let output_value = if kind == "tool_end" {
+                    extract_json_value_field(
+                        &path,
+                        "output",
+                        self.spools_dir
+                            .join(format!("oversized-tool-output-{line_no}.bin")),
+                    )?
+                } else {
+                    None
+                };
+                let result_value = if kind == "tool_end" {
+                    extract_json_value_field(
+                        &path,
+                        "tool_use_result",
+                        self.spools_dir
+                            .join(format!("oversized-tool-result-{line_no}.bin")),
+                    )?
+                } else {
+                    None
+                };
+                let scope_before = if kind == "tool_end" {
+                    self.open_tool_scope(&tool_use_id)
+                } else {
+                    None
+                };
+                let page_before = scope_before
+                    .as_ref()
+                    .and_then(|scope| self.open_tool_page(scope, &tool_use_id));
+                self.handle_event(&envelope)?;
+                let scope = scope_before.or_else(|| self.open_tool_scope(&tool_use_id));
+                let page_number = page_before.or_else(|| {
+                    scope
+                        .as_ref()
+                        .and_then(|owner| self.open_tool_page(owner, &tool_use_id))
+                });
+                let page_number = page_number
+                    .ok_or_else(|| format!("oversized {kind} has no matching tool entry"))?;
+                let bound_value = |key: &str, spool: SpoolText| {
+                    bounded_json_spool_at(
+                        &self.run_id,
+                        &self.generation_id,
+                        &self.blobs_dir,
+                        key,
+                        spool,
+                    )
+                };
+                let extracted_input = input_value
+                    .map(|spool| {
+                        bound_value(&format!("oversized:input:{tool_use_id}:{seq}"), spool)
+                    })
+                    .transpose()?;
+                let extracted_output = output_value
+                    .map(|spool| {
+                        bound_value(&format!("oversized:output:{tool_use_id}:{seq}"), spool)
+                    })
+                    .transpose()?;
+                let extracted_result = result_value
+                    .map(|spool| {
+                        bound_value(&format!("oversized:result:{tool_use_id}:{seq}"), spool)
+                    })
+                    .transpose()?;
+                let pages_dir = match scope.as_ref() {
+                    Some(OpenToolScope::Subhistory(parent_id)) => self
+                        .subhistories
+                        .get(parent_id)
+                        .map(|subhistory| subhistory.pages_dir.as_path())
+                        .ok_or_else(|| format!("missing subhistory owner: {parent_id}"))?,
+                    _ => self.pages_dir.as_path(),
+                };
+                update_tool_page(pages_dir, page_number, &tool_use_id, |entry| {
+                    if let HistoryEntry::Tool {
+                        input,
+                        output,
+                        input_content,
+                        output_content,
+                        result_content: old_result_content,
+                        tool_use_result,
+                        ..
+                    } = entry
+                    {
+                        if kind == "tool_start" {
+                            if let Some((value, content)) = extracted_input {
+                                *input = value;
+                                *input_content = content;
+                            }
+                        } else {
+                            if let Some((value, content)) = extracted_output {
+                                *output = value;
+                                *output_content = content;
+                            }
+                            if let Some((value, content)) = extracted_result {
+                                *tool_use_result = Some(value);
+                                *old_result_content = content;
+                            }
+                        }
+                    }
+                    Ok(())
+                })?;
+                fs::remove_file(path).map_err(|e| e.to_string())?;
+            }
+            _ => {
+                let id = format!("oversized-line-{line_no}");
+                let content = publish_external_content(
+                    &self.run_id,
+                    &self.generation_id,
+                    &self.blobs_dir,
+                    &id,
+                    &path,
+                    byte_length,
+                )?;
+                self.push(HistoryEntry::Placeholder {
+                    id: id.clone(),
+                    anchor_id: id,
+                    ts,
+                    content,
+                    first_seq: seq,
+                    last_seq: seq,
+                })?;
+            }
+        }
+        self.last_seq = self.last_seq.max(seq);
+        log::warn!(
+            "[history] oversized event projected semantically: run_id={}, line={}, type={}, bytes={}",
+            self.run_id,
+            line_no,
+            kind,
+            byte_length
+        );
+        Ok(())
+    }
+
+    fn handle_subhistory_event(
+        &mut self,
+        parent_tool_use_id: &str,
+        seq: u64,
+        ts: String,
+        event: &Value,
+    ) -> Result<(), String> {
+        let run_id = self.run_id.clone();
+        let generation_id = self.generation_id.clone();
+        let blobs_dir = self.blobs_dir.clone();
+        let subhistories_root = self.generation_dir.join("subhistories");
+        super::ensure_dir(&subhistories_root).map_err(|e| e.to_string())?;
+        if !self.subhistories.contains_key(parent_tool_use_id)
+            && self.subhistories.len() >= MAX_SUBHISTORIES
+        {
+            return Err(format!(
+                "history subhistory limit exceeded: {}",
+                MAX_SUBHISTORIES
+            ));
+        }
+        let child_history_id = sanitize_id(parent_tool_use_id);
+        // Nested sub-agent events name their immediate child tool as the parent. Link that tool to
+        // its independently paged history before borrowing/creating the target subhistory.
+        for owner in self.subhistories.values_mut() {
+            if let Some(open) = owner.open_tools.get(parent_tool_use_id) {
+                update_tool_page(
+                    &owner.pages_dir,
+                    open.page_number,
+                    parent_tool_use_id,
+                    |entry| {
+                        if let HistoryEntry::Tool { sub_history_id, .. } = entry {
+                            *sub_history_id = Some(child_history_id.clone());
+                        }
+                        Ok(())
+                    },
+                )?;
+                break;
+            }
+        }
+        let sub = if let Some(sub) = self.subhistories.get_mut(parent_tool_use_id) {
+            sub
+        } else {
+            let sub = SubHistoryState::new(
+                &subhistories_root,
+                parent_tool_use_id,
+                &run_id,
+                &generation_id,
+                &blobs_dir,
+            )?;
+            self.subhistories
+                .insert(parent_tool_use_id.to_string(), sub);
+            self.subhistories.get_mut(parent_tool_use_id).unwrap()
+        };
+        if let Some(open) = self.open_tools.get(parent_tool_use_id) {
+            update_tool_page(
+                &self.pages_dir,
+                open.page_number,
+                parent_tool_use_id,
+                |entry| {
+                    if let HistoryEntry::Tool { sub_history_id, .. } = entry {
+                        *sub_history_id = Some(sub.id.clone());
+                    }
+                    Ok(())
+                },
+            )?;
+        }
+        let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
+        match kind {
+            "message_delta" => {
+                sub.pending_message_seq.get_or_insert(seq);
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    sub.pending_message.append(text)?;
+                }
+            }
+            "thinking_delta" => {
+                sub.pending_thinking_seq.get_or_insert(seq);
+                if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    sub.pending_thinking.append(text)?;
+                }
+            }
+            "message_complete" => {
+                let id = event
+                    .get("message_id")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .unwrap_or_else(|| format!("sub-assistant-{seq}"));
+                let content = if let Some(text) = event.get("text").and_then(Value::as_str) {
+                    content_from_text_at(
+                        &run_id,
+                        &generation_id,
+                        &blobs_dir,
+                        &format!("sub:{parent_tool_use_id}:{id}:text"),
+                        text,
+                    )?
+                } else {
+                    let pending = std::mem::replace(
+                        &mut sub.pending_message,
+                        SpoolText::new(sub.spools_dir.join("message-next.bin")),
+                    );
+                    content_from_spool_at(
+                        &run_id,
+                        &generation_id,
+                        &blobs_dir,
+                        &format!("sub:{parent_tool_use_id}:{id}:text"),
+                        pending,
+                    )?
+                };
+                let thinking = if sub.pending_thinking.is_empty() {
+                    None
+                } else {
+                    let pending = std::mem::replace(
+                        &mut sub.pending_thinking,
+                        SpoolText::new(sub.spools_dir.join("thinking-next.bin")),
+                    );
+                    Some(content_from_spool_at(
+                        &run_id,
+                        &generation_id,
+                        &blobs_dir,
+                        &format!("sub:{parent_tool_use_id}:{id}:thinking"),
+                        pending,
+                    )?)
+                };
+                let first_seq = sub.pending_message_seq.take().unwrap_or(seq);
+                sub.pending_thinking_seq = None;
+                sub.push(HistoryEntry::Assistant {
+                    id: id.clone(),
+                    anchor_id: id,
+                    ts,
+                    content,
+                    thinking,
+                    model: event
+                        .get("model")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    first_seq,
+                    last_seq: seq,
+                })?;
+                sub.reset_pending_streams()?;
+            }
+            "tool_start" => {
+                let id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if id.is_empty() {
+                    return Ok(());
+                }
+                let input_raw = event.get("input").cloned().unwrap_or(Value::Null);
+                let (input, input_content) = bounded_json_at(
+                    &run_id,
+                    &generation_id,
+                    &blobs_dir,
+                    &format!("sub:{parent_tool_use_id}:{id}:input"),
+                    &input_raw,
+                )?;
+                if sub.open_tools.len() >= MAX_OPEN_TOOLS {
+                    return Err(format!(
+                        "subhistory open tool limit exceeded: {}",
+                        MAX_OPEN_TOOLS
+                    ));
+                }
+                let input_stream = event
+                    .get("input")
+                    .filter(|value| !value.is_null())
+                    .is_none()
+                    .then(|| SpoolText::new(sub.spools_dir.join(format!("tool-input-{id}.bin"))));
+                flush_entries_page(
+                    &mut sub.page,
+                    &mut sub.page_bytes,
+                    &mut sub.page_count,
+                    &sub.pages_dir,
+                )?;
+                sub.push(HistoryEntry::Tool {
+                    id: id.clone(),
+                    anchor_id: id.clone(),
+                    ts,
+                    tool_use_id: id.clone(),
+                    tool_name: event
+                        .get("tool_name")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string(),
+                    status: "running".to_string(),
+                    input,
+                    output: Value::Null,
+                    tool_use_result: None,
+                    input_content,
+                    output_content: None,
+                    result_content: None,
+                    duration_ms: None,
+                    sub_history_id: None,
+                    first_seq: seq,
+                    last_seq: seq,
+                })?;
+                flush_entries_page(
+                    &mut sub.page,
+                    &mut sub.page_bytes,
+                    &mut sub.page_count,
+                    &sub.pages_dir,
+                )?;
+                sub.open_tools.insert(
+                    id.clone(),
+                    OpenTool {
+                        page_number: sub.page_count,
+                        input_stream,
+                        output_stream: None,
+                    },
+                );
+            }
+            "tool_input_delta" => {
+                let id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(open) = sub.open_tools.get_mut(id) {
+                    if open.input_stream.is_none() {
+                        open.input_stream = Some(SpoolText::new(
+                            sub.spools_dir.join(format!("tool-input-{id}.bin")),
+                        ));
+                    }
+                    if let Some(partial) = event.get("partial_json").and_then(Value::as_str) {
+                        open.input_stream.as_mut().unwrap().append(partial)?;
+                    }
+                }
+            }
+            "tool_output_delta" => {
+                let id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(open) = sub.open_tools.get_mut(id) {
+                    if open.output_stream.is_none() {
+                        open.output_stream = Some(SpoolText::new(
+                            sub.spools_dir.join(format!("tool-output-{id}.bin")),
+                        ));
+                    }
+                    if let Some(delta) = event.get("delta").and_then(Value::as_str) {
+                        open.output_stream.as_mut().unwrap().append(delta)?;
+                    }
+                }
+            }
+            "tool_end" => {
+                let id = event
+                    .get("tool_use_id")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                if let Some(mut open) = sub.open_tools.remove(id) {
+                    let mut streamed_input = None;
+                    if let Some(input_stream) = open.input_stream.take() {
+                        if !input_stream.is_empty() {
+                            let parsed = if input_stream.file.is_none() {
+                                serde_json::from_str::<Value>(&input_stream.inline).ok()
+                            } else {
+                                None
+                            };
+                            let mut input_content = content_from_spool_at(
+                                &run_id,
+                                &generation_id,
+                                &blobs_dir,
+                                &format!("sub:{parent_tool_use_id}:{id}:input-stream"),
+                                input_stream,
+                            )?;
+                            input_content.encoding = "json".to_string();
+                            let input = parsed.unwrap_or_else(
+                                || json!({"_truncated": true, "preview": input_content.preview}),
+                            );
+                            streamed_input =
+                                Some((input, input_content.truncated.then_some(input_content)));
+                        }
+                    }
+                    let streamed_output =
+                        open.output_stream.take().filter(|spool| !spool.is_empty());
+                    let output_raw = event.get("output").cloned().unwrap_or(Value::Null);
+                    let (bounded_output, output_content) = if output_raw.is_null() {
+                        if let Some(output_stream) = streamed_output {
+                            let content = content_from_spool_at(
+                                &run_id,
+                                &generation_id,
+                                &blobs_dir,
+                                &format!("sub:{parent_tool_use_id}:{id}:output-stream"),
+                                output_stream,
+                            )?;
+                            (
+                                Value::String(content.preview.clone()),
+                                content.truncated.then_some(content),
+                            )
+                        } else {
+                            (Value::Null, None)
+                        }
+                    } else {
+                        bounded_json_at(
+                            &run_id,
+                            &generation_id,
+                            &blobs_dir,
+                            &format!("sub:{parent_tool_use_id}:{id}:output"),
+                            &output_raw,
+                        )?
+                    };
+                    let (bounded_result, result_content) =
+                        if let Some(result) = event.get("tool_use_result") {
+                            let (bounded, content) = bounded_json_at(
+                                &run_id,
+                                &generation_id,
+                                &blobs_dir,
+                                &format!("sub:{parent_tool_use_id}:{id}:result"),
+                                result,
+                            )?;
+                            (Some(bounded), content)
+                        } else {
+                            (None, None)
+                        };
+                    update_tool_page(&sub.pages_dir, open.page_number, id, |entry| {
+                        if let HistoryEntry::Tool {
+                            status,
+                            input,
+                            output,
+                            tool_use_result,
+                            input_content,
+                            output_content: old_output_content,
+                            result_content: old_result_content,
+                            duration_ms,
+                            last_seq,
+                            ..
+                        } = entry
+                        {
+                            if let Some((stream_input, stream_content)) = streamed_input {
+                                *input = stream_input;
+                                *input_content = stream_content;
+                            }
+                            *status = event
+                                .get("status")
+                                .and_then(Value::as_str)
+                                .unwrap_or("success")
+                                .to_string();
+                            *output = bounded_output;
+                            *tool_use_result = bounded_result;
+                            *old_output_content = output_content;
+                            *old_result_content = result_content;
+                            *duration_ms = event.get("duration_ms").and_then(Value::as_u64);
+                            *last_seq = seq;
+                        }
+                        Ok(())
+                    })?;
+                }
+            }
+            "user_message" => {
+                let id = format!("sub-user-{seq}");
+                let content = content_from_text_at(
+                    &run_id,
+                    &generation_id,
+                    &blobs_dir,
+                    &format!("sub:{parent_tool_use_id}:{id}"),
+                    event.get("text").and_then(Value::as_str).unwrap_or(""),
+                )?;
+                sub.push(HistoryEntry::User {
+                    id: id.clone(),
+                    anchor_id: id,
+                    ts,
+                    content,
+                    cli_uuid: None,
+                    attachments: vec![],
+                    first_seq: seq,
+                    last_seq: seq,
+                })?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_legacy_event(&mut self, event: &Value) -> Result<(), String> {
+        let kind = event.get("type").and_then(Value::as_str).unwrap_or("");
+        let seq = event.get("seq").and_then(Value::as_u64).unwrap_or_else(|| {
+            self.last_seq += 1;
+            self.last_seq
+        });
+        let ts = event
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        let text = event
+            .get("payload")
+            .and_then(|p| p.get("text").or_else(|| p.get("message")))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !matches!(kind, "user" | "assistant" | "stdout" | "stderr") || text.is_empty() {
+            return Ok(());
+        }
+        let id = format!("legacy-{kind}-{seq}");
+        let content = self.content_from_text(&id, text)?;
+        let entry = if kind == "user" {
+            self.total_turns += 1;
+            HistoryEntry::User {
+                id: id.clone(),
+                anchor_id: id,
+                ts,
+                content,
+                cli_uuid: None,
+                attachments: vec![],
+                first_seq: seq,
+                last_seq: seq,
+            }
+        } else if kind == "assistant" {
+            HistoryEntry::Assistant {
+                id: id.clone(),
+                anchor_id: id,
+                ts,
+                content,
+                thinking: None,
+                model: None,
+                first_seq: seq,
+                last_seq: seq,
+            }
+        } else {
+            HistoryEntry::CommandOutput {
+                id: id.clone(),
+                anchor_id: id,
+                ts,
+                content,
+                first_seq: seq,
+                last_seq: seq,
+            }
+        };
+        self.push(entry)
+    }
+
+    fn finish(
+        mut self,
+        source_size: u64,
+        source_mtime_ns: u128,
+        source_prefix_hash: String,
+    ) -> Result<HistoryManifest, String> {
+        self.settle_interrupted_work(self.last_seq, "Session ended before tool result")?;
+        let subhistories = std::mem::take(&mut self.subhistories);
+        for subhistory in subhistories.into_values() {
+            subhistory.finish()?;
+        }
+        self.flush_page()?;
+        let mut state_events: Vec<_> = self.state_events.into_values().collect();
+        state_events.sort_by_key(|event| event.get("_seq").and_then(Value::as_u64).unwrap_or(0));
+        let mut pending_interactions: Vec<_> = self.pending_interactions.into_values().collect();
+        pending_interactions
+            .sort_by_key(|event| event.get("_seq").and_then(Value::as_u64).unwrap_or(0));
+        state_events.extend(pending_interactions);
+        // Lifecycle facts must replay after their prompt. Sorting the two collections separately
+        // and appending prompts last would resurrect a retry button for an uncertain response.
+        state_events.sort_by_key(|event| event.get("_seq").and_then(Value::as_u64).unwrap_or(0));
+        let summary = HistorySummary {
+            run_id: self.run_id.clone(),
+            generation_id: self.generation_id.clone(),
+            page_count: self.page_count,
+            total_entries: self.total_entries,
+            total_turns: self.total_turns,
+            last_seq: self.last_seq,
+            source_size,
+            source_mtime_ns,
+            latest_cursor: (self.page_count > 0)
+                .then(|| cursor(&self.generation_id, self.page_count)),
+            state_events,
+        };
+        let summary_body = serde_json::to_vec(&summary).map_err(|e| e.to_string())?;
+        if summary_body.len() > CONTENT_CHUNK_LIMIT {
+            return Err(format!(
+                "history summary exceeds hard limit: {}",
+                summary_body.len()
+            ));
+        }
+        fs::write(self.generation_dir.join("summary.json"), summary_body)
+            .map_err(|e| e.to_string())?;
+        Ok(HistoryManifest {
+            format_version: FORMAT_VERSION,
+            builder_version: BUILDER_VERSION,
+            generation_id: self.generation_id,
+            source_size,
+            source_mtime_ns,
+            source_prefix_hash,
+            last_seq: self.last_seq,
+            page_count: self.page_count,
+            total_entries: self.total_entries,
+            total_turns: self.total_turns,
+            complete: true,
+        })
+    }
+}
+
+fn current_generation(run_id: &str) -> Result<Option<String>, String> {
+    let path = history_root(run_id).join("current.json");
+    if !path.exists() {
+        return Ok(None);
+    }
+    let body = fs::read(&path).map_err(|e| e.to_string())?;
+    let pointer: CurrentPointer = serde_json::from_slice(&body).map_err(|e| e.to_string())?;
+    Ok(Some(pointer.generation_id))
+}
+
+fn retain_generation(run_id: &str, generation_id: &str) -> Result<(), String> {
+    let path = history_root(run_id)
+        .join("generations")
+        .join(generation_id)
+        .join(".retain");
+    fs::write(&path, PROCESS_RETENTION_ID.as_bytes())
+        .map_err(|e| format!("retain history generation: {e}"))
+}
+
+fn retained_in_this_process(path: &Path) -> bool {
+    fs::read_to_string(path.join(".retain"))
+        .is_ok_and(|value| value == PROCESS_RETENTION_ID.as_str())
+}
+
+fn should_remove_generation(path: &Path, name: &str, current: Option<&str>) -> bool {
+    name.ends_with(".build")
+        || (is_hex_id(name, 32) && current != Some(name) && !retained_in_this_process(path))
+}
+
+fn load_manifest(run_id: &str, generation_id: &str) -> Result<HistoryManifest, String> {
+    if !is_hex_id(generation_id, 32) {
+        return Err("invalid history generation identifier".to_string());
+    }
+    let path = history_root(run_id)
+        .join("generations")
+        .join(generation_id)
+        .join("manifest.json");
+    let body = fs::read(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    serde_json::from_slice(&body).map_err(|e| e.to_string())
+}
+
+fn manifest_matches(run_id: &str, manifest: &HistoryManifest) -> bool {
+    if manifest.format_version != FORMAT_VERSION
+        || manifest.builder_version != BUILDER_VERSION
+        || !manifest.complete
+    {
+        return false;
+    }
+    let allow_append = !run_is_terminal(run_id);
+    manifest_matches_source(&source_path(run_id), manifest, allow_append)
+}
+
+fn run_is_terminal(run_id: &str) -> bool {
+    super::runs::get_run(run_id).is_some_and(|run| {
+        matches!(
+            run.status,
+            crate::models::RunStatus::Completed
+                | crate::models::RunStatus::Failed
+                | crate::models::RunStatus::Stopped
+        )
+    })
+}
+
+fn manifest_matches_source(source: &Path, manifest: &HistoryManifest, allow_append: bool) -> bool {
+    let Ok(meta) = source.metadata() else {
+        return manifest.source_size == 0;
+    };
+    if meta.len() < manifest.source_size || (!allow_append && meta.len() != manifest.source_size) {
+        return false;
+    }
+    // Appends after publication are consumed by bounded catch-up from `source_size`; rebuilding
+    // here would defeat that handoff and retain a new immutable generation on every run load.
+    // For an unchanged-length source, mtime still detects same-size replacement even when the
+    // boundary windows happen to match.
+    if meta.len() == manifest.source_size && modified_ns(&meta) != manifest.source_mtime_ns {
+        return false;
+    }
+    hash_prefix(source, manifest.source_size).ok().as_deref()
+        == Some(manifest.source_prefix_hash.as_str())
+}
+
+fn build_generation(run_id: &str) -> Result<String, String> {
+    let _global_guard = GLOBAL_BUILD_LOCK.lock().map_err(|e| e.to_string())?;
+    let previous_generation = current_generation(run_id).ok().flatten();
+    let root = history_root(run_id);
+    let generations = root.join("generations");
+    super::ensure_dir(&generations).map_err(|e| e.to_string())?;
+    let generation_id = uuid::Uuid::new_v4().simple().to_string();
+    let build_dir = generations.join(format!("{generation_id}.build"));
+    super::ensure_dir(&build_dir).map_err(|e| e.to_string())?;
+    log::debug!(
+        "[history] build start: run_id={}, generation={}",
+        run_id,
+        generation_id
+    );
+    let mut state = BuildState::new(run_id, &generation_id, build_dir.clone())?;
+    // The writer repairs an interrupted tail and captures metadata while holding the same
+    // per-run lock used by append. The lock is released before scanning, but this fixed prefix
+    // can only end after a complete JSONL record; later appends are delivered by catch-up.
+    let snapshot = super::events::global_writer().snapshot(run_id)?;
+    let source_meta = snapshot.metadata;
+    let source_mtime_ns = modified_ns(&source_meta);
+    let terminal = run_is_terminal(run_id);
+    // Terminal runs have no frontend catch-up phase, so their interrupted tail must remain
+    // visible. Active runs defer an open semantic tail and replay it from the safe offset.
+    let projection_size = if terminal {
+        source_meta.len()
+    } else {
+        safe_projection_size(&snapshot.file, source_meta.len(), &state.spools_dir)?
+    };
+    let source_prefix_hash = hash_file_prefix(&snapshot.file, projection_size)?;
+    let mut source_file = snapshot.file;
+    source_file
+        .seek(SeekFrom::Start(0))
+        .map_err(|e| e.to_string())?;
+    if projection_size < source_meta.len() {
+        log::debug!(
+            "[history] active tail deferred to catch-up: run_id={}, source_size={}, projection_size={}",
+            run_id,
+            source_meta.len(),
+            projection_size
+        );
+    }
+    let mut reader = BufReader::new(source_file.take(projection_size));
+    let mut line_no = 0usize;
+    loop {
+        line_no += 1;
+        let oversized_path = state
+            .spools_dir
+            .join(format!("oversized-line-{line_no}.bin"));
+        let line = match read_bounded_line(&mut reader, &oversized_path)? {
+            ScannedLine::Eof => break,
+            ScannedLine::Inline { data, .. } => data,
+            ScannedLine::External {
+                path, byte_length, ..
+            } => {
+                state.handle_oversized_event(path, byte_length, line_no)?;
+                continue;
+            }
+        };
+        let line = match std::str::from_utf8(&line) {
+            Ok(line) => line,
+            Err(e) => {
+                log::warn!(
+                    "[history] invalid utf-8 skipped: run_id={}, line={}, error={}",
+                    run_id,
+                    line_no,
+                    e
+                );
+                continue;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<Value>(line) {
+            Ok(value) => state.handle_event(&value)?,
+            Err(e) => log::warn!(
+                "[history] invalid json skipped: run_id={}, line={}, error={}",
+                run_id,
+                line_no,
+                e
+            ),
+        }
+    }
+    let manifest = state.finish(projection_size, source_mtime_ns, source_prefix_hash)?;
+    fs::write(
+        build_dir.join("manifest.json"),
+        serde_json::to_vec(&manifest).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+    let final_dir = generations.join(&generation_id);
+    fs::rename(&build_dir, &final_dir).map_err(|e| format!("publish generation: {e}"))?;
+    let pointer_tmp = root.join(format!("current.{}.tmp", generation_id));
+    fs::write(
+        &pointer_tmp,
+        serde_json::to_vec(&CurrentPointer {
+            generation_id: generation_id.clone(),
+        })
+        .map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+    let pointer = root.join("current.json");
+    // The old pointer must remain readable until replacement succeeds. Deleting it first would
+    // create a crash window with no published generation, especially on Windows.
+    replace_file(&pointer_tmp, &pointer).map_err(|e| format!("publish current pointer: {e}"))?;
+    if let Some(previous) = previous_generation {
+        retain_generation(run_id, &previous)?;
+    }
+    retain_generation(run_id, &generation_id)?;
+    log::debug!(
+        "[history] build complete: run_id={}, generation={}, pages={}, entries={}",
+        run_id,
+        generation_id,
+        manifest.page_count,
+        manifest.total_entries
+    );
+    cleanup_history(run_id)?;
+    Ok(generation_id)
+}
+
+fn ensure_history_with_refresh(run_id: &str, refresh: bool) -> Result<String, String> {
+    let digest = Sha256::digest(run_id.as_bytes());
+    let shard = digest[0] as usize % BUILD_LOCKS.len();
+    let _guard = BUILD_LOCKS[shard].lock().map_err(|e| e.to_string())?;
+    cleanup_history(run_id)?;
+    if !refresh {
+        if let Ok(Some(generation)) = current_generation(run_id) {
+            if let Ok(manifest) = load_manifest(run_id, &generation) {
+                if manifest_matches(run_id, &manifest) {
+                    log::debug!(
+                        "[history] generation hit: run_id={}, generation={}",
+                        run_id,
+                        generation
+                    );
+                    retain_generation(run_id, &generation)?;
+                    return Ok(generation);
+                }
+            }
+        }
+    } else {
+        log::debug!("[history] forced rebuild: run_id={}", run_id);
+    }
+    build_generation(run_id)
+}
+
+pub fn ensure_history(run_id: &str) -> Result<String, String> {
+    ensure_history_with_refresh(run_id, false)
+}
+
+fn cleanup_history(run_id: &str) -> Result<(), String> {
+    let generations = history_root(run_id).join("generations");
+    if !generations.exists() {
+        return Ok(());
+    }
+    let current = current_generation(run_id).ok().flatten();
+    for entry in fs::read_dir(&generations).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        if !entry.file_type().map_err(|e| e.to_string())?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name().to_string_lossy().to_string();
+        if should_remove_generation(&entry.path(), &name, current.as_deref()) {
+            fs::remove_dir_all(entry.path()).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+pub fn get_summary(run_id: &str, refresh: bool) -> Result<HistorySummary, String> {
+    let generation = ensure_history_with_refresh(run_id, refresh)?;
+    read_summary(run_id, &generation)
+        .or_else(|_| build_generation(run_id).and_then(|rebuilt| read_summary(run_id, &rebuilt)))
+}
+
+fn read_summary(run_id: &str, generation: &str) -> Result<HistorySummary, String> {
+    let path = history_root(run_id)
+        .join("generations")
+        .join(generation)
+        .join("summary.json");
+    let body = fs::read(&path).map_err(|e| e.to_string())?;
+    if body.len() > CONTENT_CHUNK_LIMIT {
+        return Err("history summary exceeds hard limit".to_string());
+    }
+    let summary: HistorySummary = serde_json::from_slice(&body).map_err(|e| e.to_string())?;
+    if summary.page_count > 0 {
+        let latest = history_root(run_id)
+            .join("generations")
+            .join(generation)
+            .join("pages")
+            .join(format!("{:08}.json", summary.page_count));
+        let page = fs::read(&latest).map_err(|e| e.to_string())?;
+        if page.len() > PAGE_BYTE_LIMIT {
+            return Err("history page exceeds hard limit".to_string());
+        }
+        serde_json::from_slice::<Vec<HistoryEntry>>(&page).map_err(|e| e.to_string())?;
+    }
+    Ok(summary)
+}
+
+pub fn get_page(
+    run_id: &str,
+    generation_id: Option<&str>,
+    before_cursor: Option<&str>,
+) -> Result<HistoryPage, String> {
+    let (generation, page) = if let Some(raw) = before_cursor {
+        let (generation, page) = parse_cursor(raw)?;
+        if generation_id.is_some_and(|expected| expected != generation) {
+            return Err("history cursor generation mismatch".to_string());
+        }
+        (
+            generation.to_string(),
+            page.checked_sub(1)
+                .ok_or_else(|| "history cursor has no previous page".to_string())?,
+        )
+    } else {
+        let generation = generation_id
+            .map(str::to_string)
+            .map(Ok)
+            .unwrap_or_else(|| ensure_history(run_id))?;
+        let manifest = load_manifest(run_id, &generation)?;
+        let page = manifest.page_count;
+        (generation, page)
+    };
+    let manifest = load_manifest(run_id, &generation)?;
+    retain_generation(run_id, &generation)?;
+    if page == 0 || page > manifest.page_count {
+        return Err("history page not found".to_string());
+    }
+    let path = history_root(run_id)
+        .join("generations")
+        .join(&generation)
+        .join("pages")
+        .join(format!("{page:08}.json"));
+    let body = fs::read(&path).map_err(|e| e.to_string())?;
+    if body.len() > PAGE_BYTE_LIMIT {
+        return Err("history page exceeds hard limit".to_string());
+    }
+    let entries: Vec<HistoryEntry> = serde_json::from_slice(&body).map_err(|e| e.to_string())?;
+    let first_seq = entries.first().map(HistoryEntry::first_seq).unwrap_or(0);
+    let last_seq = entries.last().map(HistoryEntry::last_seq).unwrap_or(0);
+    Ok(HistoryPage {
+        run_id: run_id.to_string(),
+        generation_id: generation.clone(),
+        entries,
+        page_cursor: cursor(&generation, page),
+        previous_cursor: (page > 1).then(|| cursor(&generation, page)),
+        has_more: page > 1,
+        first_seq,
+        last_seq,
+    })
+}
+
+pub fn get_content_chunk(
+    run_id: &str,
+    generation_id: &str,
+    content_id: &str,
+    offset: u64,
+    max_bytes: usize,
+) -> Result<ContentChunk, String> {
+    if !is_hex_id(generation_id, 32) || !is_hex_id(content_id, 64) {
+        return Err("invalid history content identifier".to_string());
+    }
+    retain_generation(run_id, generation_id)?;
+    let max_bytes = max_bytes.min(CONTENT_CHUNK_LIMIT);
+    if max_bytes == 0 {
+        return Err("max_bytes must be positive".to_string());
+    }
+    let path = history_root(run_id)
+        .join("generations")
+        .join(generation_id)
+        .join("blobs")
+        .join(format!("{content_id}.bin"));
+    let mut file = File::open(&path).map_err(|e| format!("open history content: {e}"))?;
+    let total = file.metadata().map_err(|e| e.to_string())?.len();
+    if offset > total {
+        return Err("history content offset out of range".to_string());
+    }
+    use std::io::{Seek, SeekFrom};
+    file.seek(SeekFrom::Start(offset))
+        .map_err(|e| e.to_string())?;
+    let mut data = vec![0u8; max_bytes.min((total - offset) as usize)];
+    file.read_exact(&mut data).map_err(|e| e.to_string())?;
+    let next_offset = offset + data.len() as u64;
+    use base64::Engine;
+    Ok(ContentChunk {
+        run_id: run_id.to_string(),
+        generation_id: generation_id.to_string(),
+        content_id: content_id.to_string(),
+        offset,
+        next_offset,
+        total_bytes: total,
+        eof: next_offset >= total,
+        data_base64: base64::engine::general_purpose::STANDARD.encode(data),
+    })
+}
+
+pub fn get_subhistory_page(
+    run_id: &str,
+    generation_id: &str,
+    sub_history_id: &str,
+    before_cursor: Option<&str>,
+) -> Result<SubHistoryPage, String> {
+    if !is_hex_id(generation_id, 32) || !is_hex_id(sub_history_id, 64) {
+        return Err("invalid subhistory identifier".to_string());
+    }
+    retain_generation(run_id, generation_id)?;
+    let root = history_root(run_id)
+        .join("generations")
+        .join(generation_id)
+        .join("subhistories")
+        .join(sub_history_id);
+    let manifest: Value =
+        serde_json::from_slice(&fs::read(root.join("manifest.json")).map_err(|e| e.to_string())?)
+            .map_err(|e| e.to_string())?;
+    let page_count = manifest
+        .get("pageCount")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let page = if let Some(raw) = before_cursor {
+        let (cursor_generation, cursor_page) = parse_cursor(raw)?;
+        if cursor_generation != generation_id {
+            return Err("subhistory cursor generation mismatch".to_string());
+        }
+        cursor_page.saturating_sub(1)
+    } else {
+        page_count
+    };
+    if page == 0 || page > page_count {
+        return Err("subhistory page not found".to_string());
+    }
+    let body =
+        fs::read(root.join("pages").join(format!("{page:08}.json"))).map_err(|e| e.to_string())?;
+    if body.len() > PAGE_BYTE_LIMIT {
+        return Err("subhistory page exceeds hard limit".to_string());
+    }
+    Ok(SubHistoryPage {
+        run_id: run_id.to_string(),
+        generation_id: generation_id.to_string(),
+        sub_history_id: sub_history_id.to_string(),
+        entries: serde_json::from_slice(&body).map_err(|e| e.to_string())?,
+        page_cursor: cursor(generation_id, page),
+        previous_cursor: (page > 1).then(|| cursor(generation_id, page)),
+        has_more: page > 1,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn state(temp: &TempDir) -> BuildState {
+        BuildState::new("run-test", "gen-test", temp.path().join("gen")).unwrap()
+    }
+
+    fn page_entries(pages_dir: &Path, page: u64) -> Vec<HistoryEntry> {
+        serde_json::from_slice(&fs::read(pages_dir.join(format!("{page:08}.json"))).unwrap())
+            .unwrap()
+    }
+
+    #[test]
+    fn manifest_accepts_append_only_source_prefix() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        fs::write(&source, b"{\"seq\":1}\n").unwrap();
+        let metadata = source.metadata().unwrap();
+        let source_size = metadata.len();
+        let manifest = HistoryManifest {
+            format_version: FORMAT_VERSION,
+            builder_version: BUILDER_VERSION,
+            generation_id: "0123456789abcdef0123456789abcdef".to_string(),
+            source_size,
+            source_mtime_ns: modified_ns(&metadata),
+            source_prefix_hash: hash_prefix(&source, source_size).unwrap(),
+            last_seq: 1,
+            page_count: 0,
+            total_entries: 0,
+            total_turns: 0,
+            complete: true,
+        };
+
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&source)
+            .unwrap()
+            .write_all(b"{\"seq\":2}\n")
+            .unwrap();
+
+        assert!(manifest_matches_source(&source, &manifest, true));
+        assert!(!manifest_matches_source(&source, &manifest, false));
+
+        let mut replacement = fs::read(&source).unwrap();
+        replacement[1] = b'X';
+        fs::write(&source, replacement).unwrap();
+        assert!(!manifest_matches_source(&source, &manifest, true));
+    }
+
+    #[test]
+    fn manifest_rejects_middle_prefix_mutation_after_append() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        let original = vec![b'a'; 24 * 1024];
+        fs::write(&source, &original).unwrap();
+        let metadata = source.metadata().unwrap();
+        let source_size = metadata.len();
+        let manifest = HistoryManifest {
+            format_version: FORMAT_VERSION,
+            builder_version: BUILDER_VERSION,
+            generation_id: "0123456789abcdef0123456789abcdef".to_string(),
+            source_size,
+            source_mtime_ns: modified_ns(&metadata),
+            source_prefix_hash: hash_prefix(&source, source_size).unwrap(),
+            last_seq: 1,
+            page_count: 0,
+            total_entries: 0,
+            total_turns: 0,
+            complete: true,
+        };
+
+        let mut replacement = original;
+        replacement[12 * 1024] = b'b';
+        replacement.extend_from_slice(b"append");
+        fs::write(&source, replacement).unwrap();
+
+        assert!(!manifest_matches_source(&source, &manifest, true));
+    }
+
+    #[test]
+    fn semantic_boundary_defers_open_main_and_subhistory_work() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        let events = [
+            json!({"_bus":true,"seq":1,"event":{"type":"user_message","text":"question"}}),
+            json!({"_bus":true,"seq":2,"event":{"type":"message_delta","text":"partial"}}),
+            json!({"_bus":true,"seq":3,"event":{"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash"}}),
+            json!({"_bus":true,"seq":4,"event":{"type":"message_delta","parent_tool_use_id":"parent-tool","text":"child partial"}}),
+            json!({"_bus":true,"seq":5,"event":{"type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash"}}),
+        ];
+        let mut body = Vec::new();
+        let mut safe_size = 0u64;
+        for (index, event) in events.iter().enumerate() {
+            serde_json::to_writer(&mut body, event).unwrap();
+            body.push(b'\n');
+            if index == 0 {
+                safe_size = body.len() as u64;
+            }
+        }
+        fs::write(&source, &body).unwrap();
+        let file = File::open(&source).unwrap();
+
+        assert_eq!(
+            safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+            safe_size
+        );
+    }
+
+    #[test]
+    fn semantic_boundary_advances_after_main_and_subhistory_completion() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        let events = [
+            json!({"_bus":true,"seq":1,"event":{"type":"message_delta","text":"partial"}}),
+            json!({"_bus":true,"seq":2,"event":{"type":"message_complete","message_id":"main-message","text":"done"}}),
+            json!({"_bus":true,"seq":3,"event":{"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash"}}),
+            json!({"_bus":true,"seq":4,"event":{"type":"tool_end","tool_use_id":"main-tool","status":"success"}}),
+            json!({"_bus":true,"seq":5,"event":{"type":"message_delta","parent_tool_use_id":"parent-tool","text":"partial"}}),
+            json!({"_bus":true,"seq":6,"event":{"type":"message_complete","parent_tool_use_id":"parent-tool","message_id":"sub-message","text":"done"}}),
+            json!({"_bus":true,"seq":7,"event":{"type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash"}}),
+            json!({"_bus":true,"seq":8,"event":{"type":"tool_end","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","status":"success"}}),
+        ];
+        let mut body = Vec::new();
+        for event in events {
+            serde_json::to_writer(&mut body, &event).unwrap();
+            body.push(b'\n');
+        }
+        fs::write(&source, &body).unwrap();
+        let file = File::open(&source).unwrap();
+
+        assert_eq!(
+            safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+            body.len() as u64
+        );
+    }
+
+    #[test]
+    fn semantic_boundary_handles_each_open_work_kind_independently() {
+        let cases = [
+            (
+                "main-assistant",
+                json!({"_bus":true,"seq":1,"event":{"type":"message_delta","text":"partial"}}),
+                json!({"_bus":true,"seq":2,"event":{"type":"message_complete","message_id":"main-message","text":"done"}}),
+            ),
+            (
+                "main-tool",
+                json!({"_bus":true,"seq":1,"event":{"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash"}}),
+                json!({"_bus":true,"seq":2,"event":{"type":"tool_end","tool_use_id":"main-tool","status":"success"}}),
+            ),
+            (
+                "subhistory-assistant",
+                json!({"_bus":true,"seq":1,"event":{"type":"message_delta","parent_tool_use_id":"parent-tool","text":"partial"}}),
+                json!({"_bus":true,"seq":2,"event":{"type":"message_complete","parent_tool_use_id":"parent-tool","message_id":"sub-message","text":"done"}}),
+            ),
+            (
+                "subhistory-tool",
+                json!({"_bus":true,"seq":1,"event":{"type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash"}}),
+                json!({"_bus":true,"seq":2,"event":{"type":"tool_end","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","status":"success"}}),
+            ),
+        ];
+
+        for (name, started, completed) in cases {
+            let temp = TempDir::new().unwrap();
+            let source = temp.path().join(format!("{name}.jsonl"));
+            let mut body = serde_json::to_vec(&started).unwrap();
+            body.push(b'\n');
+            fs::write(&source, &body).unwrap();
+            let file = File::open(&source).unwrap();
+            assert_eq!(
+                safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+                0,
+                "{name} must remain in catch-up while open"
+            );
+
+            serde_json::to_writer(&mut body, &completed).unwrap();
+            body.push(b'\n');
+            fs::write(&source, &body).unwrap();
+            let file = File::open(&source).unwrap();
+            assert_eq!(
+                safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+                body.len() as u64,
+                "{name} must become publishable after completion"
+            );
+        }
+    }
+
+    #[test]
+    fn main_history_normalizes_absent_null_and_empty_parent_scope() {
+        let parent_representations = [
+            ("absent", None),
+            ("null", Some(Value::Null)),
+            ("empty", Some(Value::String(String::new()))),
+        ];
+
+        for (name, parent) in parent_representations {
+            let temp = TempDir::new().unwrap();
+            let source = temp.path().join(format!("parent-{name}.jsonl"));
+            let mut events = vec![
+                json!({"type":"message_delta","text":"partial"}),
+                json!({"type":"message_complete","message_id":"main-message","text":"done"}),
+                json!({"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash","input":{"command":"pwd"}}),
+                json!({"type":"tool_end","tool_use_id":"main-tool","status":"success","output":{"stdout":"/tmp"}}),
+            ];
+            if let Some(parent) = parent {
+                for event in &mut events {
+                    event
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("parent_tool_use_id".to_string(), parent.clone());
+                }
+            }
+
+            let mut body = Vec::new();
+            for (index, event) in events.iter().enumerate() {
+                serde_json::to_writer(
+                    &mut body,
+                    &json!({"_bus":true,"seq":index + 1,"ts":"t","event":event}),
+                )
+                .unwrap();
+                body.push(b'\n');
+            }
+            fs::write(&source, &body).unwrap();
+            let file = File::open(&source).unwrap();
+            assert_eq!(
+                safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+                body.len() as u64,
+                "{name} parent scope must be publishable after completion"
+            );
+
+            let mut state = state(&temp);
+            for (index, event) in events.into_iter().enumerate() {
+                state
+                    .handle_event(&json!({"_bus":true,"seq":index + 1,"ts":"t","event":event}))
+                    .unwrap();
+            }
+            state.flush_page().unwrap();
+            let mut entries = Vec::new();
+            for page in 1..=state.page_count {
+                entries.extend(page_entries(&state.pages_dir, page));
+            }
+
+            assert!(
+                matches!(
+                    entries.iter().find(|entry| matches!(entry, HistoryEntry::Assistant { id, .. } if id == "main-message")),
+                    Some(HistoryEntry::Assistant { content, last_seq: 2, .. }) if content.preview == "done"
+                ),
+                "{name} parent scope must project the assistant into main history"
+            );
+            assert!(
+                matches!(
+                    entries.iter().find(|entry| matches!(entry, HistoryEntry::Tool { tool_use_id, .. } if tool_use_id == "main-tool")),
+                    Some(HistoryEntry::Tool { status, output, last_seq: 4, .. })
+                        if status == "success" && output["stdout"] == "/tmp"
+                ),
+                "{name} parent scope must project the tool into main history"
+            );
+            assert!(state.subhistories.is_empty());
+        }
+    }
+
+    #[test]
+    fn semantic_boundary_closes_subhistory_tool_when_end_omits_parent() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        let events = [
+            json!({"_bus":true,"seq":1,"event":{"type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash"}}),
+            json!({"_bus":true,"seq":2,"event":{"type":"tool_end","tool_use_id":"child-tool","status":"success"}}),
+        ];
+        let mut body = Vec::new();
+        for event in events {
+            serde_json::to_writer(&mut body, &event).unwrap();
+            body.push(b'\n');
+        }
+        fs::write(&source, &body).unwrap();
+        let file = File::open(&source).unwrap();
+
+        assert_eq!(
+            safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+            body.len() as u64
+        );
+    }
+
+    #[test]
+    fn builder_closes_subhistory_tool_when_end_omits_parent() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash","input":{"command":"pwd"}}),
+            ),
+            (
+                2,
+                json!({"type":"tool_end","tool_use_id":"child-tool","tool_name":"Bash","status":"success","output":{"stdout":"/tmp"}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        let subhistory = state.subhistories.get("parent-tool").unwrap();
+        let entries = page_entries(&subhistory.pages_dir, 1);
+        assert!(matches!(&entries[0], HistoryEntry::Tool {
+            status,
+            output,
+            last_seq: 2,
+            ..
+        } if status == "success" && output["stdout"] == "/tmp"));
+        assert!(subhistory.open_tools.is_empty());
+    }
+
+    #[test]
+    fn semantic_boundary_advances_after_interrupted_turn_and_later_turns() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("events.jsonl");
+        let events = [
+            json!({"_bus":true,"seq":1,"event":{"type":"user_message","text":"first"}}),
+            json!({"_bus":true,"seq":2,"event":{"type":"thinking_delta","text":"partial thought"}}),
+            json!({"_bus":true,"seq":3,"event":{"type":"tool_start","tool_use_id":"abandoned","tool_name":"Bash"}}),
+            json!({"_bus":true,"seq":4,"event":{"type":"run_state","state":"idle"}}),
+            json!({"_bus":true,"seq":5,"event":{"type":"user_message","text":"second"}}),
+            json!({"_bus":true,"seq":6,"event":{"type":"message_complete","message_id":"second-answer","text":"done"}}),
+            json!({"_bus":true,"seq":7,"event":{"type":"run_state","state":"idle"}}),
+        ];
+        let mut body = Vec::new();
+        for event in events {
+            serde_json::to_writer(&mut body, &event).unwrap();
+            body.push(b'\n');
+        }
+        fs::write(&source, &body).unwrap();
+        let file = File::open(&source).unwrap();
+
+        assert_eq!(
+            safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+            body.len() as u64
+        );
+    }
+
+    #[test]
+    fn builder_settles_interrupted_main_and_subhistory_work_at_turn_boundary() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let events = [
+            json!({"type":"user_message","text":"question"}),
+            json!({"type":"message_delta","text":"partial answer"}),
+            json!({"type":"thinking_delta","text":"partial thought"}),
+            json!({"type":"tool_start","tool_use_id":"parent","tool_name":"Agent","input":{}}),
+            json!({"type":"message_delta","parent_tool_use_id":"parent","text":"child partial"}),
+            json!({"type":"tool_start","parent_tool_use_id":"parent","tool_use_id":"child","tool_name":"Bash","input":{}}),
+            json!({"type":"run_state","state":"stopped"}),
+            json!({"type":"user_message","text":"next turn"}),
+            json!({"type":"message_complete","message_id":"next-answer","text":"clean answer"}),
+            json!({"type":"run_state","state":"idle"}),
+        ];
+        for (index, event) in events.into_iter().enumerate() {
+            state
+                .handle_event(&json!({"_bus":true,"seq":index + 1,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        let mut main_entries = Vec::new();
+        for page in 1..=state.page_count {
+            main_entries.extend(page_entries(&state.pages_dir, page));
+        }
+        main_entries.extend(state.page.clone());
+        assert!(matches!(
+            main_entries.iter().find(|entry| matches!(entry, HistoryEntry::Assistant { id, .. } if id == "assistant-incomplete-2")),
+            Some(HistoryEntry::Assistant { content, thinking: Some(thinking), last_seq: 7, .. })
+                if content.preview == "partial answer" && thinking.preview == "partial thought"
+        ));
+        assert!(matches!(
+            main_entries.iter().find(|entry| matches!(entry, HistoryEntry::Tool { tool_use_id, .. } if tool_use_id == "parent")),
+            Some(HistoryEntry::Tool { status, output, last_seq: 7, .. })
+                if status == "error" && output["error"] == "Turn ended before tool result"
+        ));
+        assert!(matches!(
+            main_entries.last(),
+            Some(HistoryEntry::Assistant { id, thinking: None, .. }) if id == "next-answer"
+        ));
+
+        let sub = state.subhistories.get("parent").unwrap();
+        let mut sub_entries = Vec::new();
+        for page in 1..=sub.page_count {
+            sub_entries.extend(page_entries(&sub.pages_dir, page));
+        }
+        sub_entries.extend(sub.page.clone());
+        assert!(matches!(
+            sub_entries.iter().find(|entry| matches!(entry, HistoryEntry::Assistant { id, .. } if id == "sub-assistant-incomplete-5")),
+            Some(HistoryEntry::Assistant { content, last_seq: 7, .. }) if content.preview == "child partial"
+        ));
+        assert!(matches!(
+            sub_entries.iter().find(|entry| matches!(entry, HistoryEntry::Tool { tool_use_id, .. } if tool_use_id == "child")),
+            Some(HistoryEntry::Tool { status, last_seq: 7, .. }) if status == "error"
+        ));
+    }
+
+    #[test]
+    fn content_is_inline_below_limit_and_chunked_above_limit() {
+        let temp = TempDir::new().unwrap();
+        let state = state(&temp);
+        let small = state.content_from_text("small", "hello").unwrap();
+        assert!(!small.truncated);
+        assert_eq!(small.preview, "hello");
+
+        let large = "界".repeat(CONTENT_INLINE_LIMIT);
+        let projected = state.content_from_text("large", &large).unwrap();
+        assert!(projected.truncated);
+        assert!(projected.content_id.is_some());
+        assert!(std::str::from_utf8(projected.preview.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn page_hard_limit_and_cursor_order_are_stable() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for seq in 1..=205 {
+            let id = format!("u-{seq}");
+            state
+                .push(HistoryEntry::User {
+                    id: id.clone(),
+                    anchor_id: id,
+                    ts: String::new(),
+                    content: HistoryContent {
+                        preview: "x".to_string(),
+                        byte_length: 1,
+                        truncated: false,
+                        content_id: None,
+                        encoding: "text".to_string(),
+                    },
+                    cli_uuid: None,
+                    attachments: vec![],
+                    first_seq: seq,
+                    last_seq: seq,
+                })
+                .unwrap();
+        }
+        state.flush_page().unwrap();
+        assert_eq!(state.page_count, 3);
+        for page in 1..=3 {
+            let len = fs::metadata(state.pages_dir.join(format!("{page:08}.json")))
+                .unwrap()
+                .len();
+            assert!(len <= PAGE_BYTE_LIMIT as u64);
+        }
+        let generation = "0123456789abcdef0123456789abcdef";
+        assert_eq!(
+            parse_cursor(&format!("{generation}:3")).unwrap(),
+            (generation, 3)
+        );
+        assert!(parse_cursor("../bad:1").is_err());
+    }
+
+    #[test]
+    fn deltas_fold_into_final_assistant_entry() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"message_delta","run_id":"run-test","text":"hel"}),
+            ),
+            (
+                2,
+                json!({"type":"message_delta","run_id":"run-test","text":"lo"}),
+            ),
+            (
+                3,
+                json!({"type":"thinking_delta","run_id":"run-test","text":"hmm"}),
+            ),
+            (
+                4,
+                json!({"type":"message_complete","run_id":"run-test","message_id":"m1","text":"hello"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        match &state.page[0] {
+            HistoryEntry::Assistant {
+                content,
+                thinking,
+                first_seq,
+                last_seq,
+                ..
+            } => {
+                assert_eq!(content.preview, "hello");
+                assert_eq!(thinking.as_ref().unwrap().preview, "hmm");
+                assert_eq!((*first_seq, *last_seq), (1, 4));
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn imported_overlap_preserves_unique_render_ids_and_reducer_dedup_semantics() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"user_message","uuid":"same-user","text":"hello"}),
+            ),
+            (
+                2,
+                json!({"type":"message_complete","message_id":"same-assistant","text":"first"}),
+            ),
+            (
+                3,
+                json!({"type":"tool_start","tool_use_id":"same-tool","tool_name":"Read","input":{"path":"/first"}}),
+            ),
+            (
+                4,
+                json!({"type":"tool_end","tool_use_id":"same-tool","status":"success","output":{"ok":true}}),
+            ),
+            (
+                5,
+                json!({"type":"command_output","content":"force the first identities onto disk"}),
+            ),
+            (
+                101,
+                json!({"type":"user_message","uuid":"same-user","text":"hello"}),
+            ),
+            (
+                102,
+                json!({"type":"message_complete","message_id":"same-assistant","text":"duplicate"}),
+            ),
+            (
+                103,
+                json!({"type":"tool_start","tool_use_id":"same-tool","tool_name":"Read","input":{"path":"/duplicate"}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+            if seq == 5 {
+                state.flush_page().unwrap();
+            }
+        }
+        state.flush_page().unwrap();
+
+        let mut entries = Vec::new();
+        for page in 1..=state.page_count {
+            entries.extend(page_entries(&state.pages_dir, page));
+        }
+        let ids: Vec<&str> = entries
+            .iter()
+            .map(|entry| match entry {
+                HistoryEntry::User { id, .. }
+                | HistoryEntry::Assistant { id, .. }
+                | HistoryEntry::Tool { id, .. }
+                | HistoryEntry::CommandOutput { id, .. }
+                | HistoryEntry::Placeholder { id, .. } => id.as_str(),
+            })
+            .collect();
+        assert_eq!(ids.len(), ids.iter().copied().collect::<HashSet<_>>().len());
+        assert_eq!(
+            ids,
+            vec![
+                "user-1",
+                "same-assistant",
+                "same-tool",
+                "command-5",
+                "user-101"
+            ]
+        );
+        assert_eq!(state.total_turns, 2);
+        assert!(matches!(&entries[0], HistoryEntry::User {
+            anchor_id,
+            cli_uuid: Some(cli_uuid),
+            ..
+        } if anchor_id == "same-user" && cli_uuid == "same-user"));
+        assert!(
+            matches!(&entries[1], HistoryEntry::Assistant { content, .. }
+            if content.preview == "first")
+        );
+        assert!(
+            matches!(&entries[2], HistoryEntry::Tool { input, status, .. }
+            if input["path"] == "/first" && status == "success")
+        );
+    }
+
+    #[test]
+    fn duplicate_main_completion_discards_streamed_overlap() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let large = "x".repeat(CONTENT_INLINE_LIMIT + 1);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"message_complete","message_id":"same-assistant","text":"first"}),
+            ),
+            (2, json!({"type":"message_delta","text":large})),
+            (
+                3,
+                json!({"type":"thinking_delta","text":"y".repeat(CONTENT_INLINE_LIMIT + 1)}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let message_spool = state.pending_message.path.clone();
+        let thinking_spool = state.pending_thinking.path.clone();
+        assert!(message_spool.exists());
+        assert!(thinking_spool.exists());
+
+        state
+            .handle_event(&json!({
+                "_bus":true,
+                "seq":4,
+                "ts":"t",
+                "event":{"type":"message_complete","message_id":"same-assistant","text":"duplicate"}
+            }))
+            .unwrap();
+        state
+            .settle_interrupted_work(5, "Turn ended before tool result")
+            .unwrap();
+
+        assert_eq!(state.page.len(), 1);
+        assert!(
+            matches!(&state.page[0], HistoryEntry::Assistant { content, .. } if content.preview == "first")
+        );
+        assert!(state.pending_message.is_empty());
+        assert!(state.pending_thinking.is_empty());
+        assert!(!message_spool.exists());
+        assert!(!thinking_spool.exists());
+    }
+
+    #[test]
+    fn duplicate_subhistory_completion_discards_streamed_overlap() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let large = "x".repeat(CONTENT_INLINE_LIMIT + 1);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","tool_use_id":"parent","tool_name":"Task","input":{}}),
+            ),
+            (
+                2,
+                json!({"type":"message_complete","parent_tool_use_id":"parent","message_id":"same-child","text":"first"}),
+            ),
+            (
+                3,
+                json!({"type":"message_delta","parent_tool_use_id":"parent","text":large}),
+            ),
+            (
+                4,
+                json!({"type":"thinking_delta","parent_tool_use_id":"parent","text":"y".repeat(CONTENT_INLINE_LIMIT + 1)}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let subhistory = state.subhistories.get("parent").unwrap();
+        let message_spool = subhistory.pending_message.path.clone();
+        let thinking_spool = subhistory.pending_thinking.path.clone();
+        assert!(message_spool.exists());
+        assert!(thinking_spool.exists());
+
+        state
+            .handle_event(&json!({
+                "_bus":true,
+                "seq":5,
+                "ts":"t",
+                "event":{"type":"message_complete","parent_tool_use_id":"parent","message_id":"same-child","text":"duplicate"}
+            }))
+            .unwrap();
+        let subhistory = state.subhistories.get_mut("parent").unwrap();
+        subhistory
+            .settle_interrupted_work(6, "Turn ended before tool result")
+            .unwrap();
+
+        assert_eq!(subhistory.page.len(), 1);
+        assert!(
+            matches!(&subhistory.page[0], HistoryEntry::Assistant { content, .. } if content.preview == "first")
+        );
+        assert!(subhistory.pending_message.is_empty());
+        assert!(subhistory.pending_thinking.is_empty());
+        assert!(!message_spool.exists());
+        assert!(!thinking_spool.exists());
+    }
+
+    #[test]
+    fn tool_result_updates_single_entry_and_externalizes_large_output() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .handle_event(&json!({"_bus":true,"seq":1,"ts":"t","event":{
+                "type":"tool_start","run_id":"run-test","tool_use_id":"tool-1","tool_name":"Bash","input":{"cmd":"x"}
+            }}))
+            .unwrap();
+        let output = "z".repeat(CONTENT_INLINE_LIMIT + 1);
+        state
+            .handle_event(&json!({"_bus":true,"seq":2,"ts":"t","event":{
+                "type":"tool_end","run_id":"run-test","tool_use_id":"tool-1","tool_name":"Bash","status":"success","output":{"text":output}
+            }}))
+            .unwrap();
+        let entries = page_entries(&state.pages_dir, 1);
+        match &entries[0] {
+            HistoryEntry::Tool {
+                status,
+                output_content,
+                last_seq,
+                ..
+            } => {
+                assert_eq!(status, "success");
+                assert!(output_content.as_ref().unwrap().truncated);
+                assert_eq!(*last_seq, 2);
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn open_tool_survives_page_flush_before_tool_end() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .handle_event(&json!({"_bus":true,"seq":1,"ts":"t","event":{
+                "type":"tool_start","run_id":"run-test","tool_use_id":"tool-1","tool_name":"Bash","input":{"cmd":"x"}
+            }}))
+            .unwrap();
+        for seq in 2..=(PAGE_ENTRY_LIMIT as u64 + 2) {
+            let id = format!("user-{seq}");
+            state
+                .push(HistoryEntry::User {
+                    id: id.clone(),
+                    anchor_id: id,
+                    ts: String::new(),
+                    content: HistoryContent {
+                        preview: "x".to_string(),
+                        byte_length: 1,
+                        truncated: false,
+                        content_id: None,
+                        encoding: "text".to_string(),
+                    },
+                    cli_uuid: None,
+                    attachments: vec![],
+                    first_seq: seq,
+                    last_seq: seq,
+                })
+                .unwrap();
+        }
+        state
+            .handle_event(&json!({"_bus":true,"seq":200,"ts":"t","event":{
+                "type":"tool_end","run_id":"run-test","tool_use_id":"tool-1","status":"success","output":{"text":"done"}
+            }}))
+            .unwrap();
+        let entries = page_entries(&state.pages_dir, 1);
+        match &entries[0] {
+            HistoryEntry::Tool {
+                status,
+                output,
+                last_seq,
+                ..
+            } => {
+                assert_eq!(status, "success");
+                assert_eq!(output, &json!({"text":"done"}));
+                assert_eq!(*last_seq, 200);
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tools_remain_in_start_order_when_they_finish_out_of_order() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, id) in [(1, "first"), (2, "second")] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":{
+                    "type":"tool_start","tool_use_id":id,"tool_name":"Bash","input":{}
+                }}))
+                .unwrap();
+        }
+        for (seq, id) in [(3, "second"), (4, "first")] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":{
+                    "type":"tool_end","tool_use_id":id,"status":"success","output":{}
+                }}))
+                .unwrap();
+        }
+
+        let first = page_entries(&state.pages_dir, 1);
+        let second = page_entries(&state.pages_dir, 2);
+        assert!(
+            matches!(&first[0], HistoryEntry::Tool { tool_use_id, .. } if tool_use_id == "first")
+        );
+        assert!(
+            matches!(&second[0], HistoryEntry::Tool { tool_use_id, .. } if tool_use_id == "second")
+        );
+    }
+
+    #[test]
+    fn claude_streamed_tool_input_is_reconstructed() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","tool_use_id":"tool-1","tool_name":"Bash","input":null}),
+            ),
+            (
+                2,
+                json!({"type":"tool_input_delta","tool_use_id":"tool-1","partial_json":"{\"cmd\":"}),
+            ),
+            (
+                3,
+                json!({"type":"tool_input_delta","tool_use_id":"tool-1","partial_json":"\"echo hi\"}"}),
+            ),
+            (
+                4,
+                json!({"type":"tool_end","tool_use_id":"tool-1","status":"success","output":{}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        let entries = page_entries(&state.pages_dir, 1);
+        assert!(
+            matches!(&entries[0], HistoryEntry::Tool { input, input_content: None, .. } if input == &json!({"cmd":"echo hi"}))
+        );
+    }
+
+    #[test]
+    fn pending_interactions_are_retained_and_resolved_by_request_id() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"permission_prompt","request_id":"permission-1","tool_name":"Bash"}),
+            ),
+            (
+                2,
+                json!({"type":"elicitation_prompt","request_id":"elicitation-1","message":"choose"}),
+            ),
+            (
+                3,
+                json!({"type":"control_cancelled","request_id":"elicitation-1"}),
+            ),
+            (
+                4,
+                json!({"type":"interaction_resolved","request_id":"permission-1"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        assert!(!state.pending_interactions.contains_key("permission-1"));
+        assert!(!state.pending_interactions.contains_key("elicitation-1"));
+    }
+
+    #[test]
+    fn uncertain_interaction_keeps_prompt_and_lifecycle_in_replay_order() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"elicitation_prompt","request_id":"elicitation-1","mcp_server_name":"server","message":"choose"}),
+            ),
+            (
+                2,
+                json!({"type":"interaction_response_started","request_id":"elicitation-1","interaction_kind":"elicitation"}),
+            ),
+            (
+                3,
+                json!({"type":"interaction_response_failed","request_id":"elicitation-1","interaction_kind":"elicitation","error":"flush failed"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        assert!(state.pending_interactions.contains_key("elicitation-1"));
+        let lifecycle = state.state_events.get("interaction:elicitation-1").unwrap();
+        assert_eq!(lifecycle["type"], "interaction_response_failed");
+        assert_eq!(lifecycle["_seq"], 3);
+    }
+
+    #[test]
+    fn summary_replays_uncertain_lifecycle_after_its_prompt() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"hook_callback","request_id":"hook-1","hook_event":"PreToolUse","hook_id":"h","data":{}}),
+            ),
+            (
+                2,
+                json!({"type":"interaction_response_started","request_id":"hook-1","interaction_kind":"hook"}),
+            ),
+            (
+                3,
+                json!({"type":"interaction_response_failed","request_id":"hook-1","interaction_kind":"hook","error":"flush failed"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let source = temp.path().join("events.jsonl");
+        fs::write(&source, b"{}\n").unwrap();
+        let metadata = source.metadata().unwrap();
+        state
+            .finish(
+                metadata.len(),
+                modified_ns(&metadata),
+                hash_prefix(&source, metadata.len()).unwrap(),
+            )
+            .unwrap();
+        let summary: HistorySummary = serde_json::from_slice(
+            &fs::read(temp.path().join("gen").join("summary.json")).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(summary.state_events.len(), 2);
+        assert_eq!(summary.state_events[0]["type"], "hook_callback");
+        assert_eq!(
+            summary.state_events[1]["type"],
+            "interaction_response_failed"
+        );
+    }
+
+    #[test]
+    fn answered_user_input_is_not_restored_as_pending() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","tool_use_id":"question-1","tool_name":"AskUserQuestion","input":{"questions":[]}}),
+            ),
+            (
+                2,
+                json!({"type":"tool_end","tool_use_id":"question-1","tool_name":"AskUserQuestion","status":"error","output":{}}),
+            ),
+            (
+                3,
+                json!({"type":"interaction_response_started","request_id":"question-1","interaction_kind":"user_input"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        let entries = page_entries(&state.pages_dir, 1);
+        assert!(matches!(
+            &entries[0],
+            HistoryEntry::Tool { status, .. } if status == "response_pending"
+        ));
+    }
+
+    #[test]
+    fn failed_user_input_response_is_terminal_error() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","tool_use_id":"question-1","tool_name":"AskUserQuestion","input":{"questions":[]}}),
+            ),
+            (
+                2,
+                json!({"type":"tool_end","tool_use_id":"question-1","tool_name":"AskUserQuestion","status":"error","output":{}}),
+            ),
+            (
+                3,
+                json!({"type":"interaction_response_started","request_id":"question-1","interaction_kind":"user_input"}),
+            ),
+            (
+                4,
+                json!({"type":"interaction_response_failed","request_id":"question-1","interaction_kind":"user_input","error":"closed"}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+
+        assert!(!state.pending_user_inputs.contains_key("question-1"));
+        let entries = page_entries(&state.pages_dir, 1);
+        assert!(matches!(
+            &entries[0],
+            HistoryEntry::Tool { status, .. } if status == "response_failed"
+        ));
+    }
+
+    #[test]
+    fn oversized_json_string_combines_utf16_surrogate_pairs() {
+        let temp = TempDir::new().unwrap();
+        let input = b"\\uD83D\\uDE00\"".iter().copied().map(Ok);
+        let spool =
+            capture_json_string(&mut input.into_iter(), temp.path().join("emoji.bin")).unwrap();
+        assert_eq!(spool.inline, "😀");
+    }
+
+    #[test]
+    fn oversized_json_scanners_reject_excessive_nesting() {
+        let temp = TempDir::new().unwrap();
+        let nested_value = format!(
+            "{}0{}",
+            "[".repeat(MAX_JSON_NESTING_DEPTH + 1),
+            "]".repeat(MAX_JSON_NESTING_DEPTH + 1)
+        );
+        let mut value_bytes = nested_value.bytes().skip(1).map(Ok);
+        let value_error =
+            capture_json_value(&mut value_bytes, b'[', temp.path().join("nested-value.bin"))
+                .unwrap_err();
+        assert!(value_error.contains("nesting exceeds hard limit"));
+
+        let envelope = format!(
+            "{}{{\"input\":0}}{}",
+            "[".repeat(MAX_JSON_NESTING_DEPTH + 1),
+            "]".repeat(MAX_JSON_NESTING_DEPTH + 1)
+        );
+        let envelope_path = temp.path().join("nested-envelope.json");
+        fs::write(&envelope_path, envelope).unwrap();
+        let envelope_error = extract_json_value_field(
+            &envelope_path,
+            "input",
+            temp.path().join("nested-field.bin"),
+        )
+        .unwrap_err();
+        assert!(envelope_error.contains("nesting exceeds hard limit"));
+    }
+
+    #[test]
+    fn oversized_json_scanners_reject_mismatched_envelope_delimiters() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("mismatched-envelope.json");
+        fs::write(&path, r#"{{"event":{"input":[]}]}"#).unwrap();
+        let error =
+            extract_json_value_field(&path, "input", temp.path().join("value.bin")).unwrap_err();
+        assert!(error.contains("mismatched oversized JSON envelope delimiter"));
+    }
+
+    #[test]
+    fn oversized_json_scalar_rejects_invalid_or_unbounded_values() {
+        let temp = TempDir::new().unwrap();
+        let mut invalid = b"oops,".iter().copied().map(Ok);
+        let error =
+            capture_json_value(&mut invalid, b'n', temp.path().join("invalid.bin")).unwrap_err();
+        assert!(error.contains("invalid oversized JSON scalar"));
+
+        let mut huge = (0..=MAX_JSON_SCALAR_BYTES).map(|_| Ok(b'1'));
+        let error = capture_json_value(&mut huge, b'1', temp.path().join("huge.bin")).unwrap_err();
+        assert!(error.contains("scalar exceeds hard limit"));
+    }
+
+    #[test]
+    fn resource_limits_fail_explicitly() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for index in 0..MAX_OPEN_TOOLS {
+            state
+                .handle_event(&json!({"_bus":true,"seq":index + 1,"ts":"t","event":{
+                    "type":"tool_start","tool_use_id":format!("tool-{index}"),"tool_name":"Bash","input":{}
+                }}))
+                .unwrap();
+        }
+        let error = state
+            .handle_event(
+                &json!({"_bus":true,"seq":MAX_OPEN_TOOLS + 1,"ts":"t","event":{
+                    "type":"tool_start","tool_use_id":"overflow","tool_name":"Bash","input":{}
+                }}),
+            )
+            .unwrap_err();
+        assert!(error.contains("open tool limit"));
+    }
+
+    #[test]
+    fn streaming_text_spools_after_inline_limit_without_data_loss() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let part = "界".repeat(CONTENT_INLINE_LIMIT / 3);
+        for seq in 1..=4 {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":{
+                    "type":"message_delta","run_id":"run-test","text":part
+                }}))
+                .unwrap();
+        }
+        assert!(state.pending_message.file.is_some());
+        assert!(state.pending_message.inline.is_empty());
+        let expected_bytes = part.len() as u64 * 4;
+        state
+            .handle_event(&json!({"_bus":true,"seq":5,"ts":"t","event":{
+                "type":"message_complete","run_id":"run-test","message_id":"m1"
+            }}))
+            .unwrap();
+        match state.page.last().unwrap() {
+            HistoryEntry::Assistant { content, .. } => {
+                assert!(content.truncated);
+                assert_eq!(content.byte_length, expected_bytes);
+                let blob = fs::read(
+                    state
+                        .blobs_dir
+                        .join(format!("{}.bin", content.content_id.as_ref().unwrap())),
+                )
+                .unwrap();
+                assert_eq!(blob.len() as u64, expected_bytes);
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_entry_falls_back_to_bounded_placeholder() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .push(HistoryEntry::User {
+                id: "u1".to_string(),
+                anchor_id: "u1".to_string(),
+                ts: String::new(),
+                content: HistoryContent {
+                    preview: "x".to_string(),
+                    byte_length: 1,
+                    truncated: false,
+                    content_id: None,
+                    encoding: "text".to_string(),
+                },
+                cli_uuid: None,
+                attachments: vec![json!({"contentBase64":"x".repeat(ENTRY_BYTE_LIMIT)})],
+                first_seq: 1,
+                last_seq: 1,
+            })
+            .unwrap();
+        assert!(matches!(state.page[0], HistoryEntry::Placeholder { .. }));
+        assert!(serde_json::to_vec(&state.page[0]).unwrap().len() <= ENTRY_BYTE_LIMIT);
+    }
+
+    #[test]
+    fn bounded_line_reader_spools_without_growing_inline_buffer() {
+        let temp = TempDir::new().unwrap();
+        let data = vec![b'x'; PARSE_LINE_LIMIT + 1024];
+        let mut reader = BufReader::with_capacity(4096, data.as_slice());
+        let path = temp.path().join("oversized.bin");
+        match read_bounded_line(&mut reader, &path).unwrap() {
+            ScannedLine::External {
+                path, byte_length, ..
+            } => {
+                assert_eq!(byte_length, data.len() as u64);
+                assert_eq!(fs::metadata(path).unwrap().len(), data.len() as u64);
+            }
+            other => panic!("unexpected line: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn oversized_line_prefix_recovers_envelope_sequence() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("oversized-envelope.json");
+        fs::write(
+            &path,
+            format!(
+                "{{\"_bus\":true,\"seq\":987654,\"event\":{{\"text\":\"{}\"}}}}",
+                "x".repeat(128 * 1024)
+            ),
+        )
+        .unwrap();
+        assert_eq!(oversized_metadata(&path).unwrap()["seq"], 987654);
+    }
+
+    #[test]
+    fn oversized_metadata_ignores_nested_decoys_and_normalizes_parent_scope() {
+        let cases = [
+            ("absent", "", None),
+            ("null", r#","parent_tool_use_id":null"#, None),
+            ("empty", r#","parent_tool_use_id":"""#, None),
+            (
+                "subhistory",
+                r#","parent_tool_use_id":"actual-parent""#,
+                Some("actual-parent"),
+            ),
+        ];
+        for (name, parent_field, expected_parent) in cases {
+            let temp = TempDir::new().unwrap();
+            let path = temp.path().join(format!("metadata-{name}.json"));
+            let line = format!(
+                r#"{{"_bus":true,"seq":42,"event":{{"input":{{"seq":999,"type":"message_complete","status":"error","parent_tool_use_id":"decoy"}},"type":"tool_start","tool_use_id":"real-tool","tool_name":"Bash"{parent_field}}},"ts":"real-ts"}}"#
+            );
+            fs::write(&path, line).unwrap();
+
+            let metadata = oversized_metadata(&path).unwrap();
+            assert_eq!(metadata["seq"], 42, "{name}");
+            assert_eq!(metadata["type"], "tool_start", "{name}");
+            assert_eq!(metadata["tool_use_id"], "real-tool", "{name}");
+            assert_eq!(metadata["ts"], "real-ts", "{name}");
+            assert_eq!(
+                normalized_parent_tool_use_id(&metadata),
+                expected_parent,
+                "{name}"
+            );
+            assert!(metadata.get("status").is_none(), "{name}");
+        }
+    }
+
+    #[test]
+    fn oversized_tool_events_ignore_nested_metadata_decoys() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let start_path = state.spools_dir.join("oversized-decoy-start.bin");
+        let start = format!(
+            r#"{{"_bus":true,"seq":1,"ts":"t","event":{{"input":{{"seq":999,"type":"message_complete","parent_tool_use_id":"decoy","payload":"{}"}},"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash","parent_tool_use_id":""}}}}"#,
+            "x".repeat(PARSE_LINE_LIMIT)
+        );
+        fs::write(&start_path, &start).unwrap();
+        state
+            .handle_oversized_event(start_path, start.len() as u64, 1)
+            .unwrap();
+        assert!(state.open_tools.contains_key("main-tool"));
+        assert!(state.subhistories.is_empty());
+
+        let end_path = state.spools_dir.join("oversized-decoy-end.bin");
+        let end = format!(
+            r#"{{"_bus":true,"seq":2,"ts":"t","event":{{"output":{{"seq":888,"type":"tool_start","status":"error","parent_tool_use_id":"decoy","stdout":"{}"}},"type":"tool_end","tool_use_id":"main-tool","tool_name":"Bash","status":"success","parent_tool_use_id":""}}}}"#,
+            "x".repeat(PARSE_LINE_LIMIT)
+        );
+        fs::write(&end_path, &end).unwrap();
+        state
+            .handle_oversized_event(end_path, end.len() as u64, 2)
+            .unwrap();
+
+        let entries = page_entries(&state.pages_dir, 1);
+        assert!(matches!(&entries[0], HistoryEntry::Tool {
+            status,
+            last_seq: 2,
+            output_content: Some(content),
+            ..
+        } if status == "success" && content.truncated));
+        assert!(state.open_tools.is_empty());
+    }
+
+    #[test]
+    fn oversized_nested_metadata_decoys_do_not_block_safe_projection() {
+        let temp = TempDir::new().unwrap();
+        let start = format!(
+            r#"{{"_bus":true,"seq":1,"ts":"t","event":{{"input":{{"seq":999,"type":"message_complete","status":"error","parent_tool_use_id":"decoy","payload":"{}"}},"type":"tool_start","tool_use_id":"main-tool","tool_name":"Bash"}}}}"#,
+            "x".repeat(PARSE_LINE_LIMIT)
+        );
+        let end = format!(
+            r#"{{"_bus":true,"seq":2,"ts":"t","event":{{"output":{{"seq":888,"type":"tool_start","status":"error","parent_tool_use_id":"decoy","stdout":"{}"}},"type":"tool_end","tool_use_id":"main-tool","tool_name":"Bash","status":"success"}}}}"#,
+            "x".repeat(PARSE_LINE_LIMIT)
+        );
+        let body = format!("{start}\n{end}\n");
+        let path = temp.path().join("events.jsonl");
+        fs::write(&path, &body).unwrap();
+        let file = File::open(path).unwrap();
+
+        assert_eq!(
+            safe_projection_size(&file, body.len() as u64, temp.path()).unwrap(),
+            body.len() as u64
+        );
+    }
+
+    #[test]
+    fn oversized_message_complete_keeps_assistant_semantics() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let path = state.spools_dir.join("oversized-message.bin");
+        let expected = "large answer ".repeat(PARSE_LINE_LIMIT / 6);
+        let line = json!({
+            "_bus":true,
+            "seq":42,
+            "ts":"t",
+            "event":{
+                "type":"message_complete",
+                "run_id":"run-test",
+                "message_id":"message-42",
+                "model":"claude-sonnet-4-5",
+                "text":expected
+            }
+        })
+        .to_string();
+        fs::write(&path, &line).unwrap();
+
+        state
+            .handle_oversized_event(path, line.len() as u64, 1)
+            .unwrap();
+
+        assert_eq!(state.page.len(), 1);
+        match &state.page[0] {
+            HistoryEntry::Assistant {
+                id,
+                content,
+                model,
+                first_seq,
+                last_seq,
+                ..
+            } => {
+                assert_eq!(id, "message-42");
+                assert!(content.truncated);
+                assert_eq!(content.byte_length, expected.len() as u64);
+                assert_eq!(model.as_deref(), Some("claude-sonnet-4-5"));
+                assert_eq!((*first_seq, *last_seq), (42, 42));
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+        assert!(state.pending_message.is_empty());
+    }
+
+    #[test]
+    fn oversized_user_message_keeps_identifiers_and_attachments() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let path = state.spools_dir.join("oversized-user.bin");
+        let expected = "large prompt ".repeat(PARSE_LINE_LIMIT / 6);
+        let attachments = json!([{
+            "name":"screenshot.png",
+            "mime_type":"image/png",
+            "size":12345
+        }]);
+        let line = json!({
+            "_bus":true,
+            "seq":43,
+            "ts":"t",
+            "event":{
+                "type":"user_message",
+                "run_id":"run-test",
+                "uuid":"cli-user-43",
+                "client_uuid":"client-user-43",
+                "attachments":attachments,
+                "text":expected
+            }
+        })
+        .to_string();
+        fs::write(&path, &line).unwrap();
+
+        state
+            .handle_oversized_event(path, line.len() as u64, 1)
+            .unwrap();
+
+        assert!(matches!(&state.page[0], HistoryEntry::User {
+            id,
+            cli_uuid: Some(cli_uuid),
+            attachments: actual_attachments,
+            content,
+            ..
+        } if id == "user-43"
+            && cli_uuid == "cli-user-43"
+            && actual_attachments == attachments.as_array().unwrap()
+            && content.byte_length == expected.len() as u64));
+
+        let client_path = state.spools_dir.join("oversized-client-user.bin");
+        let client_line = json!({
+            "_bus":true,
+            "seq":44,
+            "ts":"t",
+            "event":{
+                "type":"user_message",
+                "run_id":"run-test",
+                "client_uuid":"client-only-44",
+                "attachments":[],
+                "text":expected
+            }
+        })
+        .to_string();
+        fs::write(&client_path, &client_line).unwrap();
+        state
+            .handle_oversized_event(client_path, client_line.len() as u64, 2)
+            .unwrap();
+        assert!(
+            matches!(&state.page[1], HistoryEntry::User { id, cli_uuid: None, .. }
+            if id == "user-44")
+        );
+    }
+
+    #[test]
+    fn oversized_tool_end_updates_existing_tool_without_placeholder() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .handle_event(&json!({"_bus":true,"seq":1,"ts":"t","event":{
+                "type":"tool_start","tool_use_id":"tool-1","tool_name":"Bash","input":{}
+            }}))
+            .unwrap();
+        let path = state.spools_dir.join("oversized-tool.bin");
+        let line = json!({
+            "_bus":true,
+            "seq":2,
+            "ts":"t",
+            "event":{
+                "type":"tool_end",
+                "run_id":"run-test",
+                "tool_use_id":"tool-1",
+                "tool_name":"Bash",
+                "status":"success",
+                "duration_ms":9876,
+                "output":{"stdout":"x".repeat(PARSE_LINE_LIMIT)},
+                "tool_use_result":{"exitCode":0,"detail":"result-only"}
+            }
+        })
+        .to_string();
+        fs::write(&path, &line).unwrap();
+
+        state
+            .handle_oversized_event(path, line.len() as u64, 1)
+            .unwrap();
+
+        let entries = page_entries(&state.pages_dir, 1);
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(&entries[0], HistoryEntry::Tool {
+            tool_name,
+            status,
+            output_content: Some(content),
+            tool_use_result: Some(result),
+            result_content: None,
+            duration_ms: Some(9876),
+            last_seq: 2,
+            ..
+        } if tool_name == "Bash"
+            && status == "success"
+            && content.truncated
+            && result["detail"] == "result-only"
+            && !content.preview.contains("tool_use_id")));
+        assert!(state.open_tools.is_empty());
+    }
+
+    #[test]
+    fn oversized_tool_end_without_parent_updates_subhistory_tool() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .handle_event(&json!({"_bus":true,"seq":1,"ts":"t","event":{
+                "type":"tool_start","parent_tool_use_id":"parent-tool","tool_use_id":"child-tool","tool_name":"Bash","input":{}
+            }}))
+            .unwrap();
+        let path = state.spools_dir.join("oversized-sub-tool.bin");
+        let line = json!({
+            "_bus":true,
+            "seq":2,
+            "ts":"t",
+            "event":{
+                "type":"tool_end",
+                "run_id":"run-test",
+                "tool_use_id":"child-tool",
+                "tool_name":"Bash",
+                "status":"success",
+                "output":{"stdout":"x".repeat(PARSE_LINE_LIMIT)}
+            }
+        })
+        .to_string();
+        fs::write(&path, &line).unwrap();
+
+        state
+            .handle_oversized_event(path, line.len() as u64, 1)
+            .unwrap();
+
+        let subhistory = state.subhistories.get("parent-tool").unwrap();
+        let entries = page_entries(&subhistory.pages_dir, 1);
+        assert!(matches!(&entries[0], HistoryEntry::Tool {
+            status,
+            output_content: Some(content),
+            last_seq: 2,
+            ..
+        } if status == "success" && content.truncated));
+        assert!(subhistory.open_tools.is_empty());
+    }
+
+    #[test]
+    fn history_identifiers_reject_path_like_values() {
+        assert!(parse_cursor("../bad:1").is_err());
+        assert!(parse_cursor("0123456789abcdef0123456789abcdef:1").is_ok());
+        assert!(!is_hex_id("../bad", 32));
+        assert!(!is_hex_id("g123456789abcdef0123456789abcdef", 32));
+    }
+
+    #[test]
+    fn cleanup_keeps_current_and_process_retained_generations_only() {
+        let temp = TempDir::new().unwrap();
+        let current = "0123456789abcdef0123456789abcdef";
+        let retained = "1123456789abcdef0123456789abcdef";
+        let stale = "2123456789abcdef0123456789abcdef";
+        let retained_dir = temp.path().join(retained);
+        fs::create_dir(&retained_dir).unwrap();
+        fs::write(
+            retained_dir.join(".retain"),
+            PROCESS_RETENTION_ID.as_bytes(),
+        )
+        .unwrap();
+
+        assert!(!should_remove_generation(
+            &temp.path().join(current),
+            current,
+            Some(current)
+        ));
+        assert!(!should_remove_generation(
+            &retained_dir,
+            retained,
+            Some(current)
+        ));
+        assert!(should_remove_generation(
+            &temp.path().join(stale),
+            stale,
+            Some(current)
+        ));
+        assert!(should_remove_generation(
+            &temp.path().join("dead.build"),
+            "dead.build",
+            Some(current)
+        ));
+    }
+
+    #[test]
+    fn subagent_events_are_projected_into_independent_pages() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","run_id":"run-test","tool_use_id":"parent-1","tool_name":"Task","input":{"prompt":"work"}}),
+            ),
+            (
+                2,
+                json!({"type":"message_delta","run_id":"run-test","parent_tool_use_id":"parent-1","text":"child "}),
+            ),
+            (
+                3,
+                json!({"type":"message_complete","run_id":"run-test","parent_tool_use_id":"parent-1","message_id":"child-message","text":"child answer"}),
+            ),
+            (
+                4,
+                json!({"type":"tool_end","run_id":"run-test","tool_use_id":"parent-1","tool_name":"Task","status":"success","output":{"result":"done"}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let entries = page_entries(&state.pages_dir, 1);
+        match &entries[0] {
+            HistoryEntry::Tool { sub_history_id, .. } => {
+                assert_eq!(
+                    sub_history_id.as_deref(),
+                    Some(sanitize_id("parent-1").as_str())
+                );
+            }
+            other => panic!("unexpected parent entry: {other:?}"),
+        }
+        let sub = state.subhistories.remove("parent-1").unwrap();
+        assert_eq!(sub.page.len(), 1);
+        assert!(matches!(sub.page[0], HistoryEntry::Assistant { .. }));
+        assert!(sub.pending_message.is_empty());
+        assert!(sub.pending_thinking.is_empty());
+        sub.finish().unwrap();
+        let page = fs::read(
+            state
+                .generation_dir
+                .join("subhistories")
+                .join(sanitize_id("parent-1"))
+                .join("pages/00000001.json"),
+        )
+        .unwrap();
+        assert!(page.len() <= PAGE_BYTE_LIMIT);
+        let entries: Vec<HistoryEntry> = serde_json::from_slice(&page).unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn subhistory_externalizes_large_tool_fields() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        let large = "x".repeat(CONTENT_INLINE_LIMIT + 1024);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","parent_tool_use_id":"parent","tool_use_id":"child","tool_name":"Bash","input":{"command":large}}),
+            ),
+            (
+                2,
+                json!({"type":"tool_end","parent_tool_use_id":"parent","tool_use_id":"child","status":"success","output":{"stdout":large},"tool_use_result":{"data":large}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let sub = state.subhistories.get("parent").unwrap();
+        let entries = page_entries(&sub.pages_dir, 1);
+        match &entries[0] {
+            HistoryEntry::Tool {
+                input_content,
+                output_content,
+                result_content,
+                ..
+            } => {
+                assert!(input_content.as_ref().is_some_and(|v| v.truncated));
+                assert!(output_content.as_ref().is_some_and(|v| v.truncated));
+                assert!(result_content.as_ref().is_some_and(|v| v.truncated));
+                assert!(serde_json::to_vec(&entries[0]).unwrap().len() <= ENTRY_BYTE_LIMIT);
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn subhistory_preserves_unfinished_stream_at_eof() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        state
+            .handle_event(&json!({
+                "_bus":true,"seq":7,"ts":"t",
+                "event":{"type":"message_delta","parent_tool_use_id":"parent","text":"partial answer"}
+            }))
+            .unwrap();
+        let sub = state.subhistories.remove("parent").unwrap();
+        let sub_dir = sub.pages_dir.parent().unwrap().to_path_buf();
+        sub.finish().unwrap();
+        let body = fs::read(sub_dir.join("pages/00000001.json")).unwrap();
+        let entries: Vec<HistoryEntry> = serde_json::from_slice(&body).unwrap();
+        match &entries[0] {
+            HistoryEntry::Assistant {
+                content, first_seq, ..
+            } => {
+                assert_eq!(content.preview, "partial answer");
+                assert_eq!(*first_seq, 7);
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_subhistory_is_linked_from_child_tool() {
+        let temp = TempDir::new().unwrap();
+        let mut state = state(&temp);
+        for (seq, event) in [
+            (
+                1,
+                json!({"type":"tool_start","parent_tool_use_id":"root","tool_use_id":"child","tool_name":"Task","input":{}}),
+            ),
+            (
+                2,
+                json!({"type":"message_delta","parent_tool_use_id":"child","text":"nested"}),
+            ),
+            (
+                3,
+                json!({"type":"tool_end","parent_tool_use_id":"root","tool_use_id":"child","status":"success","output":{}}),
+            ),
+        ] {
+            state
+                .handle_event(&json!({"_bus":true,"seq":seq,"ts":"t","event":event}))
+                .unwrap();
+        }
+        let root = state.subhistories.get("root").unwrap();
+        let entries = page_entries(&root.pages_dir, 1);
+        match &entries[0] {
+            HistoryEntry::Tool { sub_history_id, .. } => {
+                assert_eq!(
+                    sub_history_id.as_deref(),
+                    Some(sanitize_id("child").as_str())
+                );
+            }
+            other => panic!("unexpected entry: {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -9,6 +9,7 @@ pub mod codex_usage;
 pub mod community_skills;
 pub mod events;
 pub mod favorites;
+pub mod history;
 pub mod mcp_registry;
 pub mod plugins;
 pub mod prompt_index;
@@ -17,7 +18,77 @@ pub mod runs;
 pub mod settings;
 pub mod teams;
 
-use std::path::PathBuf;
+use std::fs::{File, OpenOptions};
+use std::path::{Path, PathBuf};
+
+/// Held for the complete application lifetime so every file under `~/.opencovibe` has one writer.
+/// Process-local mutexes in the event and history modules rely on this external invariant.
+pub struct DataDirLock {
+    _file: File,
+}
+
+impl DataDirLock {
+    pub fn acquire() -> Result<Self, String> {
+        let dir = data_dir();
+        ensure_dir(&dir).map_err(|e| format!("create data directory: {e}"))?;
+        Self::acquire_at(&dir.join(".writer.lock"))
+    }
+
+    fn acquire_at(path: &Path) -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            use std::os::fd::AsRawFd;
+
+            let file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .open(path)
+                .map_err(|e| format!("open data writer lock: {e}"))?;
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result != 0 {
+                return Err(format!(
+                    "another OpenCovibe instance is already using {}",
+                    data_dir().display()
+                ));
+            }
+            Ok(Self { _file: file })
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+
+            // A zero share mode makes the open file itself the lifetime lock. Windows releases it
+            // on crash, so a stale marker can never block the next application start.
+            let file = OpenOptions::new()
+                .create(true)
+                .truncate(false)
+                .read(true)
+                .write(true)
+                .share_mode(0)
+                .open(path)
+                .map_err(|_| {
+                    format!(
+                        "another OpenCovibe instance is already using {}",
+                        data_dir().display()
+                    )
+                })?;
+            Ok(Self { _file: file })
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let file = OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(path)
+                .map_err(|e| format!("acquire data writer lock: {e}"))?;
+            Ok(Self { _file: file })
+        }
+    }
+}
 
 pub fn data_dir() -> PathBuf {
     let home = dirs_next().expect("Could not determine home directory");
@@ -92,4 +163,19 @@ pub fn ensure_dir(path: &std::path::Path) -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod data_dir_lock_tests {
+    use super::DataDirLock;
+
+    #[test]
+    fn data_dir_lock_is_exclusive_and_released_on_drop() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("writer.lock");
+        let first = DataDirLock::acquire_at(&path).unwrap();
+        assert!(DataDirLock::acquire_at(&path).is_err());
+        drop(first);
+        DataDirLock::acquire_at(&path).unwrap();
+    }
 }

--- a/src-tauri/src/web_server/broadcaster.rs
+++ b/src-tauri/src/web_server/broadcaster.rs
@@ -89,36 +89,39 @@ impl BroadcastEmitter {
     /// A-class: persist to events.jsonl + Tauri emit + broadcast with seq.
     /// This is the ONLY entry point for bus-event emission.
     pub fn persist_and_emit(&self, run_id: &str, event: &BusEvent) {
-        let ts = crate::models::now_iso();
-        match self.writer.write_bus_event_with_ts(run_id, event, &ts) {
-            Ok(seq) => {
-                log::trace!(
-                    "[emitter] persist_and_emit: run_id={}, seq={}, type={:?}",
-                    run_id,
-                    seq,
-                    event_type_name(event)
-                );
-                let _ = self.app.emit("bus-event", event);
-                let payload = match serde_json::to_value(event) {
-                    Ok(v) => v,
-                    Err(e) => {
-                        log::error!("[emitter] serialize bus-event failed: {}", e);
-                        return;
-                    }
-                };
-                self.broadcaster.send_a(BroadcastMsg {
-                    event_name: "bus-event".to_string(),
-                    payload,
-                    seq: Some(seq),
-                    run_id: Some(run_id.to_string()),
-                });
-            }
-            Err(e) => {
-                log::warn!("[emitter] persist failed for run_id={}: {}", run_id, e);
-                // Still emit to Tauri even if persist failed
-                let _ = self.app.emit("bus-event", event);
-            }
+        if let Err(error) = self.persist_and_emit_durable(run_id, event) {
+            log::warn!("[emitter] persist failed for run_id={}: {}", run_id, error);
+            // Non-critical telemetry keeps the existing realtime degradation behavior. Callers
+            // whose correctness depends on persistence use `persist_and_emit_durable` directly.
+            let _ = self.app.emit("bus-event", event);
         }
+    }
+
+    /// Persist an A-class fact before publishing it and return its durable sequence number.
+    pub fn persist_and_emit_durable(&self, run_id: &str, event: &BusEvent) -> Result<u64, String> {
+        let ts = crate::models::now_iso();
+        let seq = self.writer.write_bus_event_with_ts(run_id, event, &ts)?;
+        log::trace!(
+            "[emitter] persist_and_emit: run_id={}, seq={}, type={:?}",
+            run_id,
+            seq,
+            event_type_name(event)
+        );
+        let mut payload =
+            serde_json::to_value(event).map_err(|e| format!("serialize bus-event failed: {e}"))?;
+        if let Some(object) = payload.as_object_mut() {
+            // Tauri has no subscription replay envelope, so carry the same durable checkpoint
+            // that WebSocket clients receive. This closes load/catch-up dedup on desktop.
+            object.insert("_seq".to_string(), Value::Number(seq.into()));
+        }
+        let _ = self.app.emit("bus-event", &payload);
+        self.broadcaster.send_a(BroadcastMsg {
+            event_name: "bus-event".to_string(),
+            payload,
+            seq: Some(seq),
+            run_id: Some(run_id.to_string()),
+        });
+        Ok(seq)
     }
 
     /// B-class: Tauri emit + broadcast (no persist, no seq).
@@ -195,6 +198,9 @@ fn event_type_name(event: &BusEvent) -> &'static str {
         BusEvent::ToolUseSummary { .. } => "tool_use_summary",
         BusEvent::FilesPersisted { .. } => "files_persisted",
         BusEvent::ControlCancelled { .. } => "control_cancelled",
+        BusEvent::InteractionResponseStarted { .. } => "interaction_response_started",
+        BusEvent::InteractionResponseFailed { .. } => "interaction_response_failed",
+        BusEvent::InteractionResolved { .. } => "interaction_resolved",
         BusEvent::CommandOutput { .. } => "command_output",
         BusEvent::ElicitationPrompt { .. } => "elicitation_prompt",
         BusEvent::RateLimitEvent { .. } => "rate_limit_event",

--- a/src-tauri/src/web_server/dispatch.rs
+++ b/src-tauri/src/web_server/dispatch.rs
@@ -165,6 +165,95 @@ pub async fn dispatch_command(
             let events = crate::storage::events::list_bus_events(&id, since_seq);
             Ok(Value::Array(events))
         }
+        "get_bus_events_page" => {
+            let id = extract_str(&params, "id")?;
+            let since_seq = extract_u64(&params, "since_seq")?;
+            let offset = params.get("offset").and_then(|value| value.as_u64());
+            crate::storage::runs::get_run(&id).ok_or_else(|| format!("Run {} not found", id))?;
+            let page = crate::storage::events::list_bus_events_page(&id, since_seq, offset)?;
+            serde_json::to_value(page).map_err(|e| e.to_string())
+        }
+        "get_history_summary" => {
+            let run_id = extract_str(&params, "run_id")?;
+            let refresh = params
+                .get("refresh")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            crate::storage::runs::get_run(&run_id)
+                .ok_or_else(|| format!("Run {run_id} not found"))?;
+            let result = tokio::task::spawn_blocking(move || {
+                crate::storage::history::get_summary(&run_id, refresh)
+            })
+            .await
+            .map_err(|e| format!("history build task failed: {e}"))??;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+        "get_history_page" => {
+            let run_id = extract_str(&params, "run_id")?;
+            let generation_id = params
+                .get("generation_id")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let before_cursor = params
+                .get("before_cursor")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            crate::storage::runs::get_run(&run_id)
+                .ok_or_else(|| format!("Run {run_id} not found"))?;
+            let result = tokio::task::spawn_blocking(move || {
+                crate::storage::history::get_page(
+                    &run_id,
+                    generation_id.as_deref(),
+                    before_cursor.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| format!("history page task failed: {e}"))??;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+        "get_history_content_chunk" => {
+            let run_id = extract_str(&params, "run_id")?;
+            let generation_id = extract_str(&params, "generation_id")?;
+            let content_id = extract_str(&params, "content_id")?;
+            let offset = extract_u64(&params, "offset")?;
+            let max_bytes = extract_u64(&params, "max_bytes")? as usize;
+            crate::storage::runs::get_run(&run_id)
+                .ok_or_else(|| format!("Run {run_id} not found"))?;
+            let result = tokio::task::spawn_blocking(move || {
+                crate::storage::history::get_content_chunk(
+                    &run_id,
+                    &generation_id,
+                    &content_id,
+                    offset,
+                    max_bytes,
+                )
+            })
+            .await
+            .map_err(|e| format!("history content task failed: {e}"))??;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
+        "get_subhistory_page" => {
+            let run_id = extract_str(&params, "run_id")?;
+            let generation_id = extract_str(&params, "generation_id")?;
+            let sub_history_id = extract_str(&params, "sub_history_id")?;
+            let before_cursor = params
+                .get("before_cursor")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            crate::storage::runs::get_run(&run_id)
+                .ok_or_else(|| format!("Run {run_id} not found"))?;
+            let result = tokio::task::spawn_blocking(move || {
+                crate::storage::history::get_subhistory_page(
+                    &run_id,
+                    &generation_id,
+                    &sub_history_id,
+                    before_cursor.as_deref(),
+                )
+            })
+            .await
+            .map_err(|e| format!("subhistory page task failed: {e}"))??;
+            serde_json::to_value(result).map_err(|e| e.to_string())
+        }
 
         // ── Artifacts ──
         "get_run_artifacts" => {

--- a/src-tauri/src/web_server/ws.rs
+++ b/src-tauri/src/web_server/ws.rs
@@ -7,6 +7,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -16,8 +17,6 @@ use crate::web_server::state::AppState;
 
 /// Max events to buffer during replay before triggering _full_reload
 const REPLAY_BUFFER_CAPACITY: usize = 4096;
-/// Minimum interval between _full_reload signals per run (seconds)
-const FULL_RELOAD_COOLDOWN_SECS: u64 = 30;
 
 type WsSink = Arc<Mutex<futures_util::stream::SplitSink<WebSocket, Message>>>;
 
@@ -50,6 +49,38 @@ struct BufferedEvent {
     seq: u64,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum ReplayError {
+    ProjectionRequired(String),
+    Catchup(String),
+    SendFailed,
+}
+
+impl ReplayError {
+    fn catchup(error: String) -> Self {
+        if error.contains(crate::storage::events::HISTORY_PROJECTION_REQUIRED) {
+            Self::ProjectionRequired(error)
+        } else {
+            Self::Catchup(error)
+        }
+    }
+}
+
+impl fmt::Display for ReplayError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ProjectionRequired(error) | Self::Catchup(error) => formatter.write_str(error),
+            Self::SendFailed => formatter.write_str("WS send failed during replay"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum FlushError {
+    Overflow,
+    SendFailed,
+}
+
 /// Per-connection WS session state
 struct WsSession {
     /// run_id → last_seq checkpoint for each subscribed run
@@ -58,8 +89,8 @@ struct WsSession {
     replay_buffer: HashMap<String, Vec<BufferedEvent>>,
     /// run_id set currently being replayed (reentry guard)
     replaying: std::collections::HashSet<String>,
-    /// Timestamp of last _full_reload signal per run_id (cooldown)
-    full_reload_cooldown: HashMap<String, std::time::Instant>,
+    /// Runs waiting for the client to rebuild history and subscribe again
+    full_reload_pending: std::collections::HashSet<String>,
 }
 
 impl WsSession {
@@ -68,29 +99,45 @@ impl WsSession {
             subscriptions: HashMap::new(),
             replay_buffer: HashMap::new(),
             replaying: std::collections::HashSet::new(),
-            full_reload_cooldown: HashMap::new(),
+            full_reload_pending: std::collections::HashSet::new(),
+        }
+    }
+
+    fn begin_full_reload(&mut self, run_id: &str) -> bool {
+        self.replay_buffer.remove(run_id);
+        self.replaying.remove(run_id);
+        // Keep the subscription active while the client rebuilds history so live events enter
+        // its history-load buffer and are deduplicated against the rebuilt checkpoint.
+        self.full_reload_pending.insert(run_id.to_string())
+    }
+
+    fn complete_replay(&mut self, run_id: &str, last_replayed_seq: u64) {
+        if let Some(checkpoint) = self.subscriptions.get_mut(run_id) {
+            *checkpoint = (*checkpoint).max(last_replayed_seq);
         }
     }
 }
 
 /// Send an RPC result response over WebSocket
-async fn send_result(ws_tx: &WsSink, id: &Option<String>, result: Value) {
+async fn send_result(ws_tx: &WsSink, id: &Option<String>, result: Value) -> Result<(), ()> {
     let resp = json!({"id": id, "result": result});
-    let _ = ws_tx
+    ws_tx
         .lock()
         .await
         .send(Message::Text(resp.to_string()))
-        .await;
+        .await
+        .map_err(|_| ())
 }
 
 /// Send an RPC error response over WebSocket
-async fn send_error(ws_tx: &WsSink, id: &Option<String>, error: &str) {
+async fn send_error(ws_tx: &WsSink, id: &Option<String>, error: &str) -> Result<(), ()> {
     let resp = json!({"id": id, "error": error});
-    let _ = ws_tx
+    ws_tx
         .lock()
         .await
         .send(Message::Text(resp.to_string()))
-        .await;
+        .await
+        .map_err(|_| ())
 }
 
 /// Handle a single WebSocket connection
@@ -112,7 +159,7 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
     let state_for_read = state.clone();
 
     // Task: forward A-class broadcast events to WS client
-    let a_forward = tokio::spawn(async move {
+    let mut a_forward = tokio::spawn(async move {
         loop {
             match a_rx.recv().await {
                 Ok(msg) => {
@@ -199,7 +246,9 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                     // Mark only non-already-replaying runs (avoid conflicting replays)
                     let mut runs_to_replay = Vec::new();
                     for (run_id, last_seq) in &subs {
-                        if !sess.replaying.contains(run_id.as_str()) {
+                        if !sess.replaying.contains(run_id.as_str())
+                            && !sess.full_reload_pending.contains(run_id.as_str())
+                        {
                             sess.replaying.insert(run_id.clone());
                             sess.replay_buffer.entry(run_id.clone()).or_default();
                             runs_to_replay.push((run_id.clone(), *last_seq));
@@ -207,23 +256,49 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                     }
                     drop(sess);
 
+                    let mut failed_runs = std::collections::HashSet::new();
                     for (run_id, last_seq) in &runs_to_replay {
-                        if let Err(e) =
-                            replay_events(&state_for_read, &ws_tx_a, &session_a, run_id, *last_seq)
-                                .await
-                        {
-                            log::error!("[ws] catchup replay failed for run={}: {}", run_id, e);
+                        match replay_events(&state_for_read, &ws_tx_a, run_id, *last_seq).await {
+                            Ok(last_replayed_seq) => {
+                                advance_checkpoint(&session_a, run_id, last_replayed_seq).await;
+                            }
+                            Err(ReplayError::SendFailed) => {
+                                log::error!("[ws] catchup replay send failed for run={}", run_id);
+                                return;
+                            }
+                            Err(error) => {
+                                log::error!(
+                                    "[ws] catchup replay failed for run={}: {}",
+                                    run_id,
+                                    error
+                                );
+                                failed_runs.insert(run_id.clone());
+                                if send_full_reload(&ws_tx_a, &session_a, run_id)
+                                    .await
+                                    .is_err()
+                                {
+                                    return;
+                                }
+                            }
                         }
                     }
 
                     // Flush buffers after replay
                     for (run_id, _) in &runs_to_replay {
-                        if let Err(overflow) =
-                            flush_replay_buffer(&ws_tx_a, &session_a, run_id).await
-                        {
-                            if overflow {
-                                send_full_reload(&ws_tx_a, &session_a, run_id).await;
+                        if failed_runs.contains(run_id) {
+                            continue;
+                        }
+                        match flush_replay_buffer(&ws_tx_a, &session_a, run_id).await {
+                            Err(FlushError::Overflow) => {
+                                if send_full_reload(&ws_tx_a, &session_a, run_id)
+                                    .await
+                                    .is_err()
+                                {
+                                    return;
+                                }
                             }
+                            Err(FlushError::SendFailed) => return,
+                            Ok(()) => {}
                         }
                     }
                 }
@@ -233,7 +308,7 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
     });
 
     // Task: forward B-class broadcast events to WS client
-    let b_forward = tokio::spawn(async move {
+    let mut b_forward = tokio::spawn(async move {
         loop {
             match b_rx.recv().await {
                 Ok(msg) => {
@@ -277,7 +352,7 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
     let session_cmd = session.clone();
     let state_cmd = state.clone();
 
-    let cmd_loop = tokio::spawn(async move {
+    let mut cmd_loop = tokio::spawn(async move {
         while let Some(Ok(msg)) = ws_rx.next().await {
             match msg {
                 Message::Text(text) => {
@@ -285,7 +360,12 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                     let parsed: Value = match serde_json::from_str(text_str) {
                         Ok(v) => v,
                         Err(e) => {
-                            send_error(&ws_tx_cmd, &None, &format!("invalid JSON: {}", e)).await;
+                            if send_error(&ws_tx_cmd, &None, &format!("invalid JSON: {}", e))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
                             continue;
                         }
                     };
@@ -305,7 +385,12 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                                 params.get("last_seq").and_then(|v| v.as_u64()).unwrap_or(0);
 
                             if run_id.is_empty() {
-                                send_error(&ws_tx_cmd, &id, "run_id required").await;
+                                if send_error(&ws_tx_cmd, &id, "run_id required")
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
                                 continue;
                             }
 
@@ -323,6 +408,8 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                                 let old_seq = sess.subscriptions.get(run_id).copied().unwrap_or(0);
                                 let effective_seq = old_seq.max(last_seq);
                                 sess.subscriptions.insert(run_id.to_string(), effective_seq);
+                                // A fresh subscribe acknowledges the preceding _full_reload.
+                                sess.full_reload_pending.remove(run_id);
                                 if !already {
                                     sess.replaying.insert(run_id.to_string());
                                     sess.replay_buffer.entry(run_id.to_string()).or_default();
@@ -336,51 +423,85 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                                     "[ws] _subscribe: already replaying run={}, checkpoint updated",
                                     run_id
                                 );
-                                send_result(
+                                if send_result(
                                     &ws_tx_cmd,
                                     &id,
                                     json!({"status": "already_replaying"}),
                                 )
-                                .await;
+                                .await
+                                .is_err()
+                                {
+                                    break;
+                                }
                                 continue;
                             }
 
                             // Replay events since effective_seq (not last_seq — avoids re-sending)
-                            if let Err(e) = replay_events(
-                                &state_cmd,
-                                &ws_tx_cmd,
-                                &session_cmd,
-                                run_id,
-                                effective_seq,
-                            )
-                            .await
+                            match replay_events(&state_cmd, &ws_tx_cmd, run_id, effective_seq).await
                             {
-                                log::error!("[ws] replay failed for run={}: {}", run_id, e);
-                                // Clean up replay state so run isn't stuck
-                                let mut sess = session_cmd.lock().await;
-                                sess.replay_buffer.remove(run_id);
-                                sess.replaying.remove(run_id);
-                                drop(sess);
-                                send_error(&ws_tx_cmd, &id, "replay failed").await;
-                                continue;
+                                Ok(last_replayed_seq) => {
+                                    advance_checkpoint(&session_cmd, run_id, last_replayed_seq)
+                                        .await;
+                                }
+                                Err(ReplayError::SendFailed) => break,
+                                Err(error) => {
+                                    log::error!("[ws] replay failed for run={}: {}", run_id, error);
+                                    // History may have completed before this replay. Rebuild it for
+                                    // both projection gaps and ordinary persistence/read failures.
+                                    if send_full_reload(&ws_tx_cmd, &session_cmd, run_id)
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                    if send_error(&ws_tx_cmd, &id, &error.to_string())
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                    continue;
+                                }
                             }
 
                             // Flush buffer after replay
                             match flush_replay_buffer(&ws_tx_cmd, &session_cmd, run_id).await {
-                                Err(true) => {
+                                Err(FlushError::Overflow) => {
                                     // Buffer overflow — send _full_reload
-                                    send_full_reload(&ws_tx_cmd, &session_cmd, run_id).await;
+                                    if send_full_reload(&ws_tx_cmd, &session_cmd, run_id)
+                                        .await
+                                        .is_err()
+                                    {
+                                        break;
+                                    }
+                                    if send_error(
+                                        &ws_tx_cmd,
+                                        &id,
+                                        "replay buffer overflow; full reload required",
+                                    )
+                                    .await
+                                    .is_err()
+                                    {
+                                        break;
+                                    }
+                                    continue;
                                 }
-                                Err(false) => {
+                                Err(FlushError::SendFailed) => {
                                     log::error!(
                                         "[ws] flush_replay_buffer send error for run={}",
                                         run_id
                                     );
+                                    break;
                                 }
                                 Ok(()) => {}
                             }
 
-                            send_result(&ws_tx_cmd, &id, json!({"ok": true})).await;
+                            if send_result(&ws_tx_cmd, &id, json!({"ok": true}))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
                         }
                         "_unsubscribe" => {
                             let run_id =
@@ -392,18 +513,27 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
                             sess.subscriptions.remove(run_id);
                             sess.replay_buffer.remove(run_id);
                             sess.replaying.remove(run_id);
-                            sess.full_reload_cooldown.remove(run_id);
+                            sess.full_reload_pending.remove(run_id);
+                            drop(sess);
 
-                            send_result(&ws_tx_cmd, &id, json!({"ok": true})).await;
+                            if send_result(&ws_tx_cmd, &id, json!({"ok": true}))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
                         }
                         _ => {
                             // Dispatch to command handler
                             let result =
                                 dispatch::dispatch_command(method, params, &state_cmd).await;
 
-                            match result {
+                            let sent = match result {
                                 Ok(value) => send_result(&ws_tx_cmd, &id, value).await,
                                 Err(err) => send_error(&ws_tx_cmd, &id, &err).await,
+                            };
+                            if sent.is_err() {
+                                break;
                             }
                         }
                     }
@@ -427,7 +557,7 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
     let state_hb = state.clone();
     let ws_tx_hb = ws_tx.clone();
 
-    let heartbeat_task = tokio::spawn(async move {
+    let mut heartbeat_task = tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
         let session_token_ver = state_hb
             .token_version
@@ -501,13 +631,19 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
 
     // Wait for any task to finish (client disconnect or channel close)
     tokio::select! {
-        _ = a_forward => {},
-        _ = b_forward => {},
-        _ = cmd_loop => {},
-        _ = heartbeat_task => {
+        _ = &mut a_forward => {},
+        _ = &mut b_forward => {},
+        _ = &mut cmd_loop => {},
+        _ = &mut heartbeat_task => {
             log::debug!("[ws] heartbeat/shutdown triggered connection close");
         },
     }
+    // A send failure in any task must close the whole connection. Detached siblings would keep
+    // the split socket alive and leave the client in an unacknowledged partial-replay state.
+    a_forward.abort();
+    b_forward.abort();
+    cmd_loop.abort();
+    heartbeat_task.abort();
 
     log::debug!("[ws] connection closed");
 }
@@ -515,12 +651,11 @@ async fn handle_ws(socket: WebSocket, state: AppState, auth_subject: auth::WsAut
 /// Flush the replay buffer for a run: send buffered events with seq > checkpoint,
 /// update checkpoint monotonically, then clear replay state.
 ///
-/// Returns Ok(()) on success, Err(true) on buffer overflow, Err(false) on send failure.
 async fn flush_replay_buffer(
     ws_tx: &WsSink,
     session: &Arc<Mutex<WsSession>>,
     run_id: &str,
-) -> Result<(), bool> {
+) -> Result<(), FlushError> {
     let mut total_flushed = 0u64;
     let mut max_seq = 0u64;
 
@@ -552,7 +687,7 @@ async fn flush_replay_buffer(
                     run_id,
                     buffer.len()
                 );
-                return Err(true);
+                return Err(FlushError::Overflow);
             }
 
             let checkpoint = sess.subscriptions.get(run_id).copied().unwrap_or(0);
@@ -569,7 +704,7 @@ async fn flush_replay_buffer(
             if ws_tx.lock().await.send(Message::Text(text)).await.is_err() {
                 let mut sess = session.lock().await;
                 sess.replaying.remove(run_id);
-                return Err(false);
+                return Err(FlushError::SendFailed);
             }
             max_seq = max_seq.max(event.seq);
             total_flushed += 1;
@@ -596,22 +731,17 @@ async fn flush_replay_buffer(
     Ok(())
 }
 
-/// Send a _full_reload event to the client, respecting cooldown.
-async fn send_full_reload(ws_tx: &WsSink, session: &Arc<Mutex<WsSession>>, run_id: &str) {
+/// Send one _full_reload event and wait for a fresh subscription before sending another.
+async fn send_full_reload(
+    ws_tx: &Arc<Mutex<impl futures_util::Sink<Message> + Unpin>>,
+    session: &Arc<Mutex<WsSession>>,
+    run_id: &str,
+) -> Result<(), ()> {
     let mut sess = session.lock().await;
-
-    // Check cooldown
-    if let Some(last) = sess.full_reload_cooldown.get(run_id) {
-        if last.elapsed().as_secs() < FULL_RELOAD_COOLDOWN_SECS {
-            log::debug!(
-                "[ws] _full_reload cooldown active for run={}, skipping",
-                run_id
-            );
-            return;
-        }
+    if !sess.begin_full_reload(run_id) {
+        log::debug!("[ws] _full_reload already pending for run={}", run_id);
+        return Ok(());
     }
-    sess.full_reload_cooldown
-        .insert(run_id.to_string(), std::time::Instant::now());
     drop(sess);
 
     let envelope = json!({
@@ -619,47 +749,174 @@ async fn send_full_reload(ws_tx: &WsSink, session: &Arc<Mutex<WsSession>>, run_i
         "run_id": run_id,
     });
     log::debug!("[ws] sending _full_reload for run={}", run_id);
-    let _ = ws_tx
+    ws_tx
         .lock()
         .await
         .send(Message::Text(envelope.to_string()))
-        .await;
+        .await
+        .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{send_full_reload, BufferedEvent, ReplayError, WsSession};
+    use futures_util::Sink;
+    use serde_json::json;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+    use tokio::sync::Mutex;
+
+    struct FailingSink;
+
+    impl Sink<axum::extract::ws::Message> for FailingSink {
+        type Error = ();
+
+        fn poll_ready(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(()))
+        }
+
+        fn start_send(
+            self: Pin<&mut Self>,
+            _item: axum::extract::ws::Message,
+        ) -> Result<(), Self::Error> {
+            Err(())
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Err(()))
+        }
+
+        fn poll_close(
+            self: Pin<&mut Self>,
+            _context: &mut Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[test]
+    fn projection_required_replay_error_forces_full_reload() {
+        assert!(matches!(
+            ReplayError::catchup(
+                "HISTORY_PROJECTION_REQUIRED: bus event 9 exceeds catch-up page limit".to_string()
+            ),
+            ReplayError::ProjectionRequired(_)
+        ));
+        assert!(matches!(
+            ReplayError::catchup("catch-up page cursor did not advance".to_string()),
+            ReplayError::Catchup(_)
+        ));
+    }
+
+    #[test]
+    fn full_reload_cleanup_preserves_live_subscription() {
+        let mut session = WsSession::new();
+        session.subscriptions.insert("run-1".to_string(), 41);
+        session.replaying.insert("run-1".to_string());
+        session.replay_buffer.insert(
+            "run-1".to_string(),
+            vec![BufferedEvent {
+                envelope: json!({"event":"bus-event"}),
+                seq: 42,
+            }],
+        );
+
+        assert!(session.begin_full_reload("run-1"));
+
+        assert_eq!(session.subscriptions.get("run-1"), Some(&41));
+        assert!(!session.replaying.contains("run-1"));
+        assert!(!session.replay_buffer.contains_key("run-1"));
+        assert!(!session.begin_full_reload("run-1"));
+        session.full_reload_pending.remove("run-1");
+        assert!(session.begin_full_reload("run-1"));
+    }
+
+    #[test]
+    fn checkpoint_advances_only_after_replay_is_complete() {
+        let mut session = WsSession::new();
+        session.subscriptions.insert("run-1".to_string(), 41);
+        session.replaying.insert("run-1".to_string());
+        session.replay_buffer.insert(
+            "run-1".to_string(),
+            vec![BufferedEvent {
+                envelope: json!({"event":"bus-event"}),
+                seq: 43,
+            }],
+        );
+
+        // Sending part of a replay does not mutate the durable resume checkpoint.
+        assert_eq!(session.subscriptions.get("run-1"), Some(&41));
+        session.begin_full_reload("run-1");
+        assert_eq!(session.subscriptions.get("run-1"), Some(&41));
+
+        session.full_reload_pending.remove("run-1");
+        session.complete_replay("run-1", 43);
+        assert_eq!(session.subscriptions.get("run-1"), Some(&43));
+    }
+
+    #[tokio::test]
+    async fn full_reload_send_failure_is_reported() {
+        let sink = Arc::new(Mutex::new(FailingSink));
+        let session = Arc::new(Mutex::new(WsSession::new()));
+        session
+            .lock()
+            .await
+            .subscriptions
+            .insert("run-1".to_string(), 41);
+
+        assert!(send_full_reload(&sink, &session, "run-1").await.is_err());
+        assert!(session.lock().await.full_reload_pending.contains("run-1"));
+    }
 }
 
 /// Replay A-class events from events.jsonl since `last_seq` for a given run.
 async fn replay_events(
     _state: &AppState,
     ws_tx: &WsSink,
-    session: &Arc<Mutex<WsSession>>,
     run_id: &str,
     last_seq: u64,
-) -> Result<(), String> {
-    // list_bus_events already filters by since_seq > last_seq
-    let events = crate::storage::events::list_bus_events(run_id, Some(last_seq));
+) -> Result<u64, ReplayError> {
+    let mut replayed = 0usize;
+    let mut last_replayed_seq = last_seq;
+    let mut page_seq = last_seq;
+    let mut page_offset = None;
+    loop {
+        let page = crate::storage::events::list_bus_events_page(run_id, page_seq, page_offset)
+            .map_err(ReplayError::catchup)?;
+        for event in &page.events {
+            let seq = event.get("_seq").and_then(|v| v.as_u64()).unwrap_or(0);
 
-    let replayed = events.len();
-    for event in &events {
-        let seq = event.get("_seq").and_then(|v| v.as_u64()).unwrap_or(0);
+            let envelope = json!({
+                "event": "bus-event",
+                "seq": seq,
+                "run_id": run_id,
+                "payload": event,
+            });
 
-        let envelope = json!({
-            "event": "bus-event",
-            "seq": seq,
-            "run_id": run_id,
-            "payload": event,
-        });
-
-        let text = envelope.to_string();
-        if ws_tx.lock().await.send(Message::Text(text)).await.is_err() {
-            return Err("WS send failed during replay".to_string());
-        }
-
-        // Update checkpoint (monotonic)
-        if seq > 0 {
-            let mut sess = session.lock().await;
-            if let Some(cp) = sess.subscriptions.get_mut(run_id) {
-                *cp = (*cp).max(seq);
+            let text = envelope.to_string();
+            if ws_tx.lock().await.send(Message::Text(text)).await.is_err() {
+                return Err(ReplayError::SendFailed);
             }
+            last_replayed_seq = last_replayed_seq.max(seq);
+            replayed += 1;
         }
+        if !page.has_more {
+            break;
+        }
+        if page.last_seq <= page_seq {
+            return Err(ReplayError::Catchup(
+                "catch-up page cursor did not advance".to_string(),
+            ));
+        }
+        page_offset = Some(page.next_offset);
+        page_seq = page.last_seq;
     }
 
     log::debug!(
@@ -669,5 +926,10 @@ async fn replay_events(
         replayed
     );
 
-    Ok(())
+    Ok(last_replayed_seq)
+}
+
+async fn advance_checkpoint(session: &Arc<Mutex<WsSession>>, run_id: &str, last_replayed_seq: u64) {
+    let mut sess = session.lock().await;
+    sess.complete_replay(run_id, last_replayed_seq);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -47,6 +47,11 @@ import type {
   CodexAuthResult,
   ThreadGoal,
   GoalStatus,
+  HistorySummary,
+  HistoryPage,
+  HistoryContentChunk,
+  SubHistoryPage,
+  BusEventPage,
 } from "./types";
 
 // Runs
@@ -619,12 +624,63 @@ export async function getBusEvents(id: string, sinceSeq?: number): Promise<BusEv
   return invoke<BusEvent[]>("get_bus_events", { id, sinceSeq });
 }
 
-export async function getToolResult(
+export async function getBusEventsPage(
+  id: string,
+  sinceSeq: number,
+  offset?: number,
+): Promise<BusEventPage> {
+  dbg("api", "getBusEventsPage", { id, sinceSeq, offset });
+  return invoke<BusEventPage>("get_bus_events_page", { id, sinceSeq, offset: offset ?? null });
+}
+
+export async function getHistorySummary(runId: string, refresh = false): Promise<HistorySummary> {
+  dbg("api", "getHistorySummary", { runId, refresh });
+  return invoke<HistorySummary>("get_history_summary", { runId, refresh });
+}
+
+export async function getHistoryPage(
   runId: string,
-  toolUseId: string,
-): Promise<Record<string, unknown> | null> {
-  dbg("api", "getToolResult", { runId, toolUseId });
-  return invoke<Record<string, unknown> | null>("get_tool_result", { runId, toolUseId });
+  generationId: string,
+  beforeCursor?: string,
+): Promise<HistoryPage> {
+  dbg("api", "getHistoryPage", { runId, generationId, beforeCursor });
+  return invoke<HistoryPage>("get_history_page", {
+    runId,
+    generationId,
+    beforeCursor: beforeCursor ?? null,
+  });
+}
+
+export async function getHistoryContentChunk(
+  runId: string,
+  generationId: string,
+  contentId: string,
+  offset: number,
+  maxBytes = 256 * 1024,
+): Promise<HistoryContentChunk> {
+  dbg("api", "getHistoryContentChunk", { runId, generationId, contentId, offset, maxBytes });
+  return invoke<HistoryContentChunk>("get_history_content_chunk", {
+    runId,
+    generationId,
+    contentId,
+    offset,
+    maxBytes,
+  });
+}
+
+export async function getSubhistoryPage(
+  runId: string,
+  generationId: string,
+  subHistoryId: string,
+  beforeCursor?: string,
+): Promise<SubHistoryPage> {
+  dbg("api", "getSubhistoryPage", { runId, generationId, subHistoryId, beforeCursor });
+  return invoke<SubHistoryPage>("get_subhistory_page", {
+    runId,
+    generationId,
+    subHistoryId,
+    beforeCursor: beforeCursor ?? null,
+  });
 }
 
 export async function forkSession(runId: string): Promise<string> {

--- a/src/lib/components/ChatMessage.svelte
+++ b/src/lib/components/ChatMessage.svelte
@@ -4,7 +4,8 @@
   import MarkdownContent from "./MarkdownContent.svelte";
   import FileAttachment from "./FileAttachment.svelte";
   import { IMAGE_TYPES } from "$lib/utils/file-types";
-  import type { ChatMessage, Attachment } from "$lib/types";
+  import type { ChatMessage, Attachment, HistoryContent } from "$lib/types";
+  import HistoryContentPager from "./HistoryContentPager.svelte";
 
   let {
     message,
@@ -12,12 +13,20 @@
     thinkingText,
     onRewind,
     agent = "claude",
+    historyContent,
+    thinkingHistoryContent,
+    historyRunId,
+    historyGenerationId,
   }: {
     message: ChatMessage;
     attachments?: Attachment[];
     thinkingText?: string;
     onRewind?: () => void;
     agent?: string;
+    historyContent?: HistoryContent;
+    thinkingHistoryContent?: HistoryContent;
+    historyRunId?: string;
+    historyGenerationId?: string;
   } = $props();
 
   const assistantLabel = $derived(agent === "codex" ? "Codex" : t("chat_roleClaude"));
@@ -238,11 +247,26 @@
             >
               {thinkingText.trimEnd()}
             </div>
+            {#if thinkingHistoryContent && historyRunId && historyGenerationId}
+              <HistoryContentPager
+                runId={historyRunId}
+                generationId={historyGenerationId}
+                content={thinkingHistoryContent}
+                label={t("historyContent_thinking")}
+              />
+            {/if}
           {/if}
         {/if}
         <div class="prose-chat">
           <MarkdownContent text={message.content} />
         </div>
+      {/if}
+      {#if historyContent && historyRunId && historyGenerationId}
+        <HistoryContentPager
+          runId={historyRunId}
+          generationId={historyGenerationId}
+          content={historyContent}
+        />
       {/if}
     </div>
   </div>

--- a/src/lib/components/ElicitationDialog.svelte
+++ b/src/lib/components/ElicitationDialog.svelte
@@ -20,7 +20,15 @@
 
   // Queue strategy: show the first pending elicitation
   let current = $derived.by(() => {
-    const iter = elicitations.values();
+    const values = [...elicitations.values()];
+    const iter = values
+      .sort((left, right) => {
+        const priority = { pending: 0, responding: 1, error: 2 } as const;
+        return (
+          priority[left.responseStatus ?? "pending"] - priority[right.responseStatus ?? "pending"]
+        );
+      })
+      .values();
     const first = iter.next();
     return first.done ? null : first.value;
   });
@@ -156,6 +164,12 @@
       <p class="mb-3 text-sm text-neutral-300">{current.message}</p>
     {/if}
 
+    {#if current.responseStatus === "responding"}
+      <p class="mb-3 text-xs text-amber-400">{t("interaction_responsePending")}</p>
+    {:else if current.responseStatus === "error"}
+      <p class="mb-3 text-xs text-red-400">{t("interaction_responseFailed")}</p>
+    {/if}
+
     <!-- URL mode -->
     {#if current.url}
       <div class="mb-3">
@@ -232,21 +246,23 @@
     {/if}
 
     <!-- Actions -->
-    <div class="flex items-center justify-end gap-2">
-      <button
-        class="rounded px-3 py-1.5 text-xs text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 disabled:opacity-50"
-        disabled={submitting}
-        onclick={handleDecline}
-      >
-        {t("elicitation_decline")}
-      </button>
-      <button
-        class="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-500 disabled:opacity-50"
-        disabled={submitting || missingRequired.length > 0}
-        onclick={handleAccept}
-      >
-        {submitting ? "..." : t("elicitation_accept")}
-      </button>
-    </div>
+    {#if (current.responseStatus ?? "pending") === "pending"}
+      <div class="flex items-center justify-end gap-2">
+        <button
+          class="rounded px-3 py-1.5 text-xs text-neutral-400 hover:bg-neutral-700 hover:text-neutral-200 disabled:opacity-50"
+          disabled={submitting}
+          onclick={handleDecline}
+        >
+          {t("elicitation_decline")}
+        </button>
+        <button
+          class="rounded bg-blue-600 px-3 py-1.5 text-xs text-white hover:bg-blue-500 disabled:opacity-50"
+          disabled={submitting || missingRequired.length > 0}
+          onclick={handleAccept}
+        >
+          {submitting ? "..." : t("elicitation_accept")}
+        </button>
+      </div>
+    {/if}
   </div>
 {/if}

--- a/src/lib/components/HistoryContentPager.svelte
+++ b/src/lib/components/HistoryContentPager.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import * as api from "$lib/api";
+  import type { HistoryContent } from "$lib/types";
+  import { dbg, dbgWarn } from "$lib/utils/debug";
+  import { appendHistoryChunkWindow } from "$lib/utils/history-content-window";
+  import { isCurrentContentChunk } from "$lib/utils/history-request-guard";
+  import { t } from "$lib/i18n/index.svelte";
+
+  let {
+    runId,
+    generationId,
+    content,
+    label,
+  }: { runId: string; generationId: string; content: HistoryContent; label?: string } = $props();
+
+  let chunks = $state<string[]>([]);
+  let chunkStarts = $state<number[]>([]);
+  let nextOffset = $state(0);
+  let eof = $state(false);
+  let loading = $state(false);
+  let error = $state("");
+  let windowStart = $state(0);
+  let decoder = new TextDecoder();
+  let requestGeneration = 0;
+
+  const decoded = $derived(chunks.join(""));
+
+  $effect(() => {
+    const identity = `${runId}:${generationId}:${content.contentId ?? "inline"}`;
+    void identity;
+    requestGeneration++;
+    chunks = [];
+    chunkStarts = [];
+    nextOffset = 0;
+    eof = false;
+    loading = false;
+    error = "";
+    windowStart = 0;
+    decoder = new TextDecoder();
+  });
+
+  async function loadNext() {
+    if (!content.contentId || loading || eof) return;
+    const request = {
+      token: ++requestGeneration,
+      runId,
+      generationId,
+      contentId: content.contentId,
+      offset: nextOffset,
+    };
+    loading = true;
+    error = "";
+    try {
+      const chunk = await api.getHistoryContentChunk(
+        request.runId,
+        request.generationId,
+        request.contentId,
+        request.offset,
+      );
+      const current = { runId, generationId, contentId: content.contentId ?? "" };
+      if (!isCurrentContentChunk(request, requestGeneration, chunk, current)) {
+        return;
+      }
+      const bytes = Uint8Array.from(atob(chunk.dataBase64), (char) => char.charCodeAt(0));
+      const decodedChunk = decoder.decode(bytes, { stream: !chunk.eof });
+      const window = appendHistoryChunkWindow(chunks, chunkStarts, decodedChunk, chunk.offset);
+      chunks = window.chunks;
+      chunkStarts = window.chunkStarts;
+      windowStart = window.windowStart;
+      nextOffset = chunk.nextOffset;
+      eof = chunk.eof;
+      dbg("history", "content chunk loaded", {
+        contentId: content.contentId,
+        offset: chunk.offset,
+        nextOffset,
+        eof,
+      });
+    } catch (e) {
+      if (
+        request.token !== requestGeneration ||
+        request.runId !== runId ||
+        request.generationId !== generationId ||
+        request.contentId !== content.contentId
+      )
+        return;
+      error = String(e);
+      dbgWarn("history", "content chunk failed", e);
+    } finally {
+      if (
+        request.token === requestGeneration &&
+        request.runId === runId &&
+        request.generationId === generationId &&
+        request.contentId === content.contentId
+      )
+        loading = false;
+    }
+  }
+</script>
+
+<div class="mt-2 rounded border border-border/50 bg-muted/30 p-2 text-xs" data-export-exclude>
+  {#if label}<div class="mb-1 font-medium text-muted-foreground">{label}</div>{/if}
+  {#if decoded}
+    {#if windowStart > 0}
+      <div class="mb-1 text-muted-foreground">
+        {t("historyContent_window", { offset: windowStart.toLocaleString() })}
+      </div>
+    {/if}
+    <pre class="max-h-64 overflow-auto whitespace-pre-wrap break-words font-mono">{decoded}</pre>
+  {:else}
+    <div class="text-muted-foreground">
+      {t("historyContent_preview", { bytes: content.byteLength.toLocaleString() })}
+    </div>
+  {/if}
+  <button
+    class="mt-2 rounded bg-muted px-2 py-1 text-foreground hover:bg-muted/80 disabled:opacity-50"
+    disabled={loading || eof}
+    onclick={loadNext}
+  >
+    {loading
+      ? t("historyContent_loading")
+      : eof
+        ? t("historyContent_loaded")
+        : error
+          ? t("historyContent_retry")
+          : t("historyContent_loadNext")}
+  </button>
+  {#if error}<span class="ml-2 text-destructive">{error}</span>{/if}
+</div>

--- a/src/lib/components/HookReviewCard.svelte
+++ b/src/lib/components/HookReviewCard.svelte
@@ -13,18 +13,19 @@
       request_id?: string;
       status?: string;
     };
-    onRespond: (requestId: string, decision: "allow" | "deny") => void | Promise<void>;
+    onRespond: (requestId: string, decision: "allow" | "deny") => Promise<void>;
   } = $props();
 
   let submitting = $state(false);
 
   // Extract display info from hook data
-  const data = hookEvent.data as Record<string, unknown>;
-  const hookName =
+  let data = $derived(hookEvent.data as Record<string, unknown>);
+  let hookName = $derived(
     (data as { hook_name?: string }).hook_name ??
-    (data as { tool_name?: string }).tool_name ??
-    "Unknown Tool";
-  const hookEventType = (data as { hook_event?: string }).hook_event ?? hookEvent.type;
+      (data as { tool_name?: string }).tool_name ??
+      "Unknown Tool",
+  );
+  let hookEventType = $derived((data as { hook_event?: string }).hook_event ?? hookEvent.type);
 
   async function handleRespond(decision: "allow" | "deny") {
     if (!hookEvent.request_id || submitting) return;
@@ -61,5 +62,13 @@
         onclick={() => handleRespond("deny")}>{t("common_deny")}</button
       >
     </div>
+  </div>
+{:else if hookEvent.status === "responding"}
+  <div class="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 my-2 text-xs text-amber-500">
+    {t("interaction_responsePending")}
+  </div>
+{:else if hookEvent.status === "error"}
+  <div class="rounded-lg border border-red-500/30 bg-red-500/5 p-3 my-2 text-xs text-red-500">
+    {t("interaction_responseFailed")}
   </div>
 {/if}

--- a/src/lib/components/InlineToolCard.svelte
+++ b/src/lib/components/InlineToolCard.svelte
@@ -4,6 +4,7 @@
     TimelineEntry,
     PermissionSuggestion,
     CodexAgentIdentity,
+    HistoryContent,
   } from "$lib/types";
   import type { TaskNotificationItem } from "$lib/stores/session-store.svelte";
   import { getToolColor } from "$lib/utils/tool-colors";
@@ -33,12 +34,14 @@
   import StatusIcon from "$lib/components/StatusIcon.svelte";
   import { t } from "$lib/i18n/index.svelte";
   import { dbg } from "$lib/utils/debug";
+  import HistoryContentPager from "$lib/components/HistoryContentPager.svelte";
+  import { isCurrentSubhistoryPage } from "$lib/utils/history-request-guard";
+  import * as api from "$lib/api";
 
   let {
     tool,
     subTimeline,
     runId,
-    fetchToolResult,
     onAnswer,
     onApprove,
     onPermissionRespond,
@@ -50,13 +53,11 @@
     codexAgentInfo,
     agentDisplayName,
     onPreviewFile,
+    historyGenerationId,
   }: {
     tool: BusToolItem;
     subTimeline?: TimelineEntry[];
-    /** Run ID for lazy-loading truncated tool results. */
     runId?: string;
-    /** Callback to fetch full tool result from backend (with caching). */
-    fetchToolResult?: (runId: string, toolUseId: string) => Promise<Record<string, unknown> | null>;
     onAnswer?: (answer: string) => void | Promise<void>;
     onApprove?: (toolName: string) => void;
     /** Inline permission response (--permission-prompt-tool stdio). */
@@ -84,7 +85,14 @@
     agentDisplayName?: string;
     /** Click on Edit/Write/Read tool card's file path → open preview in right panel. */
     onPreviewFile?: (path: string) => void;
+    historyGenerationId?: string;
   } = $props();
+
+  let historyContents = $derived(
+    tool._historyContent as
+      | { input?: HistoryContent; output?: HistoryContent; result?: HistoryContent }
+      | undefined,
+  );
 
   // Look up the task notification for this specific Task tool
   let taskNotification = $derived.by(() => {
@@ -98,49 +106,31 @@
   let userExpanded = $state<boolean | null>(null);
   let submitting = $state(false);
 
-  // ── Lazy loading for truncated tool results ──
-  let lazyResult = $state<Record<string, unknown> | null>(null);
-  let lazyLoading = $state(false);
-  let lazyFailed = $state(false);
-  let lazyReqId = 0; // request generation marker
+  let historySubTimeline = $state<TimelineEntry[]>([]);
+  let historySubCursor = $state<string | undefined>(undefined);
+  let historySubHasMore = $state(false);
+  let historySubLoading = $state(false);
+  let historySubLoaded = $state(false);
+  let historySubError = $state("");
+  let historySubRequestGeneration = 0;
 
   let isTruncated = $derived(
     (tool.tool_use_result as Record<string, unknown> | undefined)?._truncated === true,
   );
+  let subHistoryId = $derived(tool._subHistoryId as string | undefined);
 
-  // Merge lazy-loaded result into tool for rendering
-  let enrichedTool = $derived.by(() => {
-    if (!lazyResult) return tool;
-    return { ...tool, tool_use_result: lazyResult };
-  });
-
-  // Auto-fetch full result when expanded + truncated
-  // Guard: Level 2 auto-expand does NOT auto-fetch truncated results to avoid
-  // a fetch storm on history load. User must click "Load full output" first.
   $effect(() => {
-    if (!expanded || !isTruncated || lazyResult || lazyLoading || lazyFailed) return;
-    if (!runId || !fetchToolResult) return;
-    if (userExpanded === null && isTruncated) return;
-    const reqId = ++lazyReqId;
-    lazyLoading = true;
-    fetchToolResult(runId, tool.tool_use_id)
-      .then((r) => {
-        if (reqId !== lazyReqId) return; // stale — component switched/collapsed
-        lazyResult = r;
-        if (!r) lazyFailed = true; // not found → terminal state
-      })
-      .catch(() => {
-        if (reqId !== lazyReqId) return;
-        lazyFailed = true;
-      })
-      .finally(() => {
-        if (reqId === lazyReqId) lazyLoading = false;
-      });
+    const identity = `${runId}:${historyGenerationId ?? ""}:${subHistoryId ?? ""}`;
+    void identity;
+    historySubRequestGeneration++;
+    historySubTimeline = [];
+    historySubCursor = undefined;
+    historySubHasMore = false;
+    historySubLoading = false;
+    historySubLoaded = false;
+    historySubError = "";
   });
 
-  function retryLazyLoad() {
-    lazyFailed = false; // reset — effect will re-trigger
-  }
   let multiChecked: Record<string, boolean> = $state({});
   // Per-question answers for multi-question AskUserQuestion
   let questionAnswers: Record<string, string> = $state({});
@@ -175,7 +165,10 @@
     userExpanded ?? (renderLevel === 2 || (isPlan && latestPlanTool) || isInputStreaming),
   );
 
-  let hasSubTimeline = $derived((subTimeline?.length ?? 0) > 0);
+  let effectiveSubTimeline = $derived(
+    historySubTimeline.length > 0 ? historySubTimeline : subTimeline,
+  );
+  let hasSubTimeline = $derived((effectiveSubTimeline?.length ?? 0) > 0 || !!subHistoryId);
 
   // SubTimeline visibility: all tools auto-collapse on terminal state, userExpanded overrides
   let showSubTimeline = $derived.by(() => {
@@ -192,6 +185,117 @@
       toolName: tool.tool_name,
       renderLevel,
     });
+    if (willExpand && subHistoryId && !historySubLoaded) void loadSubhistory();
+  }
+
+  function mapSubEntry(entry: import("$lib/types").HistoryEntry): TimelineEntry {
+    if (entry.kind === "assistant") {
+      return {
+        kind: "assistant",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        content: entry.content.preview,
+        thinkingText: entry.thinking?.preview,
+        ts: entry.ts,
+        historyContent: entry.content.truncated ? entry.content : undefined,
+        thinkingHistoryContent: entry.thinking?.truncated ? entry.thinking : undefined,
+      };
+    }
+    if (entry.kind === "user") {
+      return {
+        kind: "user",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        content: entry.content.preview,
+        ts: entry.ts,
+      };
+    }
+    if (entry.kind === "tool") {
+      return {
+        kind: "tool",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        ts: entry.ts,
+        tool: {
+          tool_use_id: entry.toolUseId,
+          tool_name: entry.toolName,
+          input: entry.input,
+          output: entry.output ?? undefined,
+          status: entry.status,
+          duration_ms: entry.durationMs,
+          tool_use_result: entry.toolUseResult,
+          _historyContent: {
+            input: entry.inputContent,
+            output: entry.outputContent,
+            result: entry.resultContent,
+          },
+          _subHistoryId: entry.subHistoryId,
+        },
+      };
+    }
+    return {
+      kind: "command_output",
+      id: entry.id,
+      anchorId: entry.anchorId,
+      content: entry.content.preview,
+      ts: entry.ts,
+    };
+  }
+
+  async function loadSubhistory() {
+    if (!runId || !historyGenerationId || !subHistoryId || historySubLoading) return;
+    const request = {
+      token: ++historySubRequestGeneration,
+      runId,
+      generationId: historyGenerationId,
+      subHistoryId,
+    };
+    const requestedCursor = historySubCursor;
+    historySubLoading = true;
+    historySubError = "";
+    try {
+      const page = await api.getSubhistoryPage(
+        request.runId,
+        request.generationId,
+        request.subHistoryId,
+        requestedCursor,
+      );
+      const current = {
+        runId: runId ?? "",
+        generationId: historyGenerationId ?? "",
+        subHistoryId: subHistoryId ?? "",
+      };
+      if (!isCurrentSubhistoryPage(request, historySubRequestGeneration, page, current)) {
+        return;
+      }
+      historySubTimeline = [...page.entries.map(mapSubEntry), ...historySubTimeline];
+      historySubCursor = page.pageCursor;
+      historySubHasMore = page.hasMore;
+      historySubLoaded = true;
+      dbg("history", "subhistory page loaded", {
+        subHistoryId,
+        entries: page.entries.length,
+        hasMore: page.hasMore,
+      });
+    } catch (error) {
+      if (
+        request.token === historySubRequestGeneration &&
+        request.runId === runId &&
+        request.generationId === historyGenerationId &&
+        request.subHistoryId === subHistoryId
+      ) {
+        historySubError = String(error);
+        dbg("history", "subhistory page failed", { subHistoryId, error: historySubError });
+      }
+    } finally {
+      if (
+        request.token === historySubRequestGeneration &&
+        request.runId === runId &&
+        request.generationId === historyGenerationId &&
+        request.subHistoryId === subHistoryId
+      )
+        historySubLoading = false;
+    }
   }
 
   let subToolCount = $derived.by(() => {
@@ -267,6 +371,7 @@
     tool.status === "success"
       ? "done"
       : tool.status === "error" ||
+          tool.status === "response_failed" ||
           tool.status === "denied" ||
           tool.status === "permission_denied" ||
           tool.status === "rejected"
@@ -283,7 +388,7 @@
     if (!isAsk) return false;
     if (tool.status === "permission_denied") return true;
     // Fallback: error status + no option selected = denied/interrupted
-    if (tool.status === "error") {
+    if (tool.status === "error" || tool.status === "response_failed") {
       const opts = parsedQuestions[0]?.options.map((o) => o.label) ?? [];
       const ansText = extractOutputText(tool.output);
       const ansSet = new Set(
@@ -850,7 +955,17 @@
               </svg>
             </div>
             <span class="text-xs font-medium text-muted-foreground">{t("inline_question")}</span>
-            {#if isAskDenied}
+            {#if tool.status === "response_pending"}
+              <span
+                class="ml-auto rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-500"
+                >{t("interaction_responsePending")}</span
+              >
+            {:else if tool.status === "response_failed"}
+              <span
+                class="ml-auto rounded-full border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium text-red-500"
+                >{t("interaction_responseFailed")}</span
+              >
+            {:else if isAskDenied}
               <span
                 class="ml-auto rounded-full border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium text-red-500"
                 >{t("common_denied")}</span
@@ -1826,31 +1941,38 @@
     <!-- Expanded content area with accent left border -->
     {#if expanded}
       <div class="ml-2.5 pl-2 border-l-2 {renderLevel === 2 ? style.border : 'border-border/20'}">
-        {#if isTruncated && !lazyResult}
-          {#if lazyLoading}
-            <div class="px-4 py-3 text-center text-xs text-muted-foreground animate-pulse">
-              Loading tool details...
-            </div>
-          {:else if lazyFailed}
-            <div class="px-4 py-3 text-center text-xs text-muted-foreground">
-              Failed to load details
-              <button class="ml-2 underline hover:text-foreground" onclick={retryLazyLoad}
-                >Retry</button
-              >
-            </div>
-          {:else}
-            <!-- Auto-expanded but not yet fetched (truncated) -->
-            <button
-              class="w-full text-xs text-muted-foreground/60 hover:text-muted-foreground py-2 transition-colors"
-              onclick={() => {
-                userExpanded = true;
-              }}
-            >
-              {t("inline_loadDetails")}
-            </button>
-          {/if}
+        {#if isTruncated && !historyContents}
+          <div class="px-4 py-3 text-center text-xs text-muted-foreground">
+            {t("historyContent_unavailable")}
+          </div>
         {:else}
-          <ToolDetailView tool={enrichedTool} {isInputStreaming} {onPreviewFile} {codexAgentInfo} />
+          <ToolDetailView {tool} {isInputStreaming} {onPreviewFile} {codexAgentInfo} />
+        {/if}
+        {#if historyContents && runId && historyGenerationId}
+          {#if historyContents.input}
+            <HistoryContentPager
+              {runId}
+              generationId={historyGenerationId}
+              content={historyContents.input}
+              label={t("historyContent_toolInput")}
+            />
+          {/if}
+          {#if historyContents.output}
+            <HistoryContentPager
+              {runId}
+              generationId={historyGenerationId}
+              content={historyContents.output}
+              label={t("historyContent_toolOutput")}
+            />
+          {/if}
+          {#if historyContents.result}
+            <HistoryContentPager
+              {runId}
+              generationId={historyGenerationId}
+              content={historyContents.result}
+              label={t("historyContent_toolResult")}
+            />
+          {/if}
         {/if}
       </div>
     {/if}
@@ -1883,7 +2005,20 @@
   <!-- Subagent subTimeline: nested entries from child agents -->
   {#if showSubTimeline}
     <div class="mt-2 ml-4 pl-3 border-l-2 border-blue-500/30 space-y-1">
-      {#each subTimeline as subEntry (subEntry.id)}
+      {#if historySubHasMore}
+        <button
+          class="text-xs text-muted-foreground underline disabled:opacity-50"
+          disabled={historySubLoading}
+          onclick={loadSubhistory}
+          >{historySubLoading ? t("historyContent_loading") : t("historySub_loadEarlier")}</button
+        >
+      {/if}
+      {#if historySubError}
+        <button class="text-xs text-destructive underline" onclick={loadSubhistory}
+          >{t("historyContent_retry")}: {historySubError}</button
+        >
+      {/if}
+      {#each effectiveSubTimeline ?? [] as subEntry (subEntry.id)}
         {#if subEntry.kind === "assistant"}
           <div class="text-sm text-muted-foreground py-1">
             {#if subEntry.thinkingText}
@@ -1894,13 +2029,38 @@
               text={subEntry.content}
               streaming={subEntry.id?.startsWith("__sub_stream_") ?? false}
             />
+            {#if subEntry.historyContent && runId && historyGenerationId}
+              <HistoryContentPager
+                {runId}
+                generationId={historyGenerationId}
+                content={subEntry.historyContent}
+              />
+            {/if}
+            {#if subEntry.thinkingHistoryContent && runId && historyGenerationId}
+              <HistoryContentPager
+                {runId}
+                generationId={historyGenerationId}
+                content={subEntry.thinkingHistoryContent}
+                label={t("historyContent_thinking")}
+              />
+            {/if}
+          </div>
+        {:else if subEntry.kind === "user"}
+          <div class="text-sm text-foreground/80 py-1">
+            <MarkdownContent text={subEntry.content} />
+            {#if subEntry.historyContent && runId && historyGenerationId}
+              <HistoryContentPager
+                {runId}
+                generationId={historyGenerationId}
+                content={subEntry.historyContent}
+              />
+            {/if}
           </div>
         {:else if subEntry.kind === "tool"}
           <svelte:self
             tool={subEntry.tool}
             subTimeline={subEntry.subTimeline}
             {runId}
-            {fetchToolResult}
             {onAnswer}
             {onApprove}
             {onPermissionRespond}
@@ -1909,6 +2069,7 @@
             {codexAgentInfo}
             {agentDisplayName}
             {onPreviewFile}
+            {historyGenerationId}
           />
         {/if}
       {/each}

--- a/src/lib/components/ToolActivity.svelte
+++ b/src/lib/components/ToolActivity.svelte
@@ -63,8 +63,9 @@
     cwd?: string;
     /** Run id — when it changes the preview is cleared. */
     runId?: string;
-    /** Remote run flag — disables file preview (file APIs are local-only). */
+    /** Remote run flag — routes file preview through SSH instead of local file APIs. */
     isRemote?: boolean;
+    /** Remote host name (when isRemote) — used to read files/diff over SSH. */
     /** External request to open preview for a path (auto-switches to files tab). */
     requestedPreviewPath?: string | null;
   } = $props();
@@ -236,12 +237,14 @@
       case "running":
         return "running";
       case "error":
+      case "response_failed":
       case "denied":
       case "permission_denied":
       case "rejected":
         return "error";
       case "ask_pending":
       case "permission_prompt":
+      case "response_pending":
         return "other";
       default:
         return "other";

--- a/src/lib/stores/__fixtures__/protocol-events.json
+++ b/src/lib/stores/__fixtures__/protocol-events.json
@@ -138,6 +138,33 @@
     "parent_thread_id": "root"
   },
   {
+    "type": "interaction_response_started",
+    "run_id": "run-1",
+    "request_id": "req-started-1",
+    "interaction_kind": "permission",
+    "resolution": "deny"
+  },
+  {
+    "type": "interaction_response_failed",
+    "run_id": "run-1",
+    "request_id": "req-failed-1",
+    "interaction_kind": "elicitation",
+    "error": "CLI stdin closed"
+  },
+  {
+    "type": "interaction_response_started",
+    "run_id": "run-1",
+    "request_id": "req-user-input-1",
+    "interaction_kind": "user_input"
+  },
+  {
+    "type": "interaction_resolved",
+    "run_id": "run-1",
+    "request_id": "req-resolved-1",
+    "interaction_kind": "permission",
+    "resolution": "allow"
+  },
+  {
     "type": "message_complete",
     "run_id": "run-1",
     "message_id": "msg-1",

--- a/src/lib/stores/event-middleware.test.ts
+++ b/src/lib/stores/event-middleware.test.ts
@@ -22,7 +22,7 @@ const mockTransport = {
     _unlistenSpies.push(unlisten);
     return unlisten;
   }),
-  subscribeRun: vi.fn(),
+  subscribeRun: vi.fn().mockResolvedValue(undefined),
   unsubscribeRun: vi.fn(),
   invoke: vi.fn(),
 };
@@ -68,7 +68,7 @@ function mockStore() {
     applyEventBatch: vi.fn(),
     applyHookEvent: vi.fn(),
     applyHookUsage: vi.fn(),
-    loadRun: vi.fn().mockResolvedValue(undefined),
+    loadRun: vi.fn().mockResolvedValue(true),
   };
 }
 
@@ -189,6 +189,23 @@ describe("EventMiddleware", () => {
   // ── Microbatching ──
 
   describe("microbatching", () => {
+    it("buffers live events until history load commits and filters persisted sequences", async () => {
+      await mw.start();
+      const store = mockStore();
+      mw.subscribeCurrent("run-1", store as any);
+      const token = mw.beginHistoryLoad("run-1", store as any);
+      const old = makeBusEvent("run-1", "message_delta", { text: "old", _seq: 4 });
+      const fresh = makeBusEvent("run-1", "message_delta", { text: "fresh", _seq: 6 });
+
+      fireBusEvent(old);
+      fireBusEvent(fresh);
+      vi.advanceTimersByTime(16);
+      expect(store.applyEventBatch).not.toHaveBeenCalled();
+
+      mw.finishHistoryLoad("run-1", store as any, token, 5);
+      expect(store.applyEvent).toHaveBeenCalledWith(fresh);
+    });
+
     it("batches multiple events within 16ms into applyEventBatch", async () => {
       await mw.start();
       const store = mockStore();
@@ -246,6 +263,23 @@ describe("EventMiddleware", () => {
 
       expect(store1.applyEvent).not.toHaveBeenCalled();
       expect(store2.applyEvent).toHaveBeenCalledOnce();
+    });
+
+    it("subscribeCurrent cancels the previous run's active history load", async () => {
+      await mw.start();
+      const store1 = mockStore();
+      const store2 = mockStore();
+      mw.subscribeCurrent("run-1", store1 as any);
+      const token = mw.beginHistoryLoad("run-1", store1 as any);
+      fireBusEvent(makeBusEvent("run-1", "message_delta", { text: "stale" }));
+
+      mw.subscribeCurrent("run-2", store2 as any);
+      mw.finishHistoryLoad("run-1", store1 as any, token, 0);
+      vi.advanceTimersByTime(16);
+
+      expect(store1.applyEvent).not.toHaveBeenCalled();
+      expect(store1.applyEventBatch).not.toHaveBeenCalled();
+      expect(mockTransport.unsubscribeRun).toHaveBeenCalledWith("run-1");
     });
 
     it("unsubscribe clears buffer and prevents delivery", async () => {
@@ -532,23 +566,29 @@ describe("EventMiddleware", () => {
       expect(store.loadRun).not.toHaveBeenCalled();
     });
 
-    it("debounces consecutive _full_reload for same run_id", async () => {
+    it("serializes consecutive _full_reload requests for the same run_id", async () => {
       await mw.start();
       const store = mockStore();
+      let finishReload!: (loaded: boolean) => void;
+      store.loadRun.mockImplementation(
+        () =>
+          new Promise<boolean>((resolve) => {
+            finishReload = resolve;
+          }),
+      );
       mw.subscribeCurrent("run-1", store as any);
 
       fireFullReload("run-1");
       expect(store.loadRun).toHaveBeenCalledTimes(1);
 
-      // Second fire while first is still in-flight → debounced
+      // Second fire while first is in-flight queues exactly one follow-up reload.
+      fireFullReload("run-1");
       fireFullReload("run-1");
       expect(store.loadRun).toHaveBeenCalledTimes(1);
 
-      // Flush the promise (.finally clears _reloadingRuns)
+      finishReload(true);
       await Promise.resolve();
-
-      // Now debounce is cleared, should accept again
-      fireFullReload("run-1");
+      await Promise.resolve();
       expect(store.loadRun).toHaveBeenCalledTimes(2);
     });
 
@@ -564,6 +604,50 @@ describe("EventMiddleware", () => {
 
       expect(store1.loadRun).toHaveBeenCalledTimes(1);
       expect(store2.loadRun).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries bounded reload failures and succeeds on the third attempt", async () => {
+      await mw.start();
+      const store = mockStore();
+      store.loadRun.mockResolvedValueOnce(false).mockRejectedValueOnce(new Error("read failed"));
+      mw.subscribeCurrent("run-1", store as any);
+
+      fireFullReload("run-1");
+      await vi.runAllTimersAsync();
+
+      expect(store.loadRun).toHaveBeenCalledTimes(3);
+      expect(mockTransport.unsubscribeRun).not.toHaveBeenCalledWith("run-1");
+    });
+
+    it("unsubscribes after bounded reload attempts are exhausted", async () => {
+      await mw.start();
+      const store = mockStore();
+      store.loadRun.mockResolvedValue(false);
+      mw.subscribeCurrent("run-1", store as any);
+      mockTransport.unsubscribeRun.mockClear();
+
+      fireFullReload("run-1");
+      await vi.runAllTimersAsync();
+
+      expect(store.loadRun).toHaveBeenCalledTimes(3);
+      expect(mockTransport.unsubscribeRun).toHaveBeenCalledWith("run-1");
+    });
+
+    it("does not retry or unsubscribe after destroy", async () => {
+      await mw.start();
+      const store = mockStore();
+      store.loadRun.mockResolvedValue(false);
+      mw.subscribeCurrent("run-1", store as any);
+
+      fireFullReload("run-1");
+      await Promise.resolve();
+      expect(store.loadRun).toHaveBeenCalledTimes(1);
+      mw.destroy();
+      mockTransport.unsubscribeRun.mockClear();
+      await vi.runAllTimersAsync();
+
+      expect(store.loadRun).toHaveBeenCalledTimes(1);
+      expect(mockTransport.unsubscribeRun).not.toHaveBeenCalled();
     });
 
     it("destroy() clears _full_reload unlisten", async () => {

--- a/src/lib/stores/event-middleware.ts
+++ b/src/lib/stores/event-middleware.ts
@@ -26,6 +26,8 @@ export interface RunEventHandler {
 // ── Middleware ──
 
 export class EventMiddleware {
+  private static readonly _FULL_RELOAD_MAX_ATTEMPTS = 3;
+  private static readonly _FULL_RELOAD_RETRY_MS = [100, 250];
   private _unlisteners: (() => void)[] = [];
   private _subscriptions = new Map<string, SessionStore>();
   private _currentRunId: string | null = null;
@@ -37,9 +39,12 @@ export class EventMiddleware {
 
   // Microbatch buffer for bus events
   private _batchBuffer = new Map<string, BusEvent[]>();
+  private _historyLoads = new Map<string, { store: SessionStore; token: number }>();
+  private _nextHistoryLoadToken = 0;
   private _flushScheduled = false;
   private _BATCH_INTERVAL = 16; // ~1 frame
   private _MAX_BUFFER_SIZE = 500; // per-run overflow threshold
+  private _MAX_HISTORY_BUFFER_SIZE = 8192;
   private _lastFlushTime = 0; // track last flush for idle detection
   private _IDLE_GAP_MS = 100; // gap above which the next token starts a fresh burst
 
@@ -48,6 +53,8 @@ export class EventMiddleware {
 
   // Debounce guard for _full_reload
   private _reloadingRuns = new Set<string>();
+  private _reloadAgainRuns = new Set<string>();
+  private _reloadEpoch = 0;
 
   // ── Lifecycle ──
 
@@ -121,17 +128,8 @@ export class EventMiddleware {
         const unlisten = await transport.listen<{ run_id: string }>("_full_reload", (payload) => {
           const runId = payload.run_id;
           dbgWarn("middleware", "_full_reload", { runId });
-          if (this._reloadingRuns.has(runId)) {
-            dbg("middleware", "_full_reload debounced", { runId });
-            return;
-          }
           const store = this._subscriptions.get(runId);
-          if (store) {
-            this._reloadingRuns.add(runId);
-            void store.loadRun(runId).finally(() => {
-              this._reloadingRuns.delete(runId);
-            });
-          }
+          if (store) this._requestFullReload(runId, store);
         });
         ul.push(unlisten);
       } catch (e) {
@@ -155,11 +153,26 @@ export class EventMiddleware {
     this._currentRunId = null;
     this._currentStore = null;
     this._batchBuffer.clear();
+    this._historyLoads.clear();
     this._reloadingRuns.clear();
+    this._reloadAgainRuns.clear();
+    this._reloadEpoch++;
     this._started = false;
   }
 
   // ── Subscriptions ──
+
+  /** The store bound to the active session, or null when none is live. Lets cross-page surfaces
+   *  (e.g. the /agents Active scope) read the running session without a global SessionStore.
+   *  Plain field — NOT reactive; callers that need updates must poll. */
+  get currentStore(): SessionStore | null {
+    return this._currentStore;
+  }
+
+  /** Run id of the active session, or null. */
+  get currentRunId(): string | null {
+    return this._currentRunId;
+  }
 
   /** Subscribe a store for a run_id. Clears previous subscription (single-session mode). */
   subscribeCurrent(runId: string, store: SessionStore): void {
@@ -175,6 +188,7 @@ export class EventMiddleware {
       getTransport().unsubscribeRun(this._currentRunId);
       this._subscriptions.delete(this._currentRunId);
       this._batchBuffer.delete(this._currentRunId);
+      this._historyLoads.delete(this._currentRunId);
     }
     if (runId) {
       this._currentRunId = runId;
@@ -188,6 +202,37 @@ export class EventMiddleware {
     dbg("middleware", "subscribeCurrent", runId || "(cleared)");
   }
 
+  /** Buffer live events while a history page is replacing store state. */
+  beginHistoryLoad(runId: string, store: SessionStore): number {
+    const token = ++this._nextHistoryLoadToken;
+    this._historyLoads.set(runId, { store, token });
+    dbg("middleware", "history load started", { runId, token });
+    return token;
+  }
+
+  /** Atomically release events newer than the persisted catch-up checkpoint. */
+  finishHistoryLoad(runId: string, store: SessionStore, token: number, lastSeq: number): void {
+    const load = this._historyLoads.get(runId);
+    if (!load || load.store !== store || load.token !== token) return;
+    this._historyLoads.delete(runId);
+    const events = (this._batchBuffer.get(runId) ?? []).filter((event) => {
+      const seq = ((event as Record<string, unknown>)._seq as number) ?? 0;
+      return seq === 0 || seq > lastSeq;
+    });
+    this._batchBuffer.delete(runId);
+    if (events.length === 1) store.applyEvent(events[0]);
+    else if (events.length > 1) store.applyEventBatch(events);
+    dbg("middleware", "history load released", { runId, token, lastSeq, events: events.length });
+  }
+
+  cancelHistoryLoad(runId: string, store: SessionStore, token: number): void {
+    const load = this._historyLoads.get(runId);
+    if (!load || load.store !== store || load.token !== token) return;
+    this._historyLoads.delete(runId);
+    this._batchBuffer.delete(runId);
+    dbg("middleware", "history load cancelled", { runId, token });
+  }
+
   /** Multi-session subscribe (for future subagent support). */
   subscribe(runId: string, store: SessionStore): void {
     this._subscriptions.set(runId, store);
@@ -198,6 +243,7 @@ export class EventMiddleware {
     getTransport().unsubscribeRun(runId);
     this._subscriptions.delete(runId);
     this._batchBuffer.delete(runId);
+    this._historyLoads.delete(runId);
     if (this._currentRunId === runId) {
       this._currentRunId = null;
       this._currentStore = null;
@@ -231,8 +277,19 @@ export class EventMiddleware {
     }
     buf.push(ev);
 
+    if (this._historyLoads.has(ev.run_id) && buf.length > this._MAX_HISTORY_BUFFER_SIZE) {
+      const store = this._subscriptions.get(ev.run_id);
+      this._historyLoads.delete(ev.run_id);
+      this._batchBuffer.delete(ev.run_id);
+      if (store) {
+        this._requestFullReload(ev.run_id, store);
+      }
+      dbgWarn("middleware", "history live buffer overflow; reloading", { runId: ev.run_id });
+      return;
+    }
+
     // Overflow protection: flush synchronously if buffer grows too large
-    if (buf.length >= this._MAX_BUFFER_SIZE) {
+    if (!this._historyLoads.has(ev.run_id) && buf.length >= this._MAX_BUFFER_SIZE) {
       dbgWarn(
         "middleware",
         `buffer overflow for ${ev.run_id} (${buf.length} events), flushing synchronously`,
@@ -264,6 +321,9 @@ export class EventMiddleware {
         }
         break;
       case "control_cancelled":
+      case "interaction_response_started":
+      case "interaction_response_failed":
+      case "interaction_resolved":
         clearAttention(ev.run_id, "permission");
         break;
       case "user_message":
@@ -286,6 +346,56 @@ export class EventMiddleware {
         }
         break;
     }
+  }
+
+  private _requestFullReload(runId: string, store: SessionStore): void {
+    if (this._reloadingRuns.has(runId)) {
+      this._reloadAgainRuns.add(runId);
+      dbg("middleware", "full reload queued", { runId });
+      return;
+    }
+    this._reloadingRuns.add(runId);
+    const epoch = this._reloadEpoch;
+    void this._performFullReload(runId, store, epoch).finally(() => {
+      this._reloadingRuns.delete(runId);
+      if (epoch !== this._reloadEpoch) return;
+      if (!this._reloadAgainRuns.delete(runId)) return;
+      const current = this._subscriptions.get(runId);
+      if (current) this._requestFullReload(runId, current);
+    });
+  }
+
+  private async _performFullReload(
+    runId: string,
+    store: SessionStore,
+    epoch: number,
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= EventMiddleware._FULL_RELOAD_MAX_ATTEMPTS; attempt++) {
+      if (epoch !== this._reloadEpoch || this._subscriptions.get(runId) !== store) return;
+      try {
+        const loaded = await store.loadRun(runId);
+        if (loaded) {
+          dbg("middleware", "full reload complete", { runId, attempt });
+          return;
+        }
+        dbgWarn("middleware", "full reload did not complete", { runId, attempt });
+      } catch (error) {
+        dbgWarn("middleware", "full reload failed", { runId, attempt, error });
+      }
+
+      if (attempt < EventMiddleware._FULL_RELOAD_MAX_ATTEMPTS) {
+        await new Promise<void>((resolve) =>
+          setTimeout(resolve, EventMiddleware._FULL_RELOAD_RETRY_MS[attempt - 1]),
+        );
+      }
+    }
+
+    if (epoch !== this._reloadEpoch || this._subscriptions.get(runId) !== store) return;
+    this._reloadAgainRuns.delete(runId);
+    // The server retains full_reload_pending until subscribe/unsubscribe. Exhaustion must clear
+    // that state without accepting more live events against an incomplete local timeline.
+    getTransport().unsubscribeRun(runId);
+    dbgWarn("middleware", "full reload exhausted", { runId });
   }
 
   private _handleHookEvent(event: HookEvent): void {
@@ -327,8 +437,12 @@ export class EventMiddleware {
     this._flushScheduled = false;
     this._lastFlushTime = performance.now();
     for (const [runId, events] of this._batchBuffer) {
+      if (this._historyLoads.has(runId)) continue;
       const store = this._subscriptions.get(runId);
-      if (!store) continue;
+      if (!store) {
+        this._batchBuffer.delete(runId);
+        continue;
+      }
       try {
         if (events.length === 1) {
           store.applyEvent(events[0]);
@@ -338,8 +452,8 @@ export class EventMiddleware {
       } catch (e) {
         dbgWarn("middleware", `flush error for run ${runId}:`, e);
       }
+      this._batchBuffer.delete(runId);
     }
-    this._batchBuffer.clear();
   }
 }
 

--- a/src/lib/stores/session-store-ws-race.test.ts
+++ b/src/lib/stores/session-store-ws-race.test.ts
@@ -1,0 +1,569 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  getUserSettings: vi.fn(),
+  getAgentSettings: vi.fn(),
+  startRun: vi.fn(),
+  getRun: vi.fn(),
+  getHistorySummary: vi.fn(),
+  getHistoryPage: vi.fn(),
+  getBusEventsPage: vi.fn(),
+  syncCliSession: vi.fn(),
+  startSession: vi.fn(),
+  sendChatMessage: vi.fn(),
+  forkSession: vi.fn(),
+}));
+
+const transportMocks = vi.hoisted(() => ({
+  subscribeRun: vi.fn(),
+  unsubscribeRun: vi.fn(),
+  isDesktop: vi.fn(() => false),
+}));
+
+const middlewareMocks = vi.hoisted(() => {
+  const state = {
+    currentRunId: null as string | null,
+    currentStore: null as unknown,
+  };
+  return {
+    state,
+    beginHistoryLoad: vi.fn(() => 1),
+    finishHistoryLoad: vi.fn(),
+    cancelHistoryLoad: vi.fn(),
+    subscribeCurrent: vi.fn((runId: string, store: unknown) => {
+      state.currentRunId = runId || null;
+      state.currentStore = runId ? store : null;
+    }),
+  };
+});
+
+vi.mock("$lib/api", () => ({
+  ...apiMocks,
+  getBusEvents: vi.fn(),
+  getRunEvents: vi.fn(),
+  sendSessionMessage: vi.fn(),
+  stopSession: vi.fn(),
+  stopRun: vi.fn(),
+  sendSessionControl: vi.fn(),
+  respondUserInput: vi.fn(),
+  steerSession: vi.fn(),
+  renameRun: vi.fn(),
+}));
+
+vi.mock("$lib/transport", () => ({ getTransport: () => transportMocks }));
+vi.mock("./event-middleware", () => ({
+  getEventMiddleware: () => ({
+    ...middlewareMocks,
+    get currentRunId() {
+      return middlewareMocks.state.currentRunId;
+    },
+    get currentStore() {
+      return middlewareMocks.state.currentStore;
+    },
+  }),
+}));
+vi.mock("$lib/utils/debug", () => ({ dbg: vi.fn(), dbgWarn: vi.fn() }));
+vi.mock("$lib/utils/snapshot-cache", () => ({
+  readSnapshot: vi.fn().mockResolvedValue(null),
+  writeSnapshot: vi.fn().mockResolvedValue(undefined),
+  deleteSnapshot: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./cli-info.svelte", () => ({
+  updateInstalledVersion: vi.fn(),
+  getCliCommands: vi.fn(() => []),
+}));
+
+import { SessionStore } from "./session-store.svelte";
+
+function currentRunId(store: SessionStore): string | undefined {
+  return (store.run as { id: string } | null)?.id;
+}
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function deferredValue<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function run(id: string, status = "running") {
+  return {
+    id,
+    prompt: "test",
+    cwd: "/tmp",
+    agent: "claude",
+    auth_mode: "cli",
+    status,
+    started_at: "2026-08-13T00:00:00Z",
+    execution_path: "session_actor",
+    session_id: `session-${id}`,
+  };
+}
+
+function history(runId: string) {
+  return {
+    summary: {
+      runId,
+      generationId: `gen-${runId}`,
+      pageCount: 1,
+      totalEntries: 0,
+      totalTurns: 0,
+      lastSeq: 4,
+      sourceSize: 100,
+      sourceMtimeNs: 1,
+      latestCursor: `gen-${runId}:1`,
+      stateEvents: [],
+    },
+    page: {
+      runId,
+      generationId: `gen-${runId}`,
+      entries: [],
+      pageCursor: `gen-${runId}:1`,
+      hasMore: false,
+      firstSeq: 0,
+      lastSeq: 4,
+    },
+  };
+}
+
+describe("SessionStore WebSocket stale guards", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window", { location: { href: "http://localhost/" } });
+    vi.clearAllMocks();
+    middlewareMocks.state.currentRunId = null;
+    middlewareMocks.state.currentStore = null;
+    apiMocks.getRun.mockImplementation(async (runId: string) => run(runId));
+    apiMocks.getHistorySummary.mockImplementation(async (runId: string) => history(runId).summary);
+    apiMocks.getHistoryPage.mockImplementation(async (runId: string) => history(runId).page);
+    apiMocks.getBusEventsPage.mockResolvedValue({
+      events: [],
+      lastSeq: 4,
+      hasMore: false,
+      nextOffset: 100,
+    });
+    apiMocks.syncCliSession.mockResolvedValue({ newEvents: 0 });
+    apiMocks.getUserSettings.mockResolvedValue({ auth_mode: "cli" });
+    apiMocks.getAgentSettings.mockResolvedValue({});
+    apiMocks.startRun.mockImplementation(async () => run("run-new", "pending"));
+    apiMocks.startSession.mockResolvedValue(undefined);
+    apiMocks.sendChatMessage.mockResolvedValue(undefined);
+  });
+
+  it("does not finish an old history load after navigation during WS subscribe", async () => {
+    const pending = deferred();
+    transportMocks.subscribeRun.mockReturnValueOnce(pending.promise);
+    const store = new SessionStore();
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const loading = store.loadRun("run-a");
+    await vi.waitFor(() => expect(transportMocks.subscribeRun).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("", store);
+    await store.loadRun("");
+    pending.resolve();
+
+    await expect(loading).resolves.toBe(false);
+    expect(middlewareMocks.finishHistoryLoad).not.toHaveBeenCalled();
+    expect(middlewareMocks.cancelHistoryLoad).toHaveBeenCalledWith("run-a", store, 1);
+    expect(transportMocks.unsubscribeRun).toHaveBeenCalledWith("run-a");
+  });
+
+  it("does not start the CLI after a resume subscription becomes stale", async () => {
+    const pending = deferred();
+    transportMocks.subscribeRun.mockReturnValueOnce(pending.promise);
+    apiMocks.getRun.mockResolvedValue(run("run-a", "stopped"));
+    const store = new SessionStore();
+    store.run = run("run-a", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const resuming = store.resumeSession("run-a", "resume");
+    await vi.waitFor(() => expect(transportMocks.subscribeRun).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("", store);
+    await store.loadRun("");
+    pending.resolve();
+
+    await expect(resuming).resolves.toEqual({ status: "cancelled" });
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+    expect(transportMocks.unsubscribeRun).toHaveBeenCalledWith("run-a");
+  });
+
+  it("cancels resume when real route ownership changes without an explicit cancel", async () => {
+    const pending = deferred();
+    transportMocks.subscribeRun.mockReturnValueOnce(pending.promise).mockResolvedValue(undefined);
+    apiMocks.getRun.mockImplementation(async (runId: string) =>
+      run(runId, runId === "run-a" ? "stopped" : "running"),
+    );
+    const store = new SessionStore();
+    store.run = run("run-a", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const resuming = store.resumeSession("run-a", "resume");
+    await vi.waitFor(() => expect(transportMocks.subscribeRun).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    pending.resolve();
+
+    await expect(resuming).resolves.toEqual({ status: "cancelled" });
+    await expect(loadingB).resolves.toBe(true);
+    expect(currentRunId(store)).toBe("run-b");
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it("does not return or retain a fork whose WS subscription resolves after cancellation", async () => {
+    const forkSubscribe = deferred();
+    transportMocks.subscribeRun
+      .mockResolvedValueOnce(undefined)
+      .mockReturnValueOnce(forkSubscribe.promise);
+    apiMocks.getRun
+      .mockResolvedValueOnce(run("run-source", "stopped"))
+      .mockResolvedValueOnce(run("run-fork", "pending"));
+    apiMocks.forkSession.mockResolvedValue("run-fork");
+    const store = new SessionStore();
+    store.run = run("run-source", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-source", store);
+    const forking = store.resumeSession("run-source", "fork");
+    await vi.waitFor(() => expect(transportMocks.subscribeRun).toHaveBeenCalledTimes(2));
+
+    store.cancelResumeOperation();
+    middlewareMocks.subscribeCurrent("", store);
+    forkSubscribe.resolve();
+
+    await expect(forking).resolves.toEqual({ status: "cancelled" });
+    expect(transportMocks.unsubscribeRun).toHaveBeenCalledWith("run-fork");
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it("does not return the source run when fork history becomes stale before WS subscribe", async () => {
+    let resolveForkSummary!: (value: ReturnType<typeof history>["summary"]) => void;
+    apiMocks.getRun
+      .mockResolvedValueOnce(run("run-source", "stopped"))
+      .mockResolvedValueOnce(run("run-fork", "pending"));
+    apiMocks.getHistorySummary
+      .mockResolvedValueOnce(history("run-source").summary)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveForkSummary = resolve;
+          }),
+      );
+    apiMocks.forkSession.mockResolvedValue("run-fork");
+    transportMocks.subscribeRun.mockResolvedValue(undefined);
+    const store = new SessionStore();
+    store.run = run("run-source", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-source", store);
+    const forking = store.resumeSession("run-source", "fork");
+    await vi.waitFor(() => expect(apiMocks.getHistorySummary).toHaveBeenCalledTimes(2));
+
+    store.cancelResumeOperation();
+    middlewareMocks.subscribeCurrent("", store);
+    resolveForkSummary(history("run-fork").summary);
+
+    await expect(forking).resolves.toEqual({ status: "cancelled" });
+    expect(transportMocks.subscribeRun).toHaveBeenCalledTimes(1);
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it("reports cancellation when resume history becomes stale before WS subscribe", async () => {
+    let resolveSummary!: (value: ReturnType<typeof history>["summary"]) => void;
+    apiMocks.getHistorySummary.mockImplementationOnce(
+      (runId: string) =>
+        new Promise((resolve) => {
+          resolveSummary = resolve;
+          expect(runId).toBe("run-a");
+        }),
+    );
+    apiMocks.getRun.mockResolvedValue(run("run-a", "stopped"));
+    const store = new SessionStore();
+    store.run = run("run-a", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const resuming = store.resumeSession("run-a", "resume");
+    await vi.waitFor(() => expect(apiMocks.getHistorySummary).toHaveBeenCalled());
+
+    store.cancelResumeOperation();
+    middlewareMocks.subscribeCurrent("", store);
+    resolveSummary(history("run-a").summary);
+
+    await expect(resuming).resolves.toEqual({ status: "cancelled" });
+    expect(transportMocks.subscribeRun).not.toHaveBeenCalled();
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it("reports cancellation when the latest history page resolves after navigation", async () => {
+    let resolvePage!: (value: ReturnType<typeof history>["page"]) => void;
+    apiMocks.getHistoryPage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolvePage = resolve;
+        }),
+    );
+    apiMocks.getRun.mockResolvedValue(run("run-a", "stopped"));
+    const store = new SessionStore();
+    store.run = run("run-a", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const resuming = store.resumeSession("run-a", "resume");
+    await vi.waitFor(() => expect(apiMocks.getHistoryPage).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("", store);
+    await store.loadRun("");
+    resolvePage(history("run-a").page);
+
+    await expect(resuming).resolves.toEqual({ status: "cancelled" });
+    expect(transportMocks.subscribeRun).not.toHaveBeenCalled();
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+  });
+
+  it("does not report success or install timers after CLI spawn resolves stale", async () => {
+    const spawn = deferred();
+    apiMocks.getRun.mockResolvedValue(run("run-a", "stopped"));
+    transportMocks.subscribeRun.mockResolvedValue(undefined);
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    store.run = run("run-a", "stopped") as never;
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-a", store);
+    const resuming = store.resumeSession("run-a", "resume", "continue");
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    store.cancelResumeOperation();
+    middlewareMocks.subscribeCurrent("", store);
+    await store.loadRun("");
+    spawn.resolve();
+
+    await expect(resuming).resolves.toEqual({ status: "cancelled" });
+    expect(store.phase).toBe("empty");
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+    expect((store as unknown as { _responseTimer: unknown })._responseTimer).toBeNull();
+  });
+
+  it("does not install a fork step-two timer after its CLI spawn resolves stale", async () => {
+    const spawn = deferred();
+    transportMocks.subscribeRun.mockResolvedValue(undefined);
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    store.run = run("run-fork", "pending") as never;
+    store.phase = "spawning";
+    middlewareMocks.subscribeCurrent("run-fork", store);
+    const connecting = store.connectSession("run-fork");
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("", store);
+    await store.loadRun("");
+    spawn.resolve();
+
+    await expect(connecting).resolves.toBeUndefined();
+    expect(store.phase).toBe("empty");
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+    expect((store as unknown as { _responseTimer: unknown })._responseTimer).toBeNull();
+  });
+
+  it("cancels fork step two when route ownership changes without an explicit cancel", async () => {
+    const spawn = deferred();
+    transportMocks.subscribeRun.mockResolvedValue(undefined);
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    apiMocks.getRun.mockImplementation(async (runId: string) => run(runId));
+    const store = new SessionStore();
+    store.run = run("run-fork", "pending") as never;
+    store.phase = "spawning";
+    middlewareMocks.subscribeCurrent("run-fork", store);
+    const connecting = store.connectSession("run-fork");
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    spawn.resolve();
+
+    await expect(connecting).resolves.toBeUndefined();
+    await expect(loadingB).resolves.toBe(true);
+    expect(currentRunId(store)).toBe("run-b");
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+  });
+
+  it("ignores a fork step-two rejection after route ownership changes", async () => {
+    const spawn = deferred();
+    transportMocks.subscribeRun.mockResolvedValue(undefined);
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    store.run = run("run-fork", "pending") as never;
+    store.phase = "spawning";
+    middlewareMocks.subscribeCurrent("run-fork", store);
+    const connecting = store.connectSession("run-fork");
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    store.invalidateOperationsForRoute("run-b");
+    const loadingB = store.loadRun("run-b");
+    spawn.reject(new Error("old spawn failed"));
+
+    await expect(connecting).resolves.toBeUndefined();
+    await expect(loadingB).resolves.toBe(true);
+    expect(currentRunId(store)).toBe("run-b");
+    expect(store.error).toBe("");
+  });
+
+  it("does not create or route a new run after navigation while settings load", async () => {
+    const settings = deferredValue<{ auth_mode: string; active_platform_id: string }>();
+    apiMocks.getUserSettings.mockReturnValueOnce(settings.promise);
+    const store = new SessionStore();
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.getUserSettings).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    await expect(loadingB).resolves.toBe(true);
+    settings.resolve({ auth_mode: "api", active_platform_id: "platform-a" });
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    expect(apiMocks.startRun).not.toHaveBeenCalled();
+    expect(currentRunId(store)).toBe("run-b");
+    expect(store.platformId).toBeNull();
+  });
+
+  it("does not apply stale agent plan mode to the run opened during settings load", async () => {
+    const agentSettings = deferredValue<{ plan_mode: boolean }>();
+    apiMocks.getAgentSettings.mockReturnValueOnce(agentSettings.promise);
+    const store = new SessionStore();
+    store.permissionMode = "default";
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.getAgentSettings).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    await expect(store.loadRun("run-b")).resolves.toBe(true);
+    agentSettings.resolve({ plan_mode: true });
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    expect(apiMocks.startRun).not.toHaveBeenCalled();
+    expect(currentRunId(store)).toBe("run-b");
+    expect(store.permissionMode).toBe("default");
+  });
+
+  it("does not apply fallback permission mode after a stale agent-settings rejection", async () => {
+    const agentSettings = deferredValue<{ plan_mode: boolean }>();
+    apiMocks.getUserSettings.mockResolvedValueOnce({
+      auth_mode: "cli",
+      permission_mode: "auto_all",
+    });
+    apiMocks.getAgentSettings.mockReturnValueOnce(agentSettings.promise);
+    const store = new SessionStore();
+    store.permissionMode = "default";
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.getAgentSettings).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    await expect(store.loadRun("run-b")).resolves.toBe(true);
+    agentSettings.reject(new Error("old settings request failed"));
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    expect(apiMocks.startRun).not.toHaveBeenCalled();
+    expect(currentRunId(store)).toBe("run-b");
+    expect(store.permissionMode).toBe("default");
+  });
+
+  it("leaves a newly persisted run in the run list after navigation before spawn", async () => {
+    const created = deferredValue<ReturnType<typeof run>>();
+    apiMocks.startRun.mockReturnValueOnce(created.promise);
+    const store = new SessionStore();
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.startRun).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    created.resolve(run("run-new", "pending"));
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    await expect(loadingB).resolves.toBe(true);
+    expect(apiMocks.startSession).not.toHaveBeenCalled();
+    expect(currentRunId(store)).toBe("run-b");
+  });
+
+  it("does not install timers after a new session spawn resolves on another route", async () => {
+    const spawn = deferred();
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    spawn.resolve();
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    await expect(loadingB).resolves.toBe(true);
+    expect(currentRunId(store)).toBe("run-b");
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+    expect((store as unknown as { _responseTimer: unknown })._responseTimer).toBeNull();
+  });
+
+  it("does not bind a stopped Codex restart timer to the run opened during spawn", async () => {
+    const spawn = deferred();
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    store.run = {
+      ...run("run-codex", "stopped"),
+      agent: "codex",
+      conversation_ref: { kind: "codex_thread", id: "thread-1" },
+    } as never;
+    store.agent = "codex";
+    store.phase = "stopped";
+    middlewareMocks.subscribeCurrent("run-codex", store);
+    const sending = store.sendMessage("continue", []);
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    middlewareMocks.subscribeCurrent("run-b", store);
+    expect(store.invalidateOperationsForRoute("run-b")).toBe(true);
+    const loadingB = store.loadRun("run-b");
+    spawn.resolve();
+
+    await expect(sending).resolves.toEqual({ status: "cancelled" });
+    await expect(loadingB).resolves.toBe(true);
+    expect(currentRunId(store)).toBe("run-b");
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+  });
+
+  it("cancels a new-session spawn after unmount without installing timers", async () => {
+    const spawn = deferred();
+    apiMocks.startSession.mockReturnValueOnce(spawn.promise);
+    const store = new SessionStore();
+    const starting = store.startSession("hello", "/tmp", []);
+    await vi.waitFor(() => expect(apiMocks.startSession).toHaveBeenCalled());
+
+    store.unmountGuards();
+    spawn.resolve();
+
+    await expect(starting).resolves.toEqual({ status: "cancelled" });
+    expect((store as unknown as { _spawnTimer: unknown })._spawnTimer).toBeNull();
+    expect((store as unknown as { _responseTimer: unknown })._responseTimer).toBeNull();
+  });
+});

--- a/src/lib/stores/session-store.svelte.ts
+++ b/src/lib/stores/session-store.svelte.ts
@@ -20,6 +20,9 @@ import type {
   TodoItem,
   PanelTask,
   CodexAgentIdentity,
+  HistoryEntry,
+  HistoryPage,
+  HistorySummary,
 } from "$lib/types";
 import { dbg, dbgWarn } from "$lib/utils/debug";
 import { yieldToMain } from "$lib/utils/yield";
@@ -55,6 +58,11 @@ import {
 const CLI_PERM_MODE_ALIASES: Record<string, string> = {
   delegate: "acceptEdits", // CLI v2.1.81+ renamed acceptEdits → delegate
 };
+
+const MAX_HISTORY_PROJECTION_REBUILDS = 3;
+const HISTORY_PROJECTION_REQUIRED = "HISTORY_PROJECTION_REQUIRED";
+const HISTORY_PREPEND_PAGE_LIMIT = 12;
+const HISTORY_PREPEND_ENTRY_TARGET = 50;
 
 function normalizePermissionMode(mode: string): string {
   return CLI_PERM_MODE_ALIASES[mode] ?? mode;
@@ -103,6 +111,15 @@ class OpGuard {
   }
 }
 
+export type ResumeSessionResult =
+  | { status: "success"; runId: string }
+  | { status: "failed" }
+  | { status: "cancelled" };
+
+export type StartSessionResult = { status: "success"; runId: string } | { status: "cancelled" };
+
+export type SendMessageResult = { status: "success" } | { status: "cancelled" };
+
 // ── Helpers ──
 
 function eventTs(ev: BusEvent): string {
@@ -128,6 +145,115 @@ function eventTsMs(ev: BusEvent): number {
   const iso = eventTs(ev);
   const ms = new Date(iso).getTime();
   return Number.isFinite(ms) ? ms : Date.now();
+}
+
+function historyEntryToTimeline(entry: HistoryEntry): TimelineEntry {
+  switch (entry.kind) {
+    case "user":
+      return {
+        kind: "user",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        content: entry.content.preview,
+        ts: entry.ts,
+        attachments: entry.attachments,
+        cliUuid: entry.cliUuid,
+        historyContent: entry.content.truncated ? entry.content : undefined,
+      };
+    case "assistant":
+      return {
+        kind: "assistant",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        content: entry.content.preview,
+        ts: entry.ts,
+        thinkingText: entry.thinking?.preview,
+        model: entry.model,
+        historyContent: entry.content.truncated ? entry.content : undefined,
+        thinkingHistoryContent: entry.thinking?.truncated ? entry.thinking : undefined,
+      };
+    case "tool":
+      return {
+        kind: "tool",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        ts: entry.ts,
+        tool: {
+          tool_use_id: entry.toolUseId,
+          tool_name: entry.toolName,
+          status: entry.status,
+          input: entry.input,
+          output: entry.output ?? undefined,
+          tool_use_result: entry.toolUseResult,
+          duration_ms: entry.durationMs,
+          _historyContent: {
+            input: entry.inputContent,
+            output: entry.outputContent,
+            result: entry.resultContent,
+          },
+          _subHistoryId: entry.subHistoryId,
+        },
+      };
+    case "command_output":
+    case "placeholder":
+      return {
+        kind: "command_output",
+        id: entry.id,
+        anchorId: entry.anchorId,
+        content: entry.content.preview,
+        ts: entry.ts,
+        historyContent: entry.content.truncated ? entry.content : undefined,
+      };
+  }
+}
+
+class CatchupSemanticTracker {
+  private streamingScopes = new Set<string>();
+  private openTools = new Set<string>();
+
+  observe(event: BusEvent): boolean {
+    const raw = event as BusEvent & {
+      parent_tool_use_id?: string;
+      tool_use_id?: string;
+      state?: string;
+    };
+    const scope = raw.parent_tool_use_id || "__main";
+    const isTurnBoundary =
+      (event.type === "user_message" && scope === "__main") ||
+      (event.type === "run_state" &&
+        ["spawning", "running", "idle", "completed", "failed", "stopped"].includes(
+          raw.state ?? "",
+        ));
+    if (isTurnBoundary) {
+      const interrupted = this.streamingScopes.size > 0 || this.openTools.size > 0;
+      this.streamingScopes.clear();
+      this.openTools.clear();
+      return interrupted;
+    }
+    switch (event.type) {
+      case "message_delta":
+      case "thinking_delta":
+        this.streamingScopes.add(scope);
+        break;
+      case "message_complete":
+        this.streamingScopes.delete(scope);
+        break;
+      case "tool_start":
+        if (raw.tool_use_id) this.openTools.add(`${scope}\0${raw.tool_use_id}`);
+        break;
+      case "tool_end":
+        if (raw.tool_use_id) {
+          const exact = `${scope}\0${raw.tool_use_id}`;
+          if (!this.openTools.delete(exact)) {
+            for (const key of this.openTools) {
+              if (key.endsWith(`\0${raw.tool_use_id}`)) this.openTools.delete(key);
+            }
+          }
+        }
+        break;
+    }
+    return false;
+  }
 }
 
 // ── Internal batch state (plain objects, no reactivity) ──
@@ -181,49 +307,6 @@ function timelineAttachments(atts: Attachment[]): Attachment[] | undefined {
   );
 }
 
-/** Replay RunEvent[] into an xterm terminal.
- *  Handles: user (prompt), system (status), stdout (agent output),
- *  stderr (error stream), assistant (final reply). */
-function replayTerminalEvents(
-  events: import("$lib/types").RunEvent[],
-  xtermRef: { writeText(s: string): void },
-  isRunning: boolean,
-): void {
-  let hasHistory = false;
-  for (const event of events) {
-    const text = String(
-      (event.payload as Record<string, unknown>).text ??
-        (event.payload as Record<string, unknown>).message ??
-        "",
-    );
-    if (!text) continue;
-    switch (event.type) {
-      case "user":
-        xtermRef.writeText(`\x1b[1;36m> ${text}\x1b[0m\r\n`);
-        hasHistory = true;
-        break;
-      case "system":
-        xtermRef.writeText(`\x1b[90m${text}\x1b[0m\r\n`);
-        break;
-      case "stdout":
-        xtermRef.writeText(text);
-        hasHistory = true;
-        break;
-      case "stderr":
-        xtermRef.writeText(`\x1b[31m${text}\x1b[0m\r\n`);
-        hasHistory = true;
-        break;
-      case "assistant":
-        xtermRef.writeText(`${text}\r\n`);
-        hasHistory = true;
-        break;
-    }
-  }
-  if (hasHistory && !isRunning) {
-    xtermRef.writeText(`\r\n\x1b[90m--- Session ended ---\x1b[0m\r\n`);
-  }
-}
-
 /** Map frontend Attachment[] to backend AttachmentData format for IPC. */
 function mapAttachments(
   atts: Attachment[],
@@ -246,6 +329,8 @@ export interface ElicitationState {
   mode?: string;
   url?: string;
   requestedSchema?: ElicitationSchema;
+  responseStatus?: "pending" | "responding" | "error";
+  responseError?: string;
 }
 
 export interface TaskNotificationItem {
@@ -309,7 +394,14 @@ export class SessionStore {
       hook_id: string;
       data: unknown;
       request_id?: string;
-      status?: "hook_pending" | "allowed" | "denied" | "cancelled";
+      status?:
+        | "hook_pending"
+        | "responding"
+        | "allowed"
+        | "denied"
+        | "cancelled"
+        | "resolved"
+        | "error";
       hook_name?: string;
       stdout?: string;
       stderr?: string;
@@ -447,6 +539,11 @@ export class SessionStore {
   private _toolHeIndex = new Map<string, number>();
   /** _lastProcessedSeq at last snapshot write — throttles idle snapshot rewrites. */
   private _lastSnapshotSeq = 0;
+
+  historySummary: HistorySummary | null = $state(null);
+  historyPageCursor: string | null = $state(null);
+  historyHasMore = $state(false);
+  historyLoadingOlder = $state(false);
 
   /** Runtime state: whether the current run uses chat timeline (bus-events) rendering.
    *  Only meaningful when `this.run` is set. Set by loadRun/startSession/resumeSession. */
@@ -703,7 +800,9 @@ export class SessionStore {
 
   /** Whether any MCP elicitation prompt is pending user response. */
   get hasElicitation(): boolean {
-    return this.pendingElicitations.size > 0;
+    return [...this.pendingElicitations.values()].some(
+      (elicitation) => (elicitation.responseStatus ?? "pending") === "pending",
+    );
   }
 
   /** True when the turn is legitimately paused waiting on the user (permission approval,
@@ -1038,7 +1137,7 @@ export class SessionStore {
     return undefined;
   }
 
-  /** Search ALL subTimelines (one level deep) for a tool with the given id.
+  /** Search all nested subTimelines for a tool with the given id.
    *  Used when parent_tool_use_id is missing but the tool exists in a subTimeline.
    *  Returns true if found and updated; false if not found. */
   private _updateToolInAnySubTimeline(
@@ -1047,27 +1146,40 @@ export class SessionStore {
     ctx: ReduceCtx | null,
   ): boolean {
     const tl = ctx ? ctx.tl : this.timeline;
-    for (let pIdx = 0; pIdx < tl.length; pIdx++) {
-      const entry = tl[pIdx];
-      if (entry.kind !== "tool" || !entry.subTimeline) continue;
-      const sub = entry.subTimeline;
-      const cIdx = sub.findIndex((e) => e.kind === "tool" && e.id === toolUseId);
-      if (cIdx < 0) continue;
-      // Found in this parent's subTimeline — update it
-      const oldChild = sub[cIdx] as Extract<TimelineEntry, { kind: "tool" }>;
-      const newSub = [...sub];
-      newSub[cIdx] = { ...oldChild, tool: updater(oldChild.tool) };
-      const updatedParent: TimelineEntry = { ...entry, subTimeline: newSub };
-      if (ctx) {
-        ctx.tl[pIdx] = updatedParent;
-      } else {
-        const u = [...this.timeline];
-        u[pIdx] = updatedParent;
-        this.timeline = u;
+    const updateNested = (
+      entries: TimelineEntry[],
+    ): { entries: TimelineEntry[]; found: boolean; parentId?: string } => {
+      for (let idx = 0; idx < entries.length; idx++) {
+        const entry = entries[idx];
+        if (entry.kind !== "tool") continue;
+        if (entry.id === toolUseId) {
+          const next = [...entries];
+          next[idx] = { ...entry, tool: updater(entry.tool) };
+          return { entries: next, found: true };
+        }
+        if (!entry.subTimeline) continue;
+        const nested = updateNested(entry.subTimeline);
+        if (nested.found) {
+          const next = [...entries];
+          next[idx] = { ...entry, subTimeline: nested.entries };
+          return { entries: next, found: true, parentId: nested.parentId ?? entry.id };
+        }
       }
+      return { entries, found: false };
+    };
+
+    for (let parentIdx = 0; parentIdx < tl.length; parentIdx++) {
+      const parent = tl[parentIdx];
+      if (parent.kind !== "tool" || !parent.subTimeline) continue;
+      const nested = updateNested(parent.subTimeline);
+      if (!nested.found) continue;
+      const updated = [...tl];
+      updated[parentIdx] = { ...parent, subTimeline: nested.entries };
+      if (ctx) ctx.tl = updated;
+      else this.timeline = updated;
       dbg("store", "found tool in subTimeline (missing parent_tool_use_id)", {
         tool: toolUseId,
-        parent: entry.id,
+        parent: nested.parentId ?? parent.id,
       });
       return true;
     }
@@ -1609,6 +1721,215 @@ export class SessionStore {
     this._toolTlIndex.clear();
     this._toolHeIndex.clear();
     this._lastSnapshotSeq = 0;
+    this.historySummary = null;
+    this.historyPageCursor = null;
+    this.historyHasMore = false;
+    this.historyLoadingOlder = false;
+  }
+
+  private _applyHistoryPage(summary: HistorySummary, page: HistoryPage): void {
+    if (page.generationId !== summary.generationId) {
+      throw new Error("History generation changed while loading");
+    }
+    this.timeline = page.entries.map(historyEntryToTimeline);
+    this.historySummary = summary;
+    this.historyPageCursor = page.pageCursor;
+    this.historyHasMore = page.hasMore;
+    this.numTurns = summary.totalTurns;
+    this._lastProcessedSeq = summary.lastSeq;
+    this._toolTlIndex.clear();
+    for (let i = 0; i < this.timeline.length; i++) {
+      const entry = this.timeline[i];
+      if (entry.kind === "tool" && !this._toolTlIndex.has(entry.id)) {
+        this._toolTlIndex.set(entry.id, i);
+      }
+    }
+    dbg("history", "latest page applied", {
+      generation: summary.generationId,
+      entries: page.entries.length,
+      totalEntries: summary.totalEntries,
+      hasMore: page.hasMore,
+    });
+  }
+
+  private async _loadLatestHistory(
+    runId: string,
+    isStale: () => boolean,
+    refresh = false,
+  ): Promise<HistorySummary | null> {
+    const summary = refresh
+      ? await api.getHistorySummary(runId, true)
+      : await api.getHistorySummary(runId);
+    if (isStale()) return null;
+    const page =
+      summary.pageCount > 0 ? await api.getHistoryPage(runId, summary.generationId) : null;
+    if (isStale()) return null;
+    if (page) {
+      this._applyHistoryPage(summary, page);
+    } else {
+      this.historySummary = summary;
+      this._lastProcessedSeq = summary.lastSeq;
+    }
+    // Interaction events mutate entries from the projected page, so restore them only after the
+    // page is installed; applying them first would discard synthetic pending permission cards.
+    if (summary.stateEvents.length > 0) {
+      this.applyEventBatch(summary.stateEvents, { replayOnly: true });
+    }
+    return summary;
+  }
+
+  private async _loadHistoryWithCatchup(
+    runId: string,
+    isStale: () => boolean,
+    replayOnly: boolean,
+  ): Promise<{ summary: HistorySummary; catchupCount: number } | null> {
+    let summary = await this._loadLatestHistory(runId, isStale);
+    if (!summary) return null;
+    let catchupSeq = summary.lastSeq;
+    let catchupOffset = summary.sourceSize;
+    let projectionRebuilds = 0;
+    let catchupCount = 0;
+    let semanticTracker = new CatchupSemanticTracker();
+    const rebuildProjection = async (reason: "oversized" | "semantic"): Promise<boolean> => {
+      if (projectionRebuilds >= MAX_HISTORY_PROJECTION_REBUILDS) {
+        throw new Error(`History catch-up remained ${reason} after bounded rebuilds`);
+      }
+      const previousSeq = catchupSeq;
+      const previousOffset = catchupOffset;
+      projectionRebuilds += 1;
+      this._clearContentState();
+      const rebuilt = await this._loadLatestHistory(runId, isStale, true);
+      if (!rebuilt) return false;
+      const regressed = rebuilt.lastSeq < previousSeq || rebuilt.sourceSize < previousOffset;
+      const advanced = rebuilt.lastSeq > previousSeq || rebuilt.sourceSize > previousOffset;
+      if (regressed || !advanced) {
+        throw new Error("History projection checkpoint did not advance during rebuild");
+      }
+      summary = rebuilt;
+      catchupSeq = rebuilt.lastSeq;
+      catchupOffset = rebuilt.sourceSize;
+      catchupCount = 0;
+      semanticTracker = new CatchupSemanticTracker();
+      dbg("history", "projection rebuilt", {
+        runId,
+        reason,
+        attempt: projectionRebuilds,
+        lastSeq: catchupSeq,
+        sourceSize: catchupOffset,
+      });
+      return true;
+    };
+    while (true) {
+      let catchupPage;
+      try {
+        catchupPage = await api.getBusEventsPage(runId, catchupSeq, catchupOffset);
+      } catch (e) {
+        if (!String(e).includes(HISTORY_PROJECTION_REQUIRED)) throw e;
+        dbgWarn("history", "catch-up contains oversized event; rebuilding pages", e);
+        if (!(await rebuildProjection("oversized"))) return null;
+        continue;
+      }
+      if (isStale()) return null;
+      const crossedInterruptedBoundary = catchupPage.events.some((event) =>
+        semanticTracker.observe(event),
+      );
+      if (crossedInterruptedBoundary) {
+        dbg("history", "catch-up crossed interrupted turn; rebuilding projection", {
+          runId,
+          events: catchupPage.events.length,
+        });
+        if (!(await rebuildProjection("semantic"))) return null;
+        continue;
+      }
+      if (catchupPage.events.length > 0) {
+        const ms = await this.applyEventBatchAsync(catchupPage.events, {
+          replayOnly,
+          isStale,
+        });
+        if (ms === null) return null;
+        catchupCount += catchupPage.events.length;
+      }
+      if (!catchupPage.hasMore) break;
+      if (catchupPage.lastSeq <= catchupSeq) {
+        throw new Error("History catch-up cursor did not advance");
+      }
+      catchupSeq = catchupPage.lastSeq;
+      catchupOffset = catchupPage.nextOffset;
+      dbg("history", "catch-up page applied", {
+        runId,
+        events: catchupPage.events.length,
+        lastSeq: catchupSeq,
+      });
+    }
+    return { summary, catchupCount };
+  }
+
+  async loadOlderHistory(): Promise<boolean> {
+    const runId = this.run?.id;
+    const summary = this.historySummary;
+    const cursor = this.historyPageCursor;
+    if (!runId || !summary || !cursor || !this.historyHasMore || this.historyLoadingOlder) {
+      return false;
+    }
+    const loadGen = this._loadGen;
+    this.historyLoadingOlder = true;
+    try {
+      const existing = new Set(this.timeline.map((entry) => `${entry.kind}:${entry.id}`));
+      const pages: TimelineEntry[][] = [];
+      let nextCursor = cursor;
+      let hasMore: boolean = this.historyHasMore;
+      let pageCount = 0;
+      let entryCount = 0;
+      while (
+        hasMore &&
+        pageCount < HISTORY_PREPEND_PAGE_LIMIT &&
+        entryCount < HISTORY_PREPEND_ENTRY_TARGET
+      ) {
+        const page = await api.getHistoryPage(runId, summary.generationId, nextCursor);
+        if (loadGen !== this._loadGen || this.run?.id !== runId) return false;
+        if (page.generationId !== summary.generationId) {
+          throw new Error("History generation changed while loading older messages");
+        }
+        if (page.pageCursor === nextCursor && page.hasMore) {
+          throw new Error("History page cursor did not advance while loading older messages");
+        }
+        const older = page.entries.map(historyEntryToTimeline).filter((entry) => {
+          const key = `${entry.kind}:${entry.id}`;
+          if (existing.has(key)) return false;
+          existing.add(key);
+          return true;
+        });
+        // Pages arrive newest-to-oldest; prepend each page to retain chronological order when
+        // the batch is committed to the timeline once after all bounded reads complete.
+        pages.unshift(older);
+        entryCount += older.length;
+        pageCount += 1;
+        nextCursor = page.pageCursor;
+        hasMore = page.hasMore;
+      }
+      const older = pages.flat();
+      this.timeline = [...older, ...this.timeline];
+      this.historyPageCursor = nextCursor;
+      this.historyHasMore = hasMore;
+      this._toolTlIndex.clear();
+      for (let i = 0; i < this.timeline.length; i++) {
+        const entry = this.timeline[i];
+        if (entry.kind === "tool" && !this._toolTlIndex.has(entry.id)) {
+          this._toolTlIndex.set(entry.id, i);
+        }
+      }
+      dbg("history", "older page prepended", {
+        entries: older.length,
+        pages: pageCount,
+        hasMore,
+      });
+      return older.length > 0;
+    } catch (e) {
+      dbgWarn("history", "older page failed", e);
+      throw e;
+    } finally {
+      if (loadGen === this._loadGen) this.historyLoadingOlder = false;
+    }
   }
 
   /** Optimistically remove an elicitation after responding.
@@ -1866,15 +2187,19 @@ export class SessionStore {
   async loadRun(
     id: string,
     xtermRef?: { clear(): void; writeText(s: string): void },
-  ): Promise<void> {
+  ): Promise<boolean> {
     const gen = ++this._loadGen;
     const loadStart = performance.now();
+    const middleware = getEventMiddleware();
     dbg("store", "loadRun id=", id, "gen=", gen);
 
     if (!id) {
       this.reset();
-      return;
+      return true;
     }
+
+    const historyLoadToken = middleware.beginHistoryLoad(id, this);
+    let historyLoadReleased = false;
 
     // Reset state for new load
     this._setPhase("loading");
@@ -1889,7 +2214,7 @@ export class SessionStore {
       this.run = await api.getRun(id);
       if (gen !== this._loadGen) {
         dbg("store", "stale after getRun, gen=", gen);
-        return;
+        return false;
       }
 
       // Auto-sync CLI imports to pick up events written after the initial import
@@ -1910,7 +2235,7 @@ export class SessionStore {
         }
         if (gen !== this._loadGen) {
           dbg("store", "stale after auto-sync, gen=", gen);
-          return;
+          return false;
         }
       }
 
@@ -1924,6 +2249,8 @@ export class SessionStore {
       const st = this.run.status;
       if (st === "running") {
         this._setPhase("running");
+      } else if (st === "idle") {
+        this._setPhase("idle");
       } else if (st === "completed" || st === "failed" || st === "stopped") {
         this._setPhase(st as SessionPhase);
       } else {
@@ -1940,156 +2267,34 @@ export class SessionStore {
         this.run!.execution_path === "session_actor" ||
         (this.run!.execution_path === "pipe_exec" && !isTerminal && !!this.run!.conversation_ref);
 
-      if (this.useStreamSession) {
-        let reducerMs = 0;
-        let snapshotHit = false;
-
-        // Try IDB snapshot (terminal + idle sessions)
-        const snapshotEligible = isTerminal || this.run!.status === "idle";
-        let snapshotBody: string | null = null;
-        if (snapshotEligible) {
-          try {
-            snapshotBody = await snapshotCache.readSnapshot(id, this.run!.status);
-          } catch {
-            /* IDB unavailable → miss */
-          }
-          if (gen !== this._loadGen) return;
-        }
-
-        if (snapshotBody) {
-          const isIdleSnap = !isTerminal;
-          // Parse once, used for both seq check and apply
-          const parsed = this._parseSnapshotBody(snapshotBody);
-          if (!parsed) {
-            snapshotBody = null; // corrupted JSON
-          } else {
-            const snapSeq = isIdleSnap ? ((parsed._lastProcessedSeq as number) ?? 0) : 1;
-
-            if (snapSeq === 0 && isIdleSnap) {
-              // seq=0: skip snapshot, delete stale entry to prevent repeated hit-then-skip
-              dbg("store", "idle snapshot seq=0, skipping for full replay");
-              snapshotCache.deleteSnapshot(id).catch(() => {});
-              snapshotBody = null; // fall through to miss path
-            } else if (this._tryApplySnapshot(parsed)) {
-              snapshotHit = true;
-              // Align _lastSnapshotSeq to prevent unnecessary rewrite on first idle
-              this._lastSnapshotSeq = this._lastProcessedSeq;
-
-              // Fix: idle snapshot hit → phase must be "idle", not "ready"
-              if (isIdleSnap) this._setPhase("idle");
-
-              // Desktop idle: incremental catchup (no WS available)
-              if (isIdleSnap && getTransport().isDesktop()) {
-                const catchupEvents = await api.getBusEvents(id, this._lastProcessedSeq);
-                if (gen !== this._loadGen) return;
-                if (catchupEvents.length > 0) {
-                  dbg("store", "idle snapshot catchup", { count: catchupEvents.length });
-                  const catchupMs = await this.applyEventBatchAsync(catchupEvents, {
-                    replayOnly: false,
-                    isStale: () => gen !== this._loadGen,
-                  });
-                  // Stale (catchupMs === null) means a newer load owns the store —
-                  // do NOT touch _isLoadingReplay; the new owner manages it.
-                  if (catchupMs === null) return;
-                  const catchupSt = this.run?.status;
-                  if (
-                    catchupSt === "idle" ||
-                    catchupSt === "completed" ||
-                    catchupSt === "failed" ||
-                    catchupSt === "stopped"
-                  ) {
-                    this._saveSnapshotToIdb(id);
-                  }
-                }
-              } else if (isIdleSnap) {
-                this._wsSubscribeWithSeq(id, this._lastProcessedSeq);
-              }
-              // Terminal: no catchup needed, just subscribe for WS if applicable
-              if (!isIdleSnap) {
-                this._wsSubscribeWithSeq(id, this._lastProcessedSeq);
-              }
-            } else {
-              snapshotBody = null; // shape validation failed
-            }
-          }
-        }
-
-        if (!snapshotHit) {
-          // Miss or snapshot corrupted → normal path
-          const busEvents = await api.getBusEvents(id);
-          if (gen !== this._loadGen) {
-            dbg("store", "stale after getBusEvents, gen=", gen);
-            return;
-          }
-          const ms = await this.applyEventBatchAsync(busEvents, {
-            replayOnly: isTerminal,
-            isStale: () => gen !== this._loadGen,
-          });
-          // Stale: a newer load owns the store; do not touch _isLoadingReplay.
-          if (ms === null) return;
-          reducerMs = ms;
-          this._wsSubscribeAfterLoad(id, busEvents);
-          // Write guard: distinguish "legit empty session" from "reducer anomaly"
-          if (snapshotEligible && (this.timeline.length > 0 || busEvents.length === 0)) {
-            this._saveSnapshotToIdb(id);
-          }
-        }
-
-        this._isLoadingReplay = false;
-        dbg("store", "loadRun", {
-          total: Math.round(performance.now() - loadStart),
-          snapshotHit,
-          reducer: Math.round(reducerMs),
-          entries: this.timeline.length,
-        });
-      } else if (this.caps.supportsBusEvents) {
-        // Codex bus-events path: try bus-events, fall back to terminal
-        const busEvents = await api.getBusEvents(id);
-        if (gen !== this._loadGen) {
-          dbg("store", "stale after getBusEvents (codex), gen=", gen);
-          return;
-        }
-        let reducerMs = 0;
-        if (busEvents.length > 0) {
-          this._useChatTimelineForRun = true;
-          // Always replayOnly for loadRun — these are persisted historical events.
-          // Live events arrive via WS subscription (set up below).
-          reducerMs = this.applyEventBatch(busEvents, { replayOnly: true });
-        } else if (!isTerminal && this.run?.conversation_ref?.kind === "codex_thread") {
-          // Active Phase 2 run with no bus-events yet (just started) → timeline, wait for real-time
-          this._useChatTimelineForRun = true;
-        } else {
-          // Terminal run with no bus-events OR active Phase 1 run (no conversation_ref) → terminal
-          this._useChatTimelineForRun = false;
-          // Replay terminal history (same as legacy branch below)
-          if (xtermRef) {
-            const termEvents = await api.getRunEvents(id);
-            if (gen !== this._loadGen) return;
-            replayTerminalEvents(termEvents, xtermRef, this.isRunning);
-          }
-        }
-        // Non-terminal Phase 2 runs must subscribe regardless of history
-        if (!isTerminal && this._useChatTimelineForRun) {
-          this._wsSubscribeAfterLoad(id, busEvents);
-        }
-        this._isLoadingReplay = false;
-        dbg("store", "loadRun (codex bus)", {
-          events: busEvents.length,
-          reducer: Math.round(reducerMs),
-          timeline: this._useChatTimelineForRun,
-        });
-      } else {
-        this._isLoadingReplay = false;
-        // CLI mode: replay history in terminal
-        const events = await api.getRunEvents(id);
-        if (gen !== this._loadGen) {
-          dbg("store", "stale after getRunEvents, gen=", gen);
-          return;
-        }
-        if (xtermRef) {
-          replayTerminalEvents(events, xtermRef, this.isRunning);
-        }
+      const restored = isTerminal
+        ? await this._loadLatestHistory(id, () => gen !== this._loadGen).then((summary) =>
+            summary ? { summary, catchupCount: 0 } : null,
+          )
+        : await this._loadHistoryWithCatchup(id, () => gen !== this._loadGen, false);
+      if (!restored) return false;
+      const { summary, catchupCount } = restored;
+      const pageEntries = this.timeline.length;
+      this._useChatTimelineForRun = true;
+      snapshotCache.deleteSnapshot(id).catch(() => {});
+      await this._wsSubscribeWithSeq(id, this._lastProcessedSeq);
+      if (gen !== this._loadGen || this.run?.id !== id) {
+        dbg("store", "stale after WS subscribe", { id, gen });
+        this._cancelWsSubscriptionIfInactive(id);
+        return false;
       }
+      // Keep live and replayed WS events buffered until the server acknowledges that replay and
+      // buffer flush completed for this checkpoint.
+      middleware.finishHistoryLoad(id, this, historyLoadToken, this._lastProcessedSeq);
+      historyLoadReleased = true;
+      this._isLoadingReplay = false;
+      dbg("store", "loadRun paged", {
+        total: Math.round(performance.now() - loadStart),
+        generation: summary.generationId,
+        pageEntries,
+        totalEntries: summary.totalEntries,
+        catchup: catchupCount,
+      });
 
       // After replay, reconcile phase with run.status:
       // bus events may leave phase as "idle"/"running" even though the run
@@ -2110,11 +2315,17 @@ export class SessionStore {
         dbg("store", "restore run model from meta:", this.run.model);
         this.model = this.run.model;
       }
+      return true;
     } catch (e) {
-      if (gen !== this._loadGen) return;
+      if (gen !== this._loadGen) return false;
       this._isLoadingReplay = false;
       this.error = String(e);
       this._setPhase("failed");
+      return false;
+    } finally {
+      if (!historyLoadReleased) {
+        middleware.cancelHistoryLoad(id, this, historyLoadToken);
+      }
     }
   }
 
@@ -2127,7 +2338,9 @@ export class SessionStore {
     cwd: string,
     attachments: Attachment[],
     permissionModeOverride?: string,
-  ): Promise<string> {
+  ): Promise<StartSessionResult> {
+    const operationGen = this._loadGen;
+    const isStale = () => !this._resumeGuard.isMounted || operationGen !== this._loadGen;
     this.error = "";
     this._setPhase("spawning");
 
@@ -2137,6 +2350,7 @@ export class SessionStore {
       // if the user changed settings without navigating away from chat.
       try {
         const freshSettings = await api.getUserSettings();
+        if (isStale()) return { status: "cancelled" };
         if (freshSettings.auth_mode === "api") {
           const freshPid = freshSettings.active_platform_id ?? "anthropic";
           if (freshPid !== this.platformId) {
@@ -2174,6 +2388,7 @@ export class SessionStore {
           } catch {
             /* non-fatal */
           }
+          if (isStale()) return { status: "cancelled" };
 
           if (agentPlanMode) {
             if (this.permissionMode !== "plan") {
@@ -2197,6 +2412,7 @@ export class SessionStore {
       } catch {
         // Non-fatal: fall through with current store values
       }
+      if (isStale()) return { status: "cancelled" };
 
       // Explicitly pass execution_path for Claude (source of truth for run mode).
       // For Codex, defer to the backend: it picks session_actor (app-server transport) vs
@@ -2215,6 +2431,12 @@ export class SessionStore {
         this.platformId || undefined,
         executionPath,
       );
+      if (isStale()) {
+        // startRun already persisted the run. Leave it under backend/run-list ownership while
+        // this stale frontend operation refrains from routing or spawning it.
+        dbg("store", "startSession stale after run creation", { runId: run.id, operationGen });
+        return { status: "cancelled" };
+      }
       this.run = run;
 
       if (this.useStreamSession) {
@@ -2240,6 +2462,10 @@ export class SessionStore {
           this.platformId || undefined,
           permissionModeOverride,
         );
+        if (isStale() || this.run?.id !== run.id) {
+          dbg("store", "startSession stale after CLI spawn", { runId: run.id, operationGen });
+          return { status: "cancelled" };
+        }
         dbg("store", "startSession resolved");
         // phase will be set by run_state bus event
         this._startSpawnTimeout(run.id);
@@ -2264,16 +2490,28 @@ export class SessionStore {
           undefined,
           clientUuid,
         );
+        if (isStale() || this.run?.id !== run.id) {
+          dbg("store", "startSession stale after bus-event spawn", {
+            runId: run.id,
+            operationGen,
+          });
+          return { status: "cancelled" };
+        }
       } else {
         // PipeExec path (Codex): useStreamSession is false iff the freshly
         // created run has execution_path=pipe_exec, so sendChatMessage is the
         // correct IPC. SessionActor runs always go through the branch above.
         this._setPhase("running");
         await api.sendChatMessage(run.id, prompt, attachments.length > 0 ? attachments : undefined);
+        if (isStale() || this.run?.id !== run.id) {
+          dbg("store", "startSession stale after pipe spawn", { runId: run.id, operationGen });
+          return { status: "cancelled" };
+        }
       }
 
-      return run.id;
+      return { status: "success", runId: run.id };
     } catch (e) {
+      if (isStale()) return { status: "cancelled" };
       this.error = String(e);
       this._setPhase("failed");
       throw e;
@@ -2288,8 +2526,14 @@ export class SessionStore {
     // the agent triggers the skill via a {type:"skill"} UserInput item. Live-Codex only (the
     // picker is gated to that); empty/undefined = unchanged behavior for Claude and no-skill sends.
     skills?: { name: string; path: string }[],
-  ): Promise<void> {
-    if (!this.run) return;
+  ): Promise<SendMessageResult> {
+    if (!this.run) return { status: "cancelled" };
+    const targetRunId = this.run.id;
+    const operationGen = this._loadGen;
+    const isStale = () =>
+      !this._resumeGuard.isMounted ||
+      operationGen !== this._loadGen ||
+      this.run?.id !== targetRunId;
     this.error = "";
     // Invalidate idle snapshot — user is sending a new message
     snapshotCache.deleteSnapshot(this.run.id).catch(() => {});
@@ -2313,7 +2557,8 @@ export class SessionStore {
         // through to the normal enqueue path below.) The steered text still shows as a user
         // entry via the optimistic push; the backend does not echo a separate UserMessage.
         this._pushOptimisticUser(text, attachments);
-        await api.steerSession(this.run.id, text);
+        await api.steerSession(targetRunId, text);
+        if (isStale()) return { status: "cancelled" };
         dbg("store", "codex mid-turn steer", { len: text.length });
       } else if (this.useStreamSession && this.sessionAlive) {
         // Optimistic user message — matches the pattern in startSession().
@@ -2321,16 +2566,17 @@ export class SessionStore {
         // when the backend's UserMessage bus event arrives.
         this._pushOptimisticUser(text, attachments);
         await api.sendSessionMessage(
-          this.run.id,
+          targetRunId,
           text,
           mapAttachments(attachments) ?? undefined,
           hasSkills ? skills : undefined,
         );
+        if (isStale()) return { status: "cancelled" };
         if (hasSkills) dbg("skills", "store send with skills", { count: skills!.length });
         if (this.isKnownSlashCommand(text)) {
           dbg("store", "skip response timeout for slash command", { cmd: text.split(" ")[0] });
         } else {
-          this._startResponseTimeout(this.run.id);
+          this._startResponseTimeout(targetRunId);
         }
       } else if (this.useStreamSession && this.run.agent === "codex") {
         // Stopped Codex app-server session (user clicked Stop, then sent a new message):
@@ -2343,17 +2589,24 @@ export class SessionStore {
         this._pushOptimisticUser(text, attachments);
         if (this.run) this.run = { ...this.run, status: "running" };
         const mw = getEventMiddleware();
-        mw.subscribeCurrent(this.run!.id, this);
-        this._wsSubscribeNewSession(this.run!.id);
+        mw.subscribeCurrent(targetRunId, this);
+        this._wsSubscribeNewSession(targetRunId);
         await api.startSession(
-          this.run!.id,
+          targetRunId,
           undefined,
           undefined,
           text,
           mapAttachments(attachments) ?? undefined,
           this.platformId || undefined,
         );
-        this._startSpawnTimeout(this.run!.id);
+        if (isStale()) {
+          dbg("store", "stopped Codex restart stale after CLI spawn", {
+            runId: targetRunId,
+            operationGen,
+          });
+          return { status: "cancelled" };
+        }
+        this._startSpawnTimeout(targetRunId);
       } else if (
         !this.useStreamSession &&
         this.caps.supportsBusEvents &&
@@ -2363,18 +2616,19 @@ export class SessionStore {
         if (!this._useChatTimelineForRun) {
           this._useChatTimelineForRun = true;
           const mw = getEventMiddleware();
-          mw.subscribeCurrent(this.run!.id, this);
-          this._wsSubscribeNewSession(this.run!.id);
+          mw.subscribeCurrent(targetRunId, this);
+          this._wsSubscribeNewSession(targetRunId);
         }
         const clientUuid = this._pushOptimisticUser(text, attachments);
         this._setPhase("running");
         await api.sendChatMessage(
-          this.run!.id,
+          targetRunId,
           text,
           attachments.length > 0 ? attachments : undefined,
           undefined,
           clientUuid,
         );
+        if (isStale()) return { status: "cancelled" };
       } else if (this.useStreamSession) {
         // Dead session_actor that's NOT a resumable Codex run (e.g. a stopped Claude
         // process): routing to sendChatMessage would be rejected (pipe_exec only), so
@@ -2385,12 +2639,15 @@ export class SessionStore {
         // PipeExec (Codex): one-shot process per message, no liveness concept.
         this._setPhase("running");
         await api.sendChatMessage(
-          this.run.id,
+          targetRunId,
           text,
           attachments.length > 0 ? attachments : undefined,
         );
+        if (isStale()) return { status: "cancelled" };
       }
+      return { status: "success" };
     } catch (e) {
+      if (isStale()) return { status: "cancelled" };
       this.error = String(e);
       throw e;
     }
@@ -2473,6 +2730,28 @@ export class SessionStore {
     return this._resumeGuard.busy;
   }
 
+  /** Invalidate an in-flight resume/fork before UI cancellation starts awaiting cleanup I/O. */
+  cancelResumeOperation(): void {
+    this._loadGen++;
+    this._clearSpawnTimeout();
+    this._clearResponseTimeout();
+    dbg("store", "resume operation cancelled", { generation: this._loadGen });
+  }
+
+  /** Invalidate async work when the URL moves away from the run currently owned by this store. */
+  invalidateOperationsForRoute(routeRunId: string): boolean {
+    if (routeRunId === (this.run?.id ?? "")) return false;
+    this._loadGen++;
+    this._clearSpawnTimeout();
+    this._clearResponseTimeout();
+    dbg("store", "operations invalidated by route change", {
+      routeRunId,
+      storeRunId: this.run?.id ?? "",
+      generation: this._loadGen,
+    });
+    return true;
+  }
+
   /** Resume/continue/fork a finished session. Returns the target run ID.
    *  Avoids flash by NOT calling reset() — clears content fields individually
    *  and uses replayOnly=true so replay doesn't overwrite phase.
@@ -2483,12 +2762,15 @@ export class SessionStore {
     mode: SessionMode,
     initialMessage?: string,
     attachments?: Attachment[],
-  ): Promise<string | null> {
-    if (!this._resumeGuard.acquire()) return null;
+  ): Promise<ResumeSessionResult> {
+    if (!this._resumeGuard.acquire()) return { status: "cancelled" };
+    let operationGen = this._loadGen;
 
     try {
       let run = await api.getRun(runId);
-      if (!this._resumeGuard.isMounted) return runId;
+      if (!this._resumeGuard.isMounted || operationGen !== this._loadGen) {
+        return { status: "cancelled" };
+      }
 
       let metaActive = ACTIVE_PHASES.includes(run.status as SessionPhase);
       if (metaActive && mode !== "fork") {
@@ -2507,6 +2789,9 @@ export class SessionStore {
         } catch (e) {
           dbgWarn("store", "resumeSession: stop attempt failed:", e);
         }
+        if (!this._resumeGuard.isMounted || operationGen !== this._loadGen) {
+          return { status: "cancelled" };
+        }
         if (metaActive) {
           // Still running after stop attempt — genuinely active, can't resume
           throw new Error("Session is still running");
@@ -2520,26 +2805,11 @@ export class SessionStore {
       // Invalidate any concurrent loadRun, then snapshot the gen for our own
       // stale-check (a later loadRun would bump _loadGen and we'd see the change).
       const loadGen = ++this._loadGen;
+      operationGen = loadGen;
       const resumeT0 = performance.now();
 
       // ★ Phase 1: async data fetch BEFORE clearing state (avoids flash)
       const isStream = run.execution_path === "session_actor"; // run-level, not agent identity
-      let snapshotBody: string | null = null;
-      let busEvents: BusEvent[] = [];
-
-      if (isStream) {
-        try {
-          snapshotBody = await snapshotCache.readSnapshot(runId, run.status);
-        } catch {
-          /* IDB unavailable */
-        }
-        if (!this._resumeGuard.isMounted) return runId;
-        if (!snapshotBody) {
-          busEvents = await api.getBusEvents(runId);
-          if (!this._resumeGuard.isMounted) return runId;
-          dbg("store", "resumeSession: fetched", busEvents.length, "bus events for replay");
-        }
-      }
 
       // ★ Phase 2: clear + set run metadata (sync frame, no await)
       this.run = run;
@@ -2548,39 +2818,26 @@ export class SessionStore {
       this._clearContentState();
       this._useChatTimelineForRun = true; // resumeSession is always Claude stream path
 
-      // ★ Phase 3: apply snapshot or events + force invalidate
-      let reducerMs = 0;
-      let snapshotHit = false;
+      // ★ Phase 3: restore only the latest bounded history page.
       if (isStream) {
-        if (snapshotBody && this._tryApplySnapshot(snapshotBody)) {
-          snapshotHit = true;
-          this._wsSubscribeWithSeq(runId, this._lastProcessedSeq);
-        } else {
-          // Fallback: snapshot corrupted → re-fetch events if needed
-          if (!busEvents.length && snapshotBody) {
-            busEvents = await api.getBusEvents(runId);
-            if (!this._resumeGuard.isMounted) return runId;
-          }
-          if (busEvents.length > 0) {
-            const ms = await this.applyEventBatchAsync(busEvents, {
-              replayOnly: true,
-              isStale: () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
-            });
-            if (ms === null) return runId;
-            reducerMs = ms;
-          }
-          // Always subscribe — even empty history needs real-time events
-          this._wsSubscribeAfterLoad(runId, busEvents);
+        const restored = await this._loadHistoryWithCatchup(
+          runId,
+          () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
+          true,
+        );
+        if (!restored) return { status: "cancelled" };
+        await this._wsSubscribeWithSeq(runId, this._lastProcessedSeq);
+        if (!this._resumeGuard.isMounted || loadGen !== this._loadGen || this.run?.id !== runId) {
+          dbg("store", "resume stale after WS subscribe", { runId, loadGen });
+          this._cancelWsSubscriptionIfInactive(runId);
+          return { status: "cancelled" };
         }
-
         // Resume makes session go live → old snapshot is always stale
         snapshotCache.deleteSnapshot(runId).catch(() => {});
       }
 
       dbg("store", "resumeSession", {
         total: Math.round(performance.now() - resumeT0),
-        snapshotHit,
-        reducer: Math.round(reducerMs),
         entries: this.timeline.length,
       });
 
@@ -2624,6 +2881,13 @@ export class SessionStore {
           backendAtt,
           run.platform_id ?? undefined,
         );
+        if (!this._resumeGuard.isMounted || loadGen !== this._loadGen || this.run?.id !== runId) {
+          // startSession has transferred ownership to the backend. Do not stop here: a newer
+          // operation may intentionally own the same run. The runs list remains the source of
+          // truth while this stale frontend operation refrains from installing timers/routing.
+          dbg("store", "resume stale after CLI spawn", { runId, loadGen });
+          return { status: "cancelled" };
+        }
       }
       // Bus events via applyEvent (live) will transition phase:
       // - With message: spawning → running → idle (from CLI result)
@@ -2643,13 +2907,15 @@ export class SessionStore {
         // No initialMessage → no response timeout (just waiting for user input)
       }
 
-      return targetRunId;
+      return { status: "success", runId: targetRunId };
     } catch (e) {
-      if (!this._resumeGuard.isMounted) return null;
+      if (!this._resumeGuard.isMounted || operationGen !== this._loadGen) {
+        return { status: "cancelled" };
+      }
       this.error = String(e);
       this._setPhase("failed");
       dbgWarn("store", "resumeSession failed:", e);
-      return null;
+      return { status: "failed" };
     } finally {
       this._resumeGuard.release();
     }
@@ -2667,10 +2933,14 @@ export class SessionStore {
 
     // Step 1: One-shot fork (backend does fork_oneshot, returns new run_id with new session_id)
     const newRunId = await api.forkSession(runId);
-    if (!this._resumeGuard.isMounted) throw new Error("Unmounted during fork");
+    if (!this._resumeGuard.isMounted || loadGen !== this._loadGen) {
+      throw new Error("Stale during fork creation");
+    }
 
     const newRun = await api.getRun(newRunId);
-    if (!this._resumeGuard.isMounted) throw new Error("Unmounted during fork");
+    if (!this._resumeGuard.isMounted || loadGen !== this._loadGen) {
+      throw new Error("Stale during fork metadata load");
+    }
 
     this.run = newRun;
 
@@ -2680,27 +2950,20 @@ export class SessionStore {
     this._clearContentState();
     this._useChatTimelineForRun = true;
 
-    // Replay copied parent events for immediate display.
-    // Subscribe to live events AFTER replay so a live applyEvent during chunked
-    // replay can't slip in and be overwritten by `_commitReduceCtx` snapshotting
-    // a now-stale `this.timeline`.
-    const allForkEvents = await api.getBusEvents(newRunId);
-    if (!this._resumeGuard.isMounted) throw new Error("Unmounted during fork");
-    const newEvents = allForkEvents.filter((ev) => ev.run_id === newRunId);
-    if (newEvents.length > 0) {
-      dbg("store", "fork: replaying", newEvents.length, "parent events");
-      const ms = await this.applyEventBatchAsync(newEvents, {
-        replayOnly: true,
-        isStale: () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
-      });
-      // Match the existing fork pattern (line ~2157): treat a stale/unmount
-      // mid-replay as a fatal interruption so the caller's catch path runs.
-      if (ms === null) throw new Error("Stale during fork replay");
-    }
+    const restored = await this._loadHistoryWithCatchup(
+      newRunId,
+      () => !this._resumeGuard.isMounted || loadGen !== this._loadGen,
+      true,
+    );
+    if (!restored) throw new Error("Stale during fork history load");
     // Subscribe to NEW run — live events from stream-json will route here.
     getEventMiddleware().subscribeCurrent(newRunId, this);
     dbg("store", "fork: middleware subscribed to new run", newRunId);
-    this._wsSubscribeAfterLoad(newRunId, allForkEvents);
+    await this._wsSubscribeWithSeq(newRunId, this._lastProcessedSeq);
+    if (!this._resumeGuard.isMounted || loadGen !== this._loadGen || this.run?.id !== newRunId) {
+      this._cancelWsSubscriptionIfInactive(newRunId);
+      throw new Error("Stale after fork WS subscribe");
+    }
 
     // Step 2 (stream-json resume) is NOT started here.
     // handleResume will dismiss the overlay first, then call connectSession()
@@ -2723,43 +2986,73 @@ export class SessionStore {
     dbg("store", "connectSession: establishing stream-json connection", { runId, sessionId: sid });
     this._wsSubscribeNewSession(runId);
     this._setPhase("spawning");
-    await api.startSession(
-      runId,
-      "resume",
-      sid,
-      undefined,
-      undefined,
-      this.platformId || undefined,
-    );
+    const loadGen = this._loadGen;
+    try {
+      await api.startSession(
+        runId,
+        "resume",
+        sid,
+        undefined,
+        undefined,
+        this.platformId || undefined,
+      );
+    } catch (error) {
+      if (!this._resumeGuard.isMounted || loadGen !== this._loadGen || this.run?.id !== runId) {
+        dbg("store", "connectSession stale after CLI spawn failure", { runId, loadGen });
+        return;
+      }
+      throw error;
+    }
+    if (!this._resumeGuard.isMounted || loadGen !== this._loadGen || this.run?.id !== runId) {
+      dbg("store", "connectSession stale after CLI spawn", { runId, loadGen });
+      return;
+    }
     this._startSpawnTimeout(runId);
   }
 
   // ── WS subscribe helpers (browser-only, no-op on desktop) ──
 
   /** Browser: notify WS server to start pushing real-time events after history load */
-  private _wsSubscribeAfterLoad(runId: string, events: BusEvent[]): void {
+  private async _wsSubscribeAfterLoad(runId: string, events: BusEvent[]): Promise<void> {
+    if (typeof window === "undefined") return;
     if (getTransport().isDesktop()) return;
     const maxSeq =
       events.length > 0
         ? (((events[events.length - 1] as Record<string, unknown>)._seq as number) ?? 0)
         : 0;
-    getTransport().subscribeRun(runId, maxSeq);
+    await getTransport().subscribeRun(runId, maxSeq);
   }
 
   private _wsSubscribeNewSession(runId: string): void {
+    if (typeof window === "undefined") return;
     if (getTransport().isDesktop()) return;
-    getTransport().subscribeRun(runId, 0);
+    void getTransport()
+      .subscribeRun(runId, 0, "live")
+      .catch((error) => dbgWarn("store", "new session WS subscribe failed", { runId, error }));
   }
 
-  private _wsSubscribeWithSeq(runId: string, lastSeq: number): void {
+  private async _wsSubscribeWithSeq(runId: string, lastSeq: number): Promise<void> {
+    if (typeof window === "undefined") return;
     if (getTransport().isDesktop()) return;
-    getTransport().subscribeRun(runId, lastSeq);
+    await getTransport().subscribeRun(runId, lastSeq);
+  }
+
+  private _cancelWsSubscriptionIfInactive(runId: string): void {
+    if (typeof window === "undefined" || getTransport().isDesktop()) return;
+    const middleware = getEventMiddleware();
+    // A newer operation may legitimately subscribe to the same run. Only remove the transport
+    // intent when routing has moved elsewhere, so a stale completion cannot revive the old run.
+    if (middleware.currentRunId !== runId || middleware.currentStore !== this) {
+      getTransport().unsubscribeRun(runId);
+    }
   }
 
   /** Call from page cleanup to prevent stale async writes after unmount. */
   unmountGuards(): void {
     this._resumeGuard.unmount();
+    this._loadGen++;
     this._clearSpawnTimeout();
+    this._clearResponseTimeout();
   }
 
   /** Update MCP servers (e.g. after getMcpStatus refresh). Deduplicates by name. */
@@ -2795,6 +3088,20 @@ export class SessionStore {
         this.tools = u;
       }
     }
+  }
+
+  markInteractionResponseFailed(
+    requestId: string,
+    interactionKind: "permission" | "hook" | "elicitation" | "user_input",
+    error: unknown,
+  ): void {
+    this.applyEvent({
+      type: "interaction_response_failed",
+      run_id: this.run?.id ?? "",
+      request_id: requestId,
+      interaction_kind: interactionKind,
+      error: String(error),
+    });
   }
 
   /** Answer an AskUserQuestion tool.
@@ -2835,25 +3142,30 @@ export class SessionStore {
           answers[questions[0]?.id ?? "0"] = [answer];
         }
         await api.respondUserInput(this.run.id, toolUseId, answers);
-        // Keep the pending card actionable until the backend confirms stdin delivery.
+        // Durable response events normally converge the card first; this keeps the direct IPC
+        // path responsive when event delivery is delayed.
         this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
       } catch (e) {
         dbgWarn("store", "codex respondUserInput failed:", e);
         this.error = String(e);
+        if (!String(e).includes("[interaction:not_started]")) {
+          this.markInteractionResponseFailed(toolUseId, "user_input", e);
+        }
         throw e;
       }
       return;
     }
+
+    // Claude answers are ordinary follow-up turns, so retain the existing optimistic card update.
+    this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
 
     try {
       // Send the user's answer as a follow-up message.
       // The session should be alive (idle phase) after the CLI auto-failed AskUserQuestion.
       if (this.sessionAlive) {
         await api.sendSessionMessage(this.run.id, display);
-        this.resolveAskQuestion(toolUseId, display, multi ? multi.byText : undefined);
       } else {
         dbgWarn("store", "session not alive for tool answer, skipping send");
-        throw new Error("session not alive for tool answer");
       }
     } catch (e) {
       dbgWarn("store", "tool answer failed:", e);
@@ -2963,13 +3275,11 @@ export class SessionStore {
     return ctx ? ctx.isStream : this.useChatTimeline;
   }
 
-  /**
-   * Resolve stale tool entries to "error" across main timeline and all subTimelines.
-   * Used by idle/spawning/control_cancelled cleanup.
-   */
+  /** Resolve matching tool entries across the main timeline and all subTimelines. */
   private _resolveStaleTools(
     predicate: (tool: BusToolItem) => boolean,
     ctx: ReduceCtx | null,
+    targetStatus: BusToolItem["status"] = "error",
   ): void {
     const tl = ctx ? ctx.tl : this.timeline;
     let cloned = !!ctx; // ctx.tl is already a mutable reference
@@ -2985,7 +3295,7 @@ export class SessionStore {
           this.timeline = [...this.timeline];
           cloned = true;
         }
-        parentUpdated = { ...e, tool: { ...e.tool, status: "error" as const } };
+        parentUpdated = { ...e, tool: { ...e.tool, status: targetStatus } };
         const target = ctx ? ctx.tl : this.timeline;
         target[i] = parentUpdated;
         dbg("store", "resolved stale tool", { id: e.id, name: e.tool.tool_name });
@@ -3004,7 +3314,7 @@ export class SessionStore {
           newSub = [...newSub];
           subChanged = true;
         }
-        newSub[j] = { ...child, tool: { ...child.tool, status: "error" as const } };
+        newSub[j] = { ...child, tool: { ...child.tool, status: targetStatus } };
         dbg("store", "resolved stale sub-tool", { id: child.id, name: child.tool.tool_name });
       }
       if (subChanged) {
@@ -3460,24 +3770,18 @@ export class SessionStore {
               : ev.status === "rejected"
                 ? ("rejected" as const) // user_rejected_tool_use → terminal rejected
                 : ("success" as const);
+        const updateTool = (tool: BusToolItem): BusToolItem => ({
+          ...tool,
+          status: resolvedStatus,
+          output: ev.output as Record<string, unknown>,
+          duration_ms: ev.duration_ms,
+          tool_name: ev.tool_name || tool.tool_name,
+          tool_use_result: ev.tool_use_result as Record<string, unknown> | undefined,
+        });
 
         // Subagent routing: update child tool inside parent's subTimeline
         if (ev.parent_tool_use_id) {
-          if (
-            this._updateSubTimelineTool(
-              ev.parent_tool_use_id,
-              ev.tool_use_id,
-              (t) => ({
-                ...t,
-                status: resolvedStatus,
-                output: ev.output as Record<string, unknown>,
-                duration_ms: ev.duration_ms,
-                tool_name: ev.tool_name || t.tool_name,
-                tool_use_result: ev.tool_use_result as Record<string, unknown> | undefined,
-              }),
-              ctx,
-            )
-          ) {
+          if (this._updateSubTimelineTool(ev.parent_tool_use_id, ev.tool_use_id, updateTool, ctx)) {
             break;
           }
           dbgWarn(
@@ -3486,6 +3790,8 @@ export class SessionStore {
             { parent: ev.parent_tool_use_id, tool: ev.tool_use_id },
           );
           // fall through to main timeline logic
+        } else if (this._updateToolInAnySubTimeline(ev.tool_use_id, updateTool, ctx)) {
+          break;
         }
 
         const tl = getTl();
@@ -4026,6 +4332,7 @@ export class SessionStore {
           mode: ev.mode,
           url: ev.url,
           requestedSchema: ev.requested_schema,
+          responseStatus: "pending",
         });
         this.pendingElicitations = updated;
         break;
@@ -4258,17 +4565,22 @@ export class SessionStore {
       }
 
       case "control_cancelled": {
-        // Resolve any permission_prompt or optimistic-running tool with matching request_id to "error"
+        // Cancellation follows a durable response_started fact, so live and catch-up replay must
+        // accept the non-retryable intermediate state as well as the original prompt state.
         // Covers both main timeline and subTimelines.
         this._resolveStaleTools(
           (t) =>
-            (t.status === "permission_prompt" || t.status === "running") &&
+            (t.status === "permission_prompt" ||
+              t.status === "running" ||
+              t.status === "response_pending") &&
             t.permission_request_id === ev.request_id,
           ctx,
+          "error",
         );
-        // Also resolve pending hook callbacks
+        // Also resolve hook callbacks after either the prompt or response_started event.
         this.hookEvents = this.hookEvents.map((h) =>
-          h.request_id === ev.request_id && h.status === "hook_pending"
+          h.request_id === ev.request_id &&
+          (h.status === "hook_pending" || h.status === "responding")
             ? { ...h, status: "cancelled" as const }
             : h,
         );
@@ -4277,6 +4589,91 @@ export class SessionStore {
           const elicUpdated = new Map(this.pendingElicitations);
           elicUpdated.delete(ev.request_id);
           this.pendingElicitations = elicUpdated;
+        }
+        this._resolveStaleTools(
+          (tool) =>
+            tool.tool_use_id === ev.request_id &&
+            tool.tool_name === "AskUserQuestion" &&
+            (tool.status === "ask_pending" || tool.status === "response_pending"),
+          ctx,
+          "error",
+        );
+        break;
+      }
+
+      case "interaction_response_started":
+      case "interaction_response_failed":
+      case "interaction_resolved": {
+        // A summary can be published after the prompt but before this source event. Catch-up must
+        // therefore converge cards restored from that summary, even though live responses already
+        // update the same UI optimistically.
+        const resolution = "resolution" in ev ? ev.resolution : undefined;
+        const failed = ev.type === "interaction_response_failed";
+        const started = ev.type === "interaction_response_started";
+        if (!ev.interaction_kind || ev.interaction_kind === "permission") {
+          const status = failed
+            ? ("response_failed" as const)
+            : started
+              ? ("response_pending" as const)
+              : resolution === "deny"
+                ? ("permission_denied" as const)
+                : ("running" as const);
+          this._resolveStaleTools(
+            (tool) =>
+              tool.permission_request_id === ev.request_id &&
+              (tool.status === "permission_prompt" ||
+                tool.status === "running" ||
+                tool.status === "response_pending"),
+            ctx,
+            status,
+          );
+        }
+        if (!ev.interaction_kind || ev.interaction_kind === "hook") {
+          this.hookEvents = this.hookEvents.map((h) =>
+            h.request_id === ev.request_id &&
+            (h.status === "hook_pending" || h.status === "responding")
+              ? {
+                  ...h,
+                  status: failed
+                    ? ("error" as const)
+                    : started
+                      ? ("responding" as const)
+                      : resolution === "allow"
+                        ? ("allowed" as const)
+                        : resolution === "deny" || resolution === "defer"
+                          ? ("denied" as const)
+                          : ("resolved" as const),
+                }
+              : h,
+          );
+        }
+        if (!ev.interaction_kind || ev.interaction_kind === "elicitation") {
+          if (this.pendingElicitations.has(ev.request_id)) {
+            const updated = new Map(this.pendingElicitations);
+            if (ev.type === "interaction_resolved") {
+              updated.delete(ev.request_id);
+            } else {
+              const existing = updated.get(ev.request_id)!;
+              updated.set(ev.request_id, {
+                ...existing,
+                responseStatus: failed ? "error" : "responding",
+                ...(failed ? { responseError: ev.error } : {}),
+              });
+            }
+            this.pendingElicitations = updated;
+          }
+        }
+        if (ev.interaction_kind === "user_input") {
+          this._resolveStaleTools(
+            (tool) =>
+              tool.tool_use_id === ev.request_id &&
+              tool.tool_name === "AskUserQuestion" &&
+              (tool.status === "ask_pending" ||
+                tool.status === "response_pending" ||
+                tool.status === "success"),
+            ctx,
+            failed ? "response_failed" : started ? "response_pending" : "success",
+          );
         }
         break;
       }

--- a/src/lib/stores/session-store.test.ts
+++ b/src/lib/stores/session-store.test.ts
@@ -5,14 +5,20 @@
  * event fixtures derived from real ~/.opencovibe/runs/ data.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { BusEvent, TimelineEntry } from "$lib/types";
+import type { BusEvent, HistoryEntry, TimelineEntry } from "$lib/types";
 import { assertTransition, canResumeRun, getResumeWarning, classifyError } from "./types";
 
 // Mock Tauri API — the store imports api.ts which calls invoke()
 vi.mock("$lib/api", () => ({
   getRun: vi.fn(),
   getBusEvents: vi.fn(),
+  getBusEventsPage: vi
+    .fn()
+    .mockResolvedValue({ events: [], lastSeq: 0, hasMore: false, nextOffset: 0 }),
   getRunEvents: vi.fn(),
+  getHistorySummary: vi.fn(),
+  getHistoryPage: vi.fn(),
+  forkSession: vi.fn(),
   startRun: vi.fn(),
   startSession: vi.fn(),
   sendSessionMessage: vi.fn(),
@@ -20,8 +26,8 @@ vi.mock("$lib/api", () => ({
   stopSession: vi.fn(),
   stopRun: vi.fn(),
   sendSessionControl: vi.fn(),
-  steerSession: vi.fn(),
   respondUserInput: vi.fn(),
+  steerSession: vi.fn(),
   syncCliSession: vi.fn().mockResolvedValue({ newEvents: 0 }),
   renameRun: vi.fn().mockResolvedValue(undefined),
 }));
@@ -81,6 +87,63 @@ function makeRun(id: string, overrides: Record<string, unknown> = {}) {
     execution_path: "session_actor" as const,
     ...overrides,
   };
+}
+
+function makeHistory(runId: string, pageCount = 1) {
+  const generationId = `gen-${runId}`;
+  const summary = {
+    runId,
+    generationId,
+    pageCount,
+    totalEntries: pageCount > 0 ? 2 : 0,
+    totalTurns: pageCount > 0 ? 1 : 0,
+    lastSeq: pageCount > 0 ? 4 : 0,
+    sourceSize: 100,
+    sourceMtimeNs: 1,
+    latestCursor: pageCount > 0 ? `${generationId}:${pageCount}` : undefined,
+    stateEvents: [],
+  };
+  const entries: HistoryEntry[] = [
+    {
+      kind: "user",
+      id: "u1",
+      anchorId: "u1",
+      ts: "t1",
+      content: {
+        preview: "Hello",
+        byteLength: 5,
+        truncated: false,
+        encoding: "text",
+      },
+      firstSeq: 1,
+      lastSeq: 1,
+    },
+    {
+      kind: "assistant",
+      id: "a1",
+      anchorId: "a1",
+      ts: "t2",
+      content: {
+        preview: "Hi there!",
+        byteLength: 9,
+        truncated: false,
+        encoding: "text",
+      },
+      firstSeq: 2,
+      lastSeq: 4,
+    },
+  ];
+  const page = {
+    runId,
+    generationId,
+    entries,
+    pageCursor: `${generationId}:${pageCount}`,
+    previousCursor: pageCount > 1 ? `${generationId}:${pageCount}` : undefined,
+    hasMore: pageCount > 1,
+    firstSeq: 1,
+    lastSeq: 4,
+  };
+  return { summary, page };
 }
 
 describe("SessionStore reducer", () => {
@@ -411,58 +474,38 @@ describe("SessionStore reducer", () => {
       expect(users[1].content).toBe("app.js");
     });
 
-    it("keeps Codex question pending when response delivery fails", async () => {
-      const codexStore = new SessionStore();
-      codexStore.run = makeRun("run-codex-ask", { agent: "codex" });
-      codexStore.phase = "running";
-      codexStore.timeline = [
+    it("keeps a Codex question retryable when durable response start fails", async () => {
+      store = new SessionStore();
+      store.run = makeRun("run-codex-question", { agent: "codex" });
+      store.phase = "running";
+      store.applyEventBatch([
         {
-          kind: "tool",
-          id: "ask-codex",
-          anchorId: "ask-codex",
-          ts: new Date().toISOString(),
-          tool: {
-            tool_use_id: "ask-codex",
-            tool_name: "AskUserQuestion",
-            input: { questions: [{ id: "q1", question: "Pick", options: [] }] },
-            status: "ask_pending",
-          },
-        } as TimelineEntry,
-      ];
-      vi.mocked(api.respondUserInput).mockRejectedValueOnce(new Error("stdin closed"));
-
-      await expect(codexStore.answerToolQuestion("ask-codex", "A")).rejects.toThrow("stdin closed");
-
-      const entry = codexStore.timeline[0] as Extract<TimelineEntry, { kind: "tool" }>;
-      expect(entry.tool.status).toBe("ask_pending");
-      expect(entry.tool.output).toBeUndefined();
-    });
-
-    it("resolves Codex question only after response delivery succeeds", async () => {
-      const codexStore = new SessionStore();
-      codexStore.run = makeRun("run-codex-ask", { agent: "codex" });
-      codexStore.phase = "running";
-      codexStore.timeline = [
+          type: "tool_start",
+          run_id: "run-codex-question",
+          tool_use_id: "question-1",
+          tool_name: "AskUserQuestion",
+          input: { questions: [{ id: "choice", question: "Choose" }] },
+        },
         {
-          kind: "tool",
-          id: "ask-codex",
-          anchorId: "ask-codex",
-          ts: new Date().toISOString(),
-          tool: {
-            tool_use_id: "ask-codex",
-            tool_name: "AskUserQuestion",
-            input: { questions: [{ id: "q1", question: "Pick", options: [] }] },
-            status: "ask_pending",
-          },
-        } as TimelineEntry,
-      ];
-      vi.mocked(api.respondUserInput).mockResolvedValueOnce(undefined);
+          type: "tool_end",
+          run_id: "run-codex-question",
+          tool_use_id: "question-1",
+          tool_name: "AskUserQuestion",
+          output: {},
+          status: "error",
+        },
+      ]);
+      vi.mocked(api.respondUserInput).mockRejectedValueOnce(
+        new Error("[interaction:not_started] persist started failed"),
+      );
 
-      await codexStore.answerToolQuestion("ask-codex", "A");
-
-      const entry = codexStore.timeline[0] as Extract<TimelineEntry, { kind: "tool" }>;
-      expect(entry.tool.status).toBe("success");
-      expect(entry.tool.output).toEqual({ answer: "A" });
+      await expect(store.answerToolQuestion("question-1", "A")).rejects.toThrow(
+        "persist started failed",
+      );
+      const toolEntry = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "question-1",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(toolEntry.tool.status).toBe("ask_pending");
     });
   });
 
@@ -996,6 +1039,50 @@ describe("SessionStore reducer", () => {
       ) as Extract<TimelineEntry, { kind: "tool" }>;
       expect(bashInSub).toBeDefined();
       expect(bashInSub.tool.status).toBe("permission_denied");
+    });
+
+    it("tool_end with missing parent_tool_use_id closes the matching nested tool", () => {
+      const events: BusEvent[] = [
+        {
+          type: "tool_start",
+          run_id: "run-tool-end-fallback",
+          tool_use_id: "task-parent",
+          tool_name: "Task",
+          input: {},
+        },
+        {
+          type: "tool_start",
+          run_id: "run-tool-end-fallback",
+          parent_tool_use_id: "task-parent",
+          tool_use_id: "bash-child",
+          tool_name: "Bash",
+          input: { command: "pwd" },
+        },
+        {
+          type: "tool_end",
+          run_id: "run-tool-end-fallback",
+          tool_use_id: "bash-child",
+          tool_name: "Bash",
+          status: "success",
+          output: { stdout: "/tmp" },
+        },
+      ];
+
+      store.run = makeRun("run-tool-end-fallback", { status: "running" });
+      store.phase = "running";
+      store.applyEventBatch(events, { replayOnly: false });
+
+      expect(
+        store.timeline.some((entry) => entry.kind === "tool" && entry.id === "bash-child"),
+      ).toBe(false);
+      const parent = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "task-parent",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(parent.subTimeline?.[0]).toMatchObject({
+        kind: "tool",
+        id: "bash-child",
+        tool: { status: "success", output: { stdout: "/tmp" } },
+      });
     });
   });
 
@@ -2329,6 +2416,369 @@ describe("SessionStore reducer", () => {
       ) as Extract<TimelineEntry, { kind: "tool" }>;
       expect(toolEntry).toBeDefined();
       expect(toolEntry.tool.status).toBe("error");
+    });
+  });
+
+  describe("interaction_resolved", () => {
+    it("treats a started or failed response as non-retryable during recovery", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "elicitation_prompt",
+          run_id: "run-1",
+          request_id: "req-uncertain",
+          mcp_server_name: "server",
+          message: "Choose",
+        },
+        {
+          type: "interaction_response_started",
+          run_id: "run-1",
+          request_id: "req-uncertain",
+          interaction_kind: "elicitation",
+          resolution: "accept",
+        },
+      ]);
+      expect(store.pendingElicitations.get("req-uncertain")?.responseStatus).toBe("responding");
+    });
+
+    it("shows explicit terminal failures for permission, hook, and elicitation", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "tool-perm",
+          tool_name: "Bash",
+          input: {},
+        },
+        {
+          type: "permission_prompt",
+          run_id: "run-1",
+          request_id: "req-perm",
+          tool_name: "Bash",
+          tool_use_id: "tool-perm",
+          tool_input: {},
+          decision_reason: "confirm",
+        },
+        {
+          type: "hook_callback",
+          run_id: "run-1",
+          request_id: "req-hook",
+          hook_event: "PreToolUse",
+          hook_id: "hook-1",
+          data: {},
+        },
+        {
+          type: "elicitation_prompt",
+          run_id: "run-1",
+          request_id: "req-elicit",
+          mcp_server_name: "server",
+          message: "Choose",
+        },
+        ...["req-perm", "req-hook", "req-elicit"].map((request_id, index) => ({
+          type: "interaction_response_failed" as const,
+          run_id: "run-1",
+          request_id,
+          interaction_kind: ["permission", "hook", "elicitation"][index] as
+            | "permission"
+            | "hook"
+            | "elicitation",
+          error: "flush failed",
+        })),
+      ]);
+
+      const permission = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "tool-perm",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(permission.tool.status).toBe("response_failed");
+      expect(store.hookEvents.find((hook) => hook.request_id === "req-hook")?.status).toBe("error");
+      expect(store.pendingElicitations.get("req-elicit")?.responseStatus).toBe("error");
+      expect(store.hasElicitation).toBe(false);
+    });
+
+    it("converges a Codex request_user_input card restored before catch-up", () => {
+      store.run = makeRun("run-1", { agent: "codex" });
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "req-question-1",
+          tool_name: "AskUserQuestion",
+          input: { questions: [{ id: "choice", question: "Choose" }] },
+        },
+        {
+          type: "tool_end",
+          run_id: "run-1",
+          tool_use_id: "req-question-1",
+          tool_name: "AskUserQuestion",
+          output: {},
+          status: "error",
+        },
+        {
+          type: "interaction_response_started",
+          run_id: "run-1",
+          request_id: "req-question-1",
+          interaction_kind: "user_input",
+        },
+      ]);
+
+      const toolEntry = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "req-question-1",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(toolEntry.tool.status).toBe("response_pending");
+      expect(store.hasInlinePermission).toBe(false);
+    });
+
+    it("shows a terminal error when a Codex user-input response write fails", () => {
+      store.run = makeRun("run-1", { agent: "codex" });
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "req-question-1",
+          tool_name: "AskUserQuestion",
+          input: { questions: [] },
+        },
+        {
+          type: "tool_end",
+          run_id: "run-1",
+          tool_use_id: "req-question-1",
+          tool_name: "AskUserQuestion",
+          output: {},
+          status: "error",
+        },
+        {
+          type: "interaction_response_started",
+          run_id: "run-1",
+          request_id: "req-question-1",
+          interaction_kind: "user_input",
+        },
+        {
+          type: "interaction_response_failed",
+          run_id: "run-1",
+          request_id: "req-question-1",
+          interaction_kind: "user_input",
+          error: "CLI stdin closed",
+        },
+      ]);
+
+      const toolEntry = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "req-question-1",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(toolEntry.tool.status).toBe("response_failed");
+    });
+
+    it("converges a permission prompt restored before catch-up", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "tool-perm-1",
+          tool_name: "Bash",
+          input: { command: "npm test" },
+        },
+        {
+          type: "permission_prompt",
+          run_id: "run-1",
+          request_id: "req-perm-1",
+          tool_name: "Bash",
+          tool_use_id: "tool-perm-1",
+          tool_input: { command: "npm test" },
+          decision_reason: "requires approval",
+        },
+        {
+          type: "interaction_resolved",
+          run_id: "run-1",
+          request_id: "req-perm-1",
+          interaction_kind: "permission",
+          resolution: "allow",
+        },
+      ]);
+
+      const toolEntry = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "tool-perm-1",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(toolEntry.tool.status).toBe("running");
+      expect(store.hasPendingPermission).toBe(false);
+    });
+
+    it("converges pending elicitation and hook cards restored before catch-up", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "elicitation_prompt",
+          run_id: "run-1",
+          request_id: "req-elicit-1",
+          mcp_server_name: "github-mcp",
+          message: "Please authenticate",
+        },
+        {
+          type: "hook_callback",
+          run_id: "run-1",
+          request_id: "req-hook-1",
+          hook_event: "PreToolUse",
+          hook_id: "hook-1",
+          data: { tool_name: "Bash" },
+        },
+        {
+          type: "interaction_resolved",
+          run_id: "run-1",
+          request_id: "req-elicit-1",
+          interaction_kind: "elicitation",
+          resolution: "accept",
+        },
+        {
+          type: "interaction_resolved",
+          run_id: "run-1",
+          request_id: "req-hook-1",
+          interaction_kind: "hook",
+          resolution: "deny",
+        },
+      ]);
+
+      expect(store.pendingElicitations.has("req-elicit-1")).toBe(false);
+      expect(store.hookEvents.find((hook) => hook.request_id === "req-hook-1")?.status).toBe(
+        "denied",
+      );
+    });
+
+    it("converges all response_started cards when cancellation is replayed", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "tool-permission",
+          tool_name: "Bash",
+          input: {},
+        },
+        {
+          type: "permission_prompt",
+          run_id: "run-1",
+          request_id: "request-permission",
+          tool_name: "Bash",
+          tool_use_id: "tool-permission",
+          tool_input: {},
+          decision_reason: "confirm",
+        },
+        {
+          type: "hook_callback",
+          run_id: "run-1",
+          request_id: "request-hook",
+          hook_event: "PreToolUse",
+          hook_id: "hook-1",
+          data: {},
+        },
+        {
+          type: "elicitation_prompt",
+          run_id: "run-1",
+          request_id: "request-elicitation",
+          mcp_server_name: "server",
+          message: "Choose",
+        },
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "request-user-input",
+          tool_name: "AskUserQuestion",
+          input: { questions: [] },
+        },
+        {
+          type: "tool_end",
+          run_id: "run-1",
+          tool_use_id: "request-user-input",
+          tool_name: "AskUserQuestion",
+          output: {},
+          status: "error",
+        },
+        ...[
+          ["request-permission", "permission"],
+          ["request-hook", "hook"],
+          ["request-elicitation", "elicitation"],
+          ["request-user-input", "user_input"],
+        ].flatMap(([request_id, interaction_kind]) => [
+          {
+            type: "interaction_response_started" as const,
+            run_id: "run-1",
+            request_id,
+            interaction_kind: interaction_kind as
+              | "permission"
+              | "hook"
+              | "elicitation"
+              | "user_input",
+          },
+          { type: "control_cancelled" as const, run_id: "run-1", request_id },
+        ]),
+      ]);
+
+      const permission = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "tool-permission",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      const userInput = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "request-user-input",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(permission.tool.status).toBe("error");
+      expect(userInput.tool.status).toBe("error");
+      expect(store.hookEvents.find((hook) => hook.request_id === "request-hook")?.status).toBe(
+        "cancelled",
+      );
+      expect(store.pendingElicitations.has("request-elicitation")).toBe(false);
+    });
+
+    it("legacy events without resolution still remove every matching pending card", () => {
+      store.run = makeRun("run-1");
+      store.phase = "running";
+      store.applyEventBatch([
+        {
+          type: "tool_start",
+          run_id: "run-1",
+          tool_use_id: "tool-legacy",
+          tool_name: "Bash",
+          input: {},
+        },
+        {
+          type: "permission_prompt",
+          run_id: "run-1",
+          request_id: "req-legacy",
+          tool_name: "Bash",
+          tool_use_id: "tool-legacy",
+          tool_input: {},
+          decision_reason: "Legacy prompt",
+        },
+        {
+          type: "elicitation_prompt",
+          run_id: "run-1",
+          request_id: "req-legacy",
+          mcp_server_name: "legacy-mcp",
+          message: "Legacy prompt",
+        },
+        {
+          type: "hook_callback",
+          run_id: "run-1",
+          request_id: "req-legacy",
+          hook_event: "PreToolUse",
+          hook_id: "hook-legacy",
+          data: {},
+        },
+        { type: "interaction_resolved", run_id: "run-1", request_id: "req-legacy" },
+      ]);
+
+      expect(store.pendingElicitations.has("req-legacy")).toBe(false);
+      const toolEntry = store.timeline.find(
+        (entry) => entry.kind === "tool" && entry.id === "tool-legacy",
+      ) as Extract<TimelineEntry, { kind: "tool" }>;
+      expect(toolEntry.tool.status).toBe("running");
+      expect(store.hookEvents.find((hook) => hook.request_id === "req-legacy")?.status).toBe(
+        "resolved",
+      );
     });
   });
 
@@ -4513,6 +4963,9 @@ describe("SessionStore reducer", () => {
     const mockDeleteSnapshot = snapshotCache.deleteSnapshot as ReturnType<typeof vi.fn>;
     const mockGetRun = api.getRun as ReturnType<typeof vi.fn>;
     const mockGetBusEvents = api.getBusEvents as ReturnType<typeof vi.fn>;
+    const mockGetBusEventsPage = api.getBusEventsPage as ReturnType<typeof vi.fn>;
+    const mockGetHistorySummary = api.getHistorySummary as ReturnType<typeof vi.fn>;
+    const mockGetHistoryPage = api.getHistoryPage as ReturnType<typeof vi.fn>;
 
     beforeEach(() => {
       mockReadSnapshot.mockReset().mockResolvedValue(null);
@@ -4520,6 +4973,18 @@ describe("SessionStore reducer", () => {
       mockDeleteSnapshot.mockReset().mockResolvedValue(undefined);
       mockGetRun.mockReset();
       mockGetBusEvents.mockReset().mockResolvedValue([]);
+      mockGetBusEventsPage.mockReset().mockResolvedValue({
+        events: [],
+        lastSeq: 0,
+        hasMore: false,
+        nextOffset: 0,
+      });
+      mockGetHistorySummary.mockReset().mockImplementation(async (runId: string) => {
+        return makeHistory(runId).summary;
+      });
+      mockGetHistoryPage.mockReset().mockImplementation(async (runId: string) => {
+        return makeHistory(runId).page;
+      });
     });
 
     describe("snapshot hit vs miss deep comparison", () => {
@@ -4644,110 +5109,847 @@ describe("SessionStore reducer", () => {
       });
     });
 
-    describe("loadRun snapshot paths", () => {
-      it("uses snapshot on hit for terminal stream session", async () => {
+    describe("loadRun paged history", () => {
+      it("ignores a legacy snapshot and loads only the latest page", async () => {
         const termRun = makeRun("run-snap-1", { status: "completed", agent: "claude" });
         mockGetRun.mockResolvedValue(termRun);
-
-        // Build snapshot body from a real replay
-        const refStore = new SessionStore();
-        refStore.run = termRun;
-        refStore.phase = "completed";
-        refStore.applyEventBatch(simpleChatEvents as BusEvent[], { replayOnly: true });
-        const snapBody = (refStore as unknown as { _buildSnapshot(): string })._buildSnapshot();
-
-        mockReadSnapshot.mockResolvedValue(snapBody);
+        mockReadSnapshot.mockResolvedValue("legacy full timeline");
 
         const testStore = new SessionStore();
         await testStore.loadRun("run-snap-1");
 
-        // Should have used snapshot (readSnapshot called, getBusEvents NOT called)
-        expect(mockReadSnapshot).toHaveBeenCalledWith("run-snap-1", "completed");
+        expect(mockReadSnapshot).not.toHaveBeenCalled();
+        expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-snap-1");
+        expect(mockGetHistorySummary).toHaveBeenCalledWith("run-snap-1");
+        expect(mockGetHistoryPage).toHaveBeenCalledWith("run-snap-1", "gen-run-snap-1");
         expect(mockGetBusEvents).not.toHaveBeenCalled();
-        // Timeline should match
-        expect(testStore.timeline).toEqual(refStore.timeline);
+        expect(testStore.timeline.map((entry) => entry.kind)).toEqual(["user", "assistant"]);
+        expect(testStore.numTurns).toBe(1);
         warnSpy.mockClear();
       });
 
-      it("falls back to getBusEvents on snapshot miss", async () => {
-        vi.useFakeTimers();
-        const termRun = makeRun("run-snap-2", { status: "stopped", agent: "claude" });
+      it("does not request a page or write a snapshot for empty history", async () => {
+        const termRun = makeRun("run-empty", { status: "stopped", agent: "claude" });
         mockGetRun.mockResolvedValue(termRun);
-        mockReadSnapshot.mockResolvedValue(null); // miss
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
+        mockGetHistorySummary.mockResolvedValue(makeHistory("run-empty", 0).summary);
 
         const testStore = new SessionStore();
-        await testStore.loadRun("run-snap-2");
+        await testStore.loadRun("run-empty");
 
-        expect(mockReadSnapshot).toHaveBeenCalledWith("run-snap-2", "stopped");
-        expect(mockGetBusEvents).toHaveBeenCalledWith("run-snap-2");
-        // Flush deferred _saveSnapshotToIdb (setTimeout(0))
-        vi.advanceTimersByTime(1);
-        // Should have written snapshot after reducer
-        expect(mockWriteSnapshot).toHaveBeenCalled();
-        expect(testStore.timeline.length).toBeGreaterThan(0);
-        vi.useRealTimers();
-        warnSpy.mockClear();
-      });
-
-      it("falls back to getBusEvents on corrupted snapshot", async () => {
-        const termRun = makeRun("run-snap-3", { status: "completed", agent: "claude" });
-        mockGetRun.mockResolvedValue(termRun);
-        mockReadSnapshot.mockResolvedValue("{ invalid json }}}"); // corrupt
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
-
-        const testStore = new SessionStore();
-        await testStore.loadRun("run-snap-3");
-
-        // Snapshot read was attempted but failed → fell back to getBusEvents
-        expect(mockReadSnapshot).toHaveBeenCalled();
-        expect(mockGetBusEvents).toHaveBeenCalledWith("run-snap-3");
-        expect(testStore.timeline.length).toBeGreaterThan(0);
-        warnSpy.mockClear();
-      });
-    });
-
-    describe("loadRun write guard", () => {
-      it("does NOT write snapshot when busEvents produce empty timeline (reducer anomaly)", async () => {
-        const termRun = makeRun("run-wg-1", { status: "completed", agent: "claude" });
-        mockGetRun.mockResolvedValue(termRun);
-        mockReadSnapshot.mockResolvedValue(null);
-        // Non-empty busEvents that produce an empty timeline is a reducer anomaly
-        // For this test, we use a single unknown event type that doesn't create timeline entries
-        mockGetBusEvents.mockResolvedValue([
-          { type: "run_state", run_id: "run-wg-1", state: "running" },
-        ]);
-
-        const testStore = new SessionStore();
-        await testStore.loadRun("run-wg-1");
-
-        // Timeline is empty, busEvents was non-empty → should NOT write snapshot
-        expect(testStore.timeline).toHaveLength(0);
+        expect(mockGetHistoryPage).not.toHaveBeenCalled();
         expect(mockWriteSnapshot).not.toHaveBeenCalled();
+        expect(testStore.timeline).toHaveLength(0);
         warnSpy.mockClear();
       });
 
-      it("writes snapshot for legit empty session (0 busEvents)", async () => {
-        vi.useFakeTimers();
-        const termRun = makeRun("run-wg-2", { status: "completed", agent: "claude" });
-        mockGetRun.mockResolvedValue(termRun);
-        mockReadSnapshot.mockResolvedValue(null);
-        mockGetBusEvents.mockResolvedValue([]); // truly empty session
+      it("prepends older pages once and preserves the current phase", async () => {
+        const run = makeRun("run-pages", { status: "completed", agent: "claude" });
+        mockGetRun.mockResolvedValue(run);
+        const latest = makeHistory("run-pages", 2);
+        latest.summary.totalEntries = 3;
+        latest.page.entries = [latest.page.entries[1]];
+        latest.page.firstSeq = 2;
+        mockGetHistorySummary.mockResolvedValue(latest.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(latest.page).mockResolvedValueOnce({
+          ...makeHistory("run-pages").page,
+          entries: [makeHistory("run-pages").page.entries[0]],
+          pageCursor: `${latest.summary.generationId}:1`,
+          previousCursor: undefined,
+          hasMore: false,
+          firstSeq: 1,
+          lastSeq: 1,
+        });
 
         const testStore = new SessionStore();
-        await testStore.loadRun("run-wg-2");
+        await testStore.loadRun("run-pages");
+        expect(testStore.timeline.map((entry) => entry.kind)).toEqual(["assistant"]);
+        const phase = testStore.phase;
+        expect(await testStore.loadOlderHistory()).toBe(true);
+        expect(testStore.timeline.map((entry) => entry.kind)).toEqual(["user", "assistant"]);
+        expect(testStore.phase).toBe(phase);
+        expect(testStore.historyHasMore).toBe(false);
+        expect(await testStore.loadOlderHistory()).toBe(false);
+        expect(mockGetHistoryPage).toHaveBeenCalledTimes(2);
+        warnSpy.mockClear();
+      });
 
-        // Flush deferred _saveSnapshotToIdb (setTimeout(0))
-        vi.advanceTimersByTime(1);
-        // 0 busEvents + 0 timeline → legit empty session → write allowed
-        expect(mockWriteSnapshot).toHaveBeenCalled();
-        vi.useRealTimers();
+      it("coalesces sparse history pages into one bounded prepend batch", async () => {
+        const run = makeRun("run-sparse-pages", { status: "completed", agent: "claude" });
+        const latest = makeHistory(run.id, 15);
+        latest.summary.totalEntries = 15;
+        latest.page.entries = [
+          {
+            ...latest.page.entries[0],
+            id: "page-15",
+            anchorId: "page-15",
+          },
+        ];
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(latest.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(latest.page);
+        mockGetHistoryPage.mockImplementation(
+          async (_runId: string, generationId: string, beforeCursor?: string) => {
+            const current = Number(beforeCursor?.split(":").at(-1));
+            const pageNumber = current - 1;
+            return {
+              ...latest.page,
+              generationId,
+              entries: [
+                {
+                  ...latest.page.entries[0],
+                  id: `page-${pageNumber}`,
+                  anchorId: `page-${pageNumber}`,
+                  firstSeq: pageNumber,
+                  lastSeq: pageNumber,
+                },
+              ],
+              pageCursor: `${generationId}:${pageNumber}`,
+              previousCursor: pageNumber > 1 ? `${generationId}:${pageNumber - 1}` : undefined,
+              hasMore: pageNumber > 1,
+            };
+          },
+        );
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+        expect(await testStore.loadOlderHistory()).toBe(true);
+
+        expect(mockGetHistoryPage).toHaveBeenCalledTimes(13);
+        expect(testStore.timeline.map((entry) => entry.id)).toEqual([
+          "page-3",
+          "page-4",
+          "page-5",
+          "page-6",
+          "page-7",
+          "page-8",
+          "page-9",
+          "page-10",
+          "page-11",
+          "page-12",
+          "page-13",
+          "page-14",
+          "page-15",
+        ]);
+        expect(testStore.historyPageCursor).toBe(`${latest.summary.generationId}:3`);
+        expect(testStore.historyHasMore).toBe(true);
+
+        expect(await testStore.loadOlderHistory()).toBe(true);
+        expect(testStore.timeline.map((entry) => entry.id)).toEqual([
+          "page-1",
+          "page-2",
+          "page-3",
+          "page-4",
+          "page-5",
+          "page-6",
+          "page-7",
+          "page-8",
+          "page-9",
+          "page-10",
+          "page-11",
+          "page-12",
+          "page-13",
+          "page-14",
+          "page-15",
+        ]);
+        expect(testStore.historyHasMore).toBe(false);
+        warnSpy.mockClear();
+      });
+
+      it("rejects a non-advancing older history cursor", async () => {
+        const run = makeRun("run-stuck-history-page", { status: "completed" });
+        const latest = makeHistory(run.id, 2);
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(latest.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(latest.page).mockResolvedValueOnce({
+          ...latest.page,
+          entries: [],
+          pageCursor: latest.page.pageCursor,
+          hasMore: true,
+        });
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        await expect(testStore.loadOlderHistory()).rejects.toThrow("cursor did not advance");
+        expect(testStore.timeline).toHaveLength(latest.page.entries.length);
+        expect(testStore.historyLoadingOlder).toBe(false);
+        warnSpy.mockClear();
+      });
+
+      it("deduplicates concurrent older-page requests", async () => {
+        const run = makeRun("run-page-guard", { status: "completed" });
+        const latest = makeHistory(run.id, 2);
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(latest.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(latest.page);
+        let resolveOlder!: (value: ReturnType<typeof makeHistory>["page"]) => void;
+        mockGetHistoryPage.mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveOlder = resolve;
+            }),
+        );
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        const first = testStore.loadOlderHistory();
+        expect(await testStore.loadOlderHistory()).toBe(false);
+        expect(mockGetHistoryPage).toHaveBeenCalledTimes(2);
+        const older = makeHistory(run.id).page;
+        older.entries = [
+          {
+            ...older.entries[0],
+            id: "older-user",
+            anchorId: "older-user",
+          },
+        ];
+        resolveOlder({ ...older, hasMore: false });
+        expect(await first).toBe(true);
+        warnSpy.mockClear();
+      });
+
+      it("maps bounded tool fields and content references", async () => {
+        const run = makeRun("run-tool-history", { status: "completed" });
+        const baseHistory = makeHistory(run.id);
+        const history: {
+          summary: ReturnType<typeof makeHistory>["summary"];
+          page: Omit<ReturnType<typeof makeHistory>["page"], "entries"> & {
+            entries: HistoryEntry[];
+          };
+        } = {
+          summary: baseHistory.summary,
+          page: baseHistory.page,
+        };
+        const contentRef = {
+          preview: "truncated",
+          byteLength: 100_000,
+          truncated: true,
+          contentId: "abcdef",
+          encoding: "json" as const,
+        };
+        history.page.entries = [
+          {
+            kind: "tool",
+            id: "tool-1",
+            anchorId: "tool-1",
+            ts: "t",
+            toolUseId: "tool-1",
+            toolName: "Bash",
+            status: "success",
+            input: { _truncated: true },
+            output: { _truncated: true },
+            inputContent: contentRef,
+            outputContent: contentRef,
+            resultContent: contentRef,
+            subHistoryId: "sub-1",
+            firstSeq: 1,
+            lastSeq: 2,
+          },
+        ];
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(history.summary);
+        mockGetHistoryPage.mockResolvedValue(history.page);
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+        const entry = testStore.timeline[0];
+        expect(entry.kind).toBe("tool");
+        if (entry.kind !== "tool") throw new Error("expected tool entry");
+        expect(entry.tool._historyContent).toEqual({
+          input: contentRef,
+          output: contentRef,
+          result: contentRef,
+        });
+        expect(entry.tool._subHistoryId).toBe("sub-1");
+        warnSpy.mockClear();
+      });
+
+      it("loads active catch-up in bounded pages", async () => {
+        const run = makeRun("run-catchup", { status: "running", agent: "claude" });
+        mockGetRun.mockResolvedValue(run);
+        const catchup = api.getBusEventsPage as ReturnType<typeof vi.fn>;
+        catchup
+          .mockResolvedValueOnce({
+            events: [
+              {
+                type: "user_message",
+                run_id: run.id,
+                text: "new question",
+                _seq: 5,
+              },
+            ],
+            lastSeq: 5,
+            hasMore: true,
+            nextOffset: 150,
+          })
+          .mockResolvedValueOnce({
+            events: [
+              {
+                type: "message_complete",
+                run_id: run.id,
+                message_id: "a2",
+                text: "new answer",
+                _seq: 6,
+              },
+            ],
+            lastSeq: 6,
+            hasMore: false,
+            nextOffset: 200,
+          });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(catchup).toHaveBeenNthCalledWith(1, run.id, 4, 100);
+        expect(catchup).toHaveBeenNthCalledWith(2, run.id, 5, 150);
+        expect(testStore.timeline.slice(-2).map((entry) => entry.kind)).toEqual([
+          "user",
+          "assistant",
+        ]);
+        expect(testStore.phase).toBe("running");
+        warnSpy.mockClear();
+      });
+
+      it("rebuilds the projection when catch-up settles an interrupted turn", async () => {
+        const run = makeRun("run-interrupted-catchup", { status: "idle", agent: "claude" });
+        const initial = makeHistory(run.id);
+        const rebuilt = makeHistory(run.id);
+        rebuilt.summary.generationId = "gen-rebuilt";
+        rebuilt.summary.lastSeq = 6;
+        rebuilt.summary.sourceSize = 180;
+        rebuilt.summary.latestCursor = "gen-rebuilt:1";
+        rebuilt.page.generationId = "gen-rebuilt";
+        rebuilt.page.pageCursor = "gen-rebuilt:1";
+        rebuilt.page.lastSeq = 6;
+        rebuilt.page.entries = [
+          initial.page.entries[0],
+          {
+            kind: "assistant",
+            id: "assistant-incomplete-5",
+            anchorId: "assistant-incomplete-5",
+            ts: "t",
+            content: {
+              preview: "partial answer",
+              byteLength: 14,
+              truncated: false,
+              encoding: "text",
+            },
+            firstSeq: 5,
+            lastSeq: 6,
+          },
+        ];
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary
+          .mockResolvedValueOnce(initial.summary)
+          .mockResolvedValueOnce(rebuilt.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(initial.page).mockResolvedValueOnce(rebuilt.page);
+        mockGetBusEventsPage
+          .mockResolvedValueOnce({
+            events: [
+              { type: "message_delta", run_id: run.id, text: "partial answer", _seq: 5 },
+              { type: "run_state", run_id: run.id, state: "idle", _seq: 6 },
+            ],
+            lastSeq: 6,
+            hasMore: false,
+            nextOffset: 180,
+          })
+          .mockResolvedValueOnce({
+            events: [],
+            lastSeq: 6,
+            hasMore: false,
+            nextOffset: 180,
+          });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(1, run.id);
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(2, run.id, true);
+        expect(mockGetBusEventsPage).toHaveBeenNthCalledWith(1, run.id, 4, 100);
+        expect(mockGetBusEventsPage).toHaveBeenNthCalledWith(2, run.id, 6, 180);
+        expect(testStore.streamingText).toBe("");
+        expect(testStore.timeline.at(-1)).toMatchObject({
+          kind: "assistant",
+          id: "assistant-incomplete-5",
+          content: "partial answer",
+        });
+        warnSpy.mockClear();
+      });
+
+      it("continues bounded semantic rebuilds while checkpoints advance", async () => {
+        const run = makeRun("run-progressing-rebuild", { status: "idle", agent: "claude" });
+        const initial = makeHistory(run.id);
+        const firstRebuild = makeHistory(run.id);
+        firstRebuild.summary.generationId = "gen-progress-1";
+        firstRebuild.summary.lastSeq = 6;
+        firstRebuild.summary.sourceSize = 180;
+        firstRebuild.page.generationId = "gen-progress-1";
+        firstRebuild.page.lastSeq = 6;
+        const secondRebuild = makeHistory(run.id);
+        secondRebuild.summary.generationId = "gen-progress-2";
+        secondRebuild.summary.lastSeq = 8;
+        secondRebuild.summary.sourceSize = 260;
+        secondRebuild.page.generationId = "gen-progress-2";
+        secondRebuild.page.lastSeq = 8;
+        secondRebuild.page.entries.push({
+          kind: "assistant",
+          id: "assistant-incomplete-7",
+          anchorId: "assistant-incomplete-7",
+          ts: "t",
+          content: {
+            preview: "second partial",
+            byteLength: 14,
+            truncated: false,
+            encoding: "text",
+          },
+          firstSeq: 7,
+          lastSeq: 8,
+        });
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary
+          .mockResolvedValueOnce(initial.summary)
+          .mockResolvedValueOnce(firstRebuild.summary)
+          .mockResolvedValueOnce(secondRebuild.summary);
+        mockGetHistoryPage
+          .mockResolvedValueOnce(initial.page)
+          .mockResolvedValueOnce(firstRebuild.page)
+          .mockResolvedValueOnce(secondRebuild.page);
+        mockGetBusEventsPage
+          .mockResolvedValueOnce({
+            events: [
+              { type: "message_delta", run_id: run.id, text: "first partial", _seq: 5 },
+              { type: "run_state", run_id: run.id, state: "idle", _seq: 6 },
+            ],
+            lastSeq: 6,
+            hasMore: false,
+            nextOffset: 180,
+          })
+          .mockResolvedValueOnce({
+            events: [
+              { type: "message_delta", run_id: run.id, text: "second partial", _seq: 7 },
+              { type: "run_state", run_id: run.id, state: "idle", _seq: 8 },
+            ],
+            lastSeq: 8,
+            hasMore: false,
+            nextOffset: 260,
+          })
+          .mockResolvedValueOnce({
+            events: [],
+            lastSeq: 8,
+            hasMore: false,
+            nextOffset: 260,
+          });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(2, run.id, true);
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(3, run.id, true);
+        expect(mockGetBusEventsPage).toHaveBeenNthCalledWith(3, run.id, 8, 260);
+        expect(testStore.timeline.at(-1)).toMatchObject({
+          kind: "assistant",
+          id: "assistant-incomplete-7",
+        });
+        expect(testStore.phase).toBe("idle");
+        warnSpy.mockClear();
+      });
+
+      it("rebuilds instead of retaining interrupted subhistory streaming entries", async () => {
+        const run = makeRun("run-sub-interrupted-catchup", { status: "idle", agent: "claude" });
+        const initial = makeHistory(run.id);
+        const parent: HistoryEntry = {
+          kind: "tool",
+          id: "parent-tool",
+          anchorId: "parent-tool",
+          ts: "t",
+          toolUseId: "parent-tool",
+          toolName: "Agent",
+          status: "running",
+          input: {},
+          output: null,
+          subHistoryId: "parent-tool",
+          firstSeq: 2,
+          lastSeq: 2,
+        };
+        initial.page.entries = [initial.page.entries[0], parent];
+        initial.summary.lastSeq = 2;
+        initial.summary.sourceSize = 50;
+        const rebuilt = makeHistory(run.id);
+        rebuilt.summary.generationId = "gen-sub-rebuilt";
+        rebuilt.summary.lastSeq = 4;
+        rebuilt.summary.sourceSize = 140;
+        rebuilt.summary.latestCursor = "gen-sub-rebuilt:1";
+        rebuilt.page.generationId = "gen-sub-rebuilt";
+        rebuilt.page.pageCursor = "gen-sub-rebuilt:1";
+        rebuilt.page.lastSeq = 4;
+        rebuilt.page.entries = [
+          initial.page.entries[0],
+          {
+            ...parent,
+            status: "error",
+            output: { error: "Turn ended before tool result" },
+            lastSeq: 4,
+          },
+        ];
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary
+          .mockResolvedValueOnce(initial.summary)
+          .mockResolvedValueOnce(rebuilt.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(initial.page).mockResolvedValueOnce(rebuilt.page);
+        mockGetBusEventsPage
+          .mockResolvedValueOnce({
+            events: [
+              {
+                type: "message_delta",
+                run_id: run.id,
+                parent_tool_use_id: "parent-tool",
+                text: "child partial",
+                _seq: 3,
+              },
+              { type: "run_state", run_id: run.id, state: "idle", _seq: 4 },
+            ],
+            lastSeq: 4,
+            hasMore: false,
+            nextOffset: 140,
+          })
+          .mockResolvedValueOnce({
+            events: [],
+            lastSeq: 4,
+            hasMore: false,
+            nextOffset: 140,
+          });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        const loadedParent = testStore.timeline.find(
+          (entry) => entry.kind === "tool" && entry.id === "parent-tool",
+        );
+        expect(loadedParent).toMatchObject({ kind: "tool", tool: { status: "error" } });
+        expect(
+          loadedParent?.kind === "tool"
+            ? loadedParent.subTimeline?.some((entry) => entry.id === "__sub_stream_parent-tool")
+            : false,
+        ).toBeFalsy();
+        warnSpy.mockClear();
+      });
+
+      it("replays an open semantic tail without incomplete entries or artificial errors", async () => {
+        const run = makeRun("run-open-tail", { status: "running", agent: "claude" });
+        const history = makeHistory(run.id);
+        history.page.entries = [
+          history.page.entries[0],
+          {
+            kind: "tool",
+            id: "parent-tool",
+            anchorId: "parent-tool",
+            ts: "t",
+            toolUseId: "parent-tool",
+            toolName: "Agent",
+            status: "running",
+            input: {},
+            output: null,
+            firstSeq: 2,
+            lastSeq: 2,
+          },
+        ];
+        history.summary.lastSeq = 2;
+        history.summary.sourceSize = 50;
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(history.summary);
+        mockGetHistoryPage.mockResolvedValue(history.page);
+        mockGetBusEventsPage.mockResolvedValue({
+          events: [
+            { type: "message_delta", run_id: run.id, text: "partial", _seq: 3 },
+            {
+              type: "message_complete",
+              run_id: run.id,
+              message_id: "main-message",
+              text: "complete",
+              _seq: 4,
+            },
+            {
+              type: "tool_start",
+              run_id: run.id,
+              tool_use_id: "main-tool",
+              tool_name: "Bash",
+              input: {},
+              _seq: 5,
+            },
+            {
+              type: "tool_end",
+              run_id: run.id,
+              tool_use_id: "main-tool",
+              tool_name: "Bash",
+              output: { stdout: "done" },
+              status: "success",
+              _seq: 6,
+            },
+            {
+              type: "message_delta",
+              run_id: run.id,
+              parent_tool_use_id: "parent-tool",
+              text: "child partial",
+              _seq: 7,
+            },
+            {
+              type: "message_complete",
+              run_id: run.id,
+              parent_tool_use_id: "parent-tool",
+              message_id: "sub-message",
+              text: "child complete",
+              _seq: 8,
+            },
+            {
+              type: "tool_start",
+              run_id: run.id,
+              parent_tool_use_id: "parent-tool",
+              tool_use_id: "child-tool",
+              tool_name: "Bash",
+              input: {},
+              _seq: 9,
+            },
+            {
+              type: "tool_end",
+              run_id: run.id,
+              tool_use_id: "child-tool",
+              tool_name: "Bash",
+              output: { stdout: "child done" },
+              status: "success",
+              _seq: 10,
+            },
+          ],
+          lastSeq: 10,
+          hasMore: false,
+          nextOffset: 500,
+        });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(testStore.timeline.some((entry) => entry.id.includes("incomplete"))).toBe(false);
+        expect(
+          testStore.timeline.find(
+            (entry) => entry.kind === "assistant" && entry.id === "main-message",
+          ),
+        ).toMatchObject({ kind: "assistant", content: "complete" });
+        const mainTool = testStore.timeline.find(
+          (entry) => entry.kind === "tool" && entry.id === "main-tool",
+        ) as Extract<TimelineEntry, { kind: "tool" }>;
+        expect(mainTool.tool.status).toBe("success");
+        const parentTool = testStore.timeline.find(
+          (entry) => entry.kind === "tool" && entry.id === "parent-tool",
+        ) as Extract<TimelineEntry, { kind: "tool" }>;
+        expect(parentTool.subTimeline?.map((entry) => entry.id)).toEqual([
+          "sub-message",
+          "child-tool",
+        ]);
+        expect(
+          (parentTool.subTimeline?.[1] as Extract<TimelineEntry, { kind: "tool" }>).tool.status,
+        ).toBe("success");
+        warnSpy.mockClear();
+      });
+
+      it("bounds repeated semantic rebuilds even while checkpoints advance", async () => {
+        const run = makeRun("run-bounded-rebuild", { status: "idle", agent: "claude" });
+        const histories = Array.from({ length: 4 }, (_, index) => {
+          const history = makeHistory(run.id);
+          const suffix = index === 0 ? "initial" : String(index);
+          history.summary.generationId = `gen-bounded-${suffix}`;
+          history.summary.lastSeq = 4 + index * 2;
+          history.summary.sourceSize = 100 + index * 80;
+          history.page.generationId = history.summary.generationId;
+          history.page.lastSeq = history.summary.lastSeq;
+          return history;
+        });
+        mockGetRun.mockResolvedValue(run);
+        for (const history of histories) {
+          mockGetHistorySummary.mockResolvedValueOnce(history.summary);
+          mockGetHistoryPage.mockResolvedValueOnce(history.page);
+        }
+        for (let index = 0; index < 4; index++) {
+          const firstSeq = 5 + index * 2;
+          mockGetBusEventsPage.mockResolvedValueOnce({
+            events: [
+              { type: "message_delta", run_id: run.id, text: `partial-${index}`, _seq: firstSeq },
+              {
+                type: "run_state",
+                run_id: run.id,
+                state: "idle",
+                _seq: firstSeq + 1,
+              },
+            ],
+            lastSeq: firstSeq + 1,
+            hasMore: false,
+            nextOffset: 180 + index * 80,
+          });
+        }
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(mockGetHistorySummary).toHaveBeenCalledTimes(4);
+        expect(mockGetBusEventsPage).toHaveBeenCalledTimes(4);
+        expect(testStore.phase).toBe("failed");
+        expect(testStore.error).toContain("bounded rebuilds");
+        warnSpy.mockClear();
+      });
+
+      it("restores pending permission and elicitation from history summary", async () => {
+        const run = makeRun("run-pending-history", { status: "running", agent: "claude" });
+        const history = makeHistory(run.id);
+        const stateEvents: BusEvent[] = [
+          {
+            type: "permission_prompt",
+            run_id: run.id,
+            request_id: "permission-1",
+            tool_use_id: "tool-pending",
+            tool_name: "Bash",
+            tool_input: { command: "pwd" },
+            decision_reason: "Needs approval",
+          },
+          {
+            type: "elicitation_prompt",
+            run_id: run.id,
+            request_id: "elicitation-1",
+            mcp_server_name: "server",
+            message: "Choose",
+            mode: "form",
+          },
+        ];
+        (history.summary as { stateEvents: BusEvent[] }).stateEvents = stateEvents;
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary.mockResolvedValue(history.summary);
+        mockGetHistoryPage.mockResolvedValue(history.page);
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(testStore.pendingToolPermissions).toHaveLength(1);
+        expect(testStore.pendingToolPermissions[0].requestId).toBe("permission-1");
+        expect(testStore.pendingElicitations.has("elicitation-1")).toBe(true);
+        warnSpy.mockClear();
+      });
+
+      it("force-rebuilds oversized catch-up and resumes from the rebuilt checkpoint", async () => {
+        const run = makeRun("run-catchup-rebuild", { status: "running", agent: "claude" });
+        const initial = makeHistory(run.id);
+        const rebuilt = makeHistory(run.id);
+        rebuilt.summary.generationId = "gen-oversized-rebuilt";
+        rebuilt.summary.lastSeq = 5;
+        rebuilt.summary.sourceSize = 250;
+        rebuilt.page.generationId = "gen-oversized-rebuilt";
+        rebuilt.page.lastSeq = 5;
+        rebuilt.page.entries.push({
+          kind: "assistant",
+          id: "oversized-message",
+          anchorId: "oversized-message",
+          ts: "t",
+          content: {
+            preview: "large answer",
+            byteLength: 100_000,
+            truncated: true,
+            contentId: "oversized-content",
+            encoding: "text",
+          },
+          firstSeq: 5,
+          lastSeq: 5,
+        });
+        mockGetRun.mockResolvedValue(run);
+        mockGetHistorySummary
+          .mockResolvedValueOnce(initial.summary)
+          .mockResolvedValueOnce(rebuilt.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(initial.page).mockResolvedValueOnce(rebuilt.page);
+        mockGetBusEventsPage
+          .mockRejectedValueOnce(
+            new Error(
+              "HISTORY_PROJECTION_REQUIRED: bus event 5 exceeds catch-up page limit: 1500000 bytes",
+            ),
+          )
+          .mockResolvedValueOnce({
+            events: [],
+            lastSeq: 5,
+            hasMore: false,
+            nextOffset: 250,
+          });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(2, run.id, true);
+        expect(mockGetBusEventsPage).toHaveBeenNthCalledWith(2, run.id, 5, 250);
+        expect(mockGetHistorySummary).toHaveBeenCalledTimes(2);
+        expect(testStore.timeline.at(-1)).toMatchObject({
+          kind: "assistant",
+          id: "oversized-message",
+        });
+        expect(testStore.phase).toBe("running");
+        warnSpy.mockClear();
+      });
+
+      it("fails a forced rebuild whose checkpoint does not advance", async () => {
+        const run = makeRun("run-catchup-stalled-rebuild", {
+          status: "running",
+          agent: "claude",
+        });
+        mockGetRun.mockResolvedValue(run);
+        mockGetBusEventsPage.mockRejectedValueOnce(
+          new Error("HISTORY_PROJECTION_REQUIRED: bus event exceeds bounded catch-up line limit"),
+        );
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(mockGetHistorySummary).toHaveBeenNthCalledWith(2, run.id, true);
+        expect(testStore.phase).toBe("failed");
+        expect(testStore.error).toContain("checkpoint did not advance");
+        warnSpy.mockClear();
+      });
+
+      it("rejects a catch-up page whose cursor does not advance", async () => {
+        const run = makeRun("run-stuck", { status: "running", agent: "claude" });
+        mockGetRun.mockResolvedValue(run);
+        (api.getBusEventsPage as ReturnType<typeof vi.fn>).mockResolvedValue({
+          events: [],
+          lastSeq: 4,
+          hasMore: true,
+          nextOffset: 100,
+        });
+
+        const testStore = new SessionStore();
+        await testStore.loadRun(run.id);
+
+        expect(testStore.phase).toBe("failed");
+        expect(testStore.error).toContain("did not advance");
+        warnSpy.mockClear();
+      });
+
+      it("ignores an older-page response after switching runs", async () => {
+        const firstRun = makeRun("run-stale-page", { status: "completed" });
+        const latest = makeHistory(firstRun.id, 2);
+        mockGetRun.mockResolvedValue(firstRun);
+        mockGetHistorySummary.mockResolvedValue(latest.summary);
+        mockGetHistoryPage.mockResolvedValueOnce(latest.page);
+        let resolveOlder!: (value: ReturnType<typeof makeHistory>["page"]) => void;
+        mockGetHistoryPage.mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              resolveOlder = resolve;
+            }),
+        );
+        const testStore = new SessionStore();
+        await testStore.loadRun(firstRun.id);
+        const olderRequest = testStore.loadOlderHistory();
+        testStore.reset();
+        resolveOlder(makeHistory(firstRun.id).page);
+
+        expect(await olderRequest).toBe(false);
+        expect(testStore.timeline).toHaveLength(0);
         warnSpy.mockClear();
       });
     });
 
-    describe("resumeSession snapshot", () => {
-      it("uses snapshot on hit and deletes after", async () => {
+    describe("resumeSession paged history", () => {
+      it("ignores legacy snapshots and restores the latest bounded page", async () => {
         const run = makeRun("run-res-1", {
           status: "stopped",
           agent: "claude",
@@ -4755,14 +5957,7 @@ describe("SessionStore reducer", () => {
         });
         mockGetRun.mockResolvedValue(run);
 
-        // Build snapshot from replay
-        const refStore = new SessionStore();
-        refStore.run = run;
-        refStore.phase = "stopped";
-        refStore.applyEventBatch(simpleChatEvents as BusEvent[], { replayOnly: true });
-        const snapBody = (refStore as unknown as { _buildSnapshot(): string })._buildSnapshot();
-
-        mockReadSnapshot.mockResolvedValue(snapBody);
+        mockReadSnapshot.mockResolvedValue("legacy full snapshot");
 
         const testStore = new SessionStore();
         testStore.agent = "claude";
@@ -4776,18 +5971,16 @@ describe("SessionStore reducer", () => {
 
         await testStore.resumeSession("run-res-1", "resume");
 
-        // Snapshot was read
-        expect(mockReadSnapshot).toHaveBeenCalledWith("run-res-1", "stopped");
-        // getBusEvents NOT called (snapshot hit)
+        expect(mockReadSnapshot).not.toHaveBeenCalled();
         expect(mockGetBusEvents).not.toHaveBeenCalled();
-        // Snapshot was deleted (session goes live)
+        expect(mockGetHistorySummary).toHaveBeenCalledWith("run-res-1");
+        expect(mockGetHistoryPage).toHaveBeenCalledWith("run-res-1", "gen-run-res-1");
         expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-res-1");
-        // Timeline populated from snapshot
-        expect(testStore.timeline).toEqual(refStore.timeline);
+        expect(testStore.timeline).toHaveLength(2);
         warnSpy.mockClear();
       });
 
-      it("falls back to getBusEvents when snapshot corrupted and deletes", async () => {
+      it("does not fall back to a full event replay when a snapshot is corrupted", async () => {
         const run = makeRun("run-res-2", {
           status: "stopped",
           agent: "claude",
@@ -4795,7 +5988,6 @@ describe("SessionStore reducer", () => {
         });
         mockGetRun.mockResolvedValue(run);
         mockReadSnapshot.mockResolvedValue("bad json {{{"); // corrupted
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
 
         const testStore = new SessionStore();
         testStore.agent = "claude";
@@ -4807,10 +5999,9 @@ describe("SessionStore reducer", () => {
 
         await testStore.resumeSession("run-res-2", "resume");
 
-        // Snapshot read attempted, then fell back to getBusEvents
-        expect(mockReadSnapshot).toHaveBeenCalled();
-        expect(mockGetBusEvents).toHaveBeenCalledWith("run-res-2");
-        // Still deleted (going live)
+        expect(mockReadSnapshot).not.toHaveBeenCalled();
+        expect(mockGetBusEvents).not.toHaveBeenCalled();
+        expect(mockGetHistorySummary).toHaveBeenCalledWith("run-res-2");
         expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-res-2");
         expect(testStore.timeline.length).toBeGreaterThan(0);
         warnSpy.mockClear();
@@ -4839,81 +6030,123 @@ describe("SessionStore reducer", () => {
         expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-res-3");
         warnSpy.mockClear();
       });
+
+      it("replays persisted events appended after the reusable generation before desktop resume", async () => {
+        const run = makeRun("run-res-catchup", {
+          status: "stopped",
+          agent: "claude",
+          session_id: "sess-catchup",
+        });
+        mockGetRun.mockResolvedValue(run);
+        mockGetBusEventsPage.mockResolvedValue({
+          events: [
+            {
+              type: "user_message",
+              run_id: run.id,
+              text: "appended question",
+              _seq: 5,
+            },
+            {
+              type: "message_complete",
+              run_id: run.id,
+              message_id: "appended-answer",
+              text: "appended answer",
+              _seq: 6,
+            },
+          ],
+          lastSeq: 6,
+          hasMore: false,
+          nextOffset: 180,
+        });
+        const mockStartSession = api.startSession as ReturnType<typeof vi.fn>;
+        mockStartSession.mockResolvedValue(undefined);
+        const testStore = new SessionStore();
+        testStore.run = run;
+        testStore.phase = "stopped";
+
+        await testStore.resumeSession(run.id, "resume");
+
+        expect(mockGetBusEventsPage).toHaveBeenCalledWith(run.id, 4, 100);
+        expect(testStore.timeline.slice(-2).map((entry) => entry.kind)).toEqual([
+          "user",
+          "assistant",
+        ]);
+        expect(testStore.timeline.at(-1)?.id).toBe("appended-answer");
+        expect(
+          testStore.timeline.filter(
+            (entry) => entry.kind === "assistant" && entry.id === "appended-answer",
+          ),
+        ).toHaveLength(1);
+        warnSpy.mockClear();
+      });
+
+      it("uses the same bounded catch-up for a newly copied fork without duplicating entries", async () => {
+        const source = makeRun("run-fork-source", {
+          status: "stopped",
+          agent: "claude",
+          session_id: "source-session",
+        });
+        const fork = makeRun("run-fork-target", {
+          status: "pending",
+          agent: "claude",
+          session_id: "fork-session",
+        });
+        mockGetRun.mockResolvedValueOnce(source).mockResolvedValueOnce(fork);
+        (api.forkSession as ReturnType<typeof vi.fn>).mockResolvedValue(fork.id);
+        mockGetHistorySummary.mockImplementation(
+          async (runId: string) => makeHistory(runId).summary,
+        );
+        mockGetHistoryPage.mockImplementation(async (runId: string) => makeHistory(runId).page);
+        mockGetBusEventsPage
+          .mockResolvedValueOnce({ events: [], lastSeq: 4, hasMore: false, nextOffset: 100 })
+          .mockResolvedValueOnce({
+            events: [
+              {
+                type: "message_complete",
+                run_id: fork.id,
+                message_id: "fork-tail",
+                text: "copied tail",
+                _seq: 5,
+              },
+            ],
+            lastSeq: 5,
+            hasMore: false,
+            nextOffset: 140,
+          });
+        const testStore = new SessionStore();
+        testStore.run = source;
+        testStore.phase = "stopped";
+
+        expect(await testStore.resumeSession(source.id, "fork")).toEqual({
+          status: "success",
+          runId: fork.id,
+        });
+
+        expect(mockGetBusEventsPage).toHaveBeenNthCalledWith(2, fork.id, 4, 100);
+        expect(
+          testStore.timeline.filter(
+            (entry) => entry.kind === "assistant" && entry.id === "fork-tail",
+          ),
+        ).toHaveLength(1);
+        warnSpy.mockClear();
+      });
     });
 
     // ── Idle snapshot paths ──
 
-    describe("idle session snapshot", () => {
-      it("snapshot hit (seq>0) → skip getBusEvents, phase = idle", async () => {
+    describe("idle paged history", () => {
+      it("loads derived history, invalidates snapshot, and keeps idle phase", async () => {
         const idleRun = makeRun("run-idle-1", { status: "idle", agent: "claude" });
         mockGetRun.mockResolvedValue(idleRun);
-
-        // Build a snapshot with seq > 0
-        const refStore = new SessionStore();
-        refStore.run = idleRun;
-        refStore.phase = "idle";
-        refStore.applyEventBatch(simpleChatEvents as BusEvent[]);
-        // Manually set _lastProcessedSeq > 0 to simulate a real snapshot
-        (refStore as any)._lastProcessedSeq = 42;
-        const snapshotBody = (refStore as any)._buildSnapshot();
-
-        mockReadSnapshot.mockResolvedValue(snapshotBody);
 
         const testStore = new SessionStore();
         await testStore.loadRun("run-idle-1");
 
-        expect(mockReadSnapshot).toHaveBeenCalledWith("run-idle-1", "idle");
+        expect(mockReadSnapshot).not.toHaveBeenCalled();
+        expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-idle-1");
         expect(mockGetBusEvents).not.toHaveBeenCalled();
         expect(testStore.phase).toBe("idle");
         expect(testStore.timeline.length).toBeGreaterThan(0);
-        warnSpy.mockClear();
-      });
-
-      it("snapshot hit (seq=0) → deleteSnapshot + full replay", async () => {
-        vi.useFakeTimers();
-        const idleRun = makeRun("run-idle-2", { status: "idle", agent: "claude" });
-        mockGetRun.mockResolvedValue(idleRun);
-
-        // Build a snapshot with seq = 0 (no reliable seq)
-        const refStore = new SessionStore();
-        refStore.run = idleRun;
-        refStore.phase = "idle";
-        refStore.applyEventBatch(simpleChatEvents as BusEvent[]);
-        (refStore as any)._lastProcessedSeq = 0; // seq=0
-        const snapshotBody = (refStore as any)._buildSnapshot();
-
-        mockReadSnapshot.mockResolvedValue(snapshotBody);
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
-
-        const testStore = new SessionStore();
-        await testStore.loadRun("run-idle-2");
-
-        // seq=0 → snapshot skipped, stale entry deleted
-        expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-idle-2");
-        // Full replay via getBusEvents
-        expect(mockGetBusEvents).toHaveBeenCalledWith("run-idle-2");
-        expect(testStore.timeline.length).toBeGreaterThan(0);
-        // Flush deferred _saveSnapshotToIdb
-        vi.advanceTimersByTime(1);
-        vi.useRealTimers();
-        warnSpy.mockClear();
-      });
-
-      it("snapshot miss → write snapshot for idle session", async () => {
-        vi.useFakeTimers();
-        const idleRun = makeRun("run-idle-3", { status: "idle", agent: "claude" });
-        mockGetRun.mockResolvedValue(idleRun);
-        mockReadSnapshot.mockResolvedValue(null);
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
-
-        const testStore = new SessionStore();
-        await testStore.loadRun("run-idle-3");
-
-        // Flush deferred _saveSnapshotToIdb
-        vi.advanceTimersByTime(1);
-        expect(mockWriteSnapshot).toHaveBeenCalled();
-        expect(testStore.timeline.length).toBeGreaterThan(0);
-        vi.useRealTimers();
         warnSpy.mockClear();
       });
 
@@ -5008,42 +6241,6 @@ describe("SessionStore reducer", () => {
         expect(tool).toBeDefined();
         expect(tool.tool.status).toBe("success");
         // dbgWarn should have been called for the index miss
-        warnSpy.mockClear();
-      });
-
-      it("seq=0 snapshot deleted, subsequent load does not re-hit stale entry", async () => {
-        vi.useFakeTimers();
-        const idleRun = makeRun("run-no-rehit", { status: "idle", agent: "claude" });
-        mockGetRun.mockResolvedValue(idleRun);
-
-        // First load: seq=0 snapshot
-        const refStore = new SessionStore();
-        refStore.run = idleRun;
-        refStore.phase = "idle";
-        refStore.applyEventBatch(simpleChatEvents as BusEvent[]);
-        (refStore as any)._lastProcessedSeq = 0;
-        const staleBody = (refStore as any)._buildSnapshot();
-
-        mockReadSnapshot.mockResolvedValueOnce(staleBody);
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
-
-        const testStore = new SessionStore();
-        await testStore.loadRun("run-no-rehit");
-
-        // deleteSnapshot called for seq=0
-        expect(mockDeleteSnapshot).toHaveBeenCalledWith("run-no-rehit");
-
-        // Second load: snapshot gone (readSnapshot returns null)
-        mockReadSnapshot.mockResolvedValueOnce(null);
-        mockGetBusEvents.mockResolvedValue(simpleChatEvents);
-
-        const testStore2 = new SessionStore();
-        await testStore2.loadRun("run-no-rehit");
-
-        // Normal full replay — no snapshot hit
-        expect(testStore2.timeline.length).toBeGreaterThan(0);
-        vi.advanceTimersByTime(1);
-        vi.useRealTimers();
         warnSpy.mockClear();
       });
     });

--- a/src/lib/transport/index.ts
+++ b/src/lib/transport/index.ts
@@ -13,7 +13,7 @@ export interface Transport {
   listen<T>(event: string, handler: (payload: T) => void): Promise<() => void>;
   isDesktop(): boolean;
   /** Subscribe to a run's real-time events (WS only, no-op on desktop) */
-  subscribeRun(runId: string, lastSeq?: number): void;
+  subscribeRun(runId: string, lastSeq?: number, recovery?: "history" | "live"): Promise<void>;
   /** Unsubscribe from a run's events (WS only, no-op on desktop) */
   unsubscribeRun(runId: string): void;
 }

--- a/src/lib/transport/tauri.ts
+++ b/src/lib/transport/tauri.ts
@@ -24,7 +24,11 @@ export class TauriTransport implements Transport {
     return true;
   }
 
-  subscribeRun(_runId: string, _lastSeq?: number): void {
+  async subscribeRun(
+    _runId: string,
+    _lastSeq?: number,
+    _recovery?: "history" | "live",
+  ): Promise<void> {
     // No-op: Tauri receives all events via app.emit(), no explicit subscription needed
   }
 

--- a/src/lib/transport/websocket.test.ts
+++ b/src/lib/transport/websocket.test.ts
@@ -1,0 +1,336 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/utils/debug", () => ({ dbg: vi.fn(), dbgWarn: vi.fn() }));
+
+import { WsTransport } from "./websocket";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+  static emitCloseOnClose = true;
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.({} as Event);
+  }
+
+  send(data: string): void {
+    if (this.readyState !== FakeWebSocket.OPEN) throw new Error("socket is not open");
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (FakeWebSocket.emitCloseOnClose) this.emitClose();
+  }
+
+  emitClose(code = 1006): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason: "test close" } as CloseEvent);
+  }
+
+  respond(index: number, response: Record<string, unknown> = { result: null }): void {
+    const request = JSON.parse(this.sent[index]) as { id: string };
+    this.onmessage?.({ data: JSON.stringify({ id: request.id, ...response }) } as MessageEvent);
+  }
+
+  push(message: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(message) } as MessageEvent);
+  }
+
+  requests(method: string): Array<Record<string, unknown>> {
+    return this.sent
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((request) => request.method === method);
+  }
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("WsTransport lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    FakeWebSocket.emitCloseOnClose = true;
+    vi.stubGlobal("window", {
+      location: { protocol: "http:", host: "localhost:1420", href: "http://localhost:1420/" },
+    });
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects a connection that closes before open", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-1", 4);
+    const socket = FakeWebSocket.instances[0];
+
+    socket.emitClose(1006);
+
+    await expect(subscribing).rejects.toThrow("closed before connection opened");
+  });
+
+  it("settles a timed-out attempt and ignores its delayed close after a new connection opens", async () => {
+    FakeWebSocket.emitCloseOnClose = false;
+    const transport = new WsTransport();
+    const first = transport.subscribeRun("run-1", 4);
+    const firstResult = expect(first).rejects.toThrow("connection timeout");
+    const oldSocket = FakeWebSocket.instances[0];
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    await firstResult;
+
+    const second = transport.subscribeRun("run-1", 4);
+    const newSocket = FakeWebSocket.instances[1];
+    newSocket.open();
+    await flushPromises();
+    oldSocket.emitClose(1006);
+    newSocket.respond(0);
+
+    await expect(second).resolves.toBeUndefined();
+    expect(newSocket.requests("_subscribe")).toHaveLength(1);
+  });
+
+  it("keeps subscription intent across repeated automatic resubscribe failures", async () => {
+    const transport = new WsTransport();
+    const initial = transport.subscribeRun("run-1", 9);
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+    firstSocket.respond(0);
+    await initial;
+
+    firstSocket.emitClose(1006);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    secondSocket.respond(0, { error: "temporary replay failure" });
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const thirdSocket = FakeWebSocket.instances[2];
+    thirdSocket.open();
+    await flushPromises();
+    expect(thirdSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-1", last_seq: 9 } }),
+    ]);
+    thirdSocket.respond(0, { error: "another temporary replay failure" });
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const fourthSocket = FakeWebSocket.instances[3];
+    fourthSocket.open();
+    await flushPromises();
+    expect(fourthSocket.requests("_subscribe")).toHaveLength(1);
+    fourthSocket.respond(0);
+    await flushPromises();
+    fourthSocket.push({
+      event: "bus-event",
+      run_id: "run-1",
+      seq: 12,
+      payload: { type: "message_delta", run_id: "run-1", text: "new" },
+    });
+
+    fourthSocket.emitClose(1006);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const fifthSocket = FakeWebSocket.instances[4];
+    fifthSocket.open();
+    await flushPromises();
+    expect(fifthSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-1", last_seq: 12 } }),
+    ]);
+  });
+
+  it("keeps a failed explicit subscription suspended until its caller retries", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-1", 7);
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+    firstSocket.respond(0, { error: "history unavailable" });
+    await expect(subscribing).rejects.toThrow("history unavailable");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toHaveLength(0);
+
+    const retry = transport.subscribeRun("run-1", 8);
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-1", last_seq: 8 } }),
+    ]);
+    secondSocket.respond(0);
+    await expect(retry).resolves.toBeUndefined();
+  });
+
+  it("automatically retries a new-session subscription after its initial connection fails", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-new", 0, "live");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.emitClose(1006);
+    await expect(subscribing).rejects.toThrow("closed before connection opened");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 0 } }),
+    ]);
+    secondSocket.respond(0);
+    await flushPromises();
+
+    secondSocket.push({
+      event: "bus-event",
+      run_id: "run-new",
+      seq: 2,
+      payload: { type: "run_state", run_id: "run-new", state: "running" },
+    });
+    secondSocket.emitClose(1006);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const thirdSocket = FakeWebSocket.instances[2];
+    thirdSocket.open();
+    await flushPromises();
+    expect(thirdSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 2 } }),
+    ]);
+  });
+
+  it("automatically retries a new-session subscription after its acknowledgement fails", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-new", 0, "live");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+    firstSocket.respond(0, { error: "temporary subscribe failure" });
+    await expect(subscribing).rejects.toThrow("temporary subscribe failure");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 0 } }),
+    ]);
+    secondSocket.respond(0, { error: "another temporary subscribe failure" });
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const thirdSocket = FakeWebSocket.instances[2];
+    thirdSocket.open();
+    await flushPromises();
+    expect(thirdSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 0 } }),
+    ]);
+    thirdSocket.respond(0);
+    await flushPromises();
+  });
+
+  it("keeps full-reload suspension when a pending live subscription fails", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-new", 0, "live");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+
+    firstSocket.push({ event: "_full_reload", run_id: "run-new" });
+    firstSocket.respond(0, { error: "replay requires history reload" });
+    await expect(subscribing).rejects.toThrow("replay requires history reload");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toHaveLength(0);
+
+    const historyRetry = transport.subscribeRun("run-new", 8);
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 8 } }),
+    ]);
+    secondSocket.respond(0);
+    await expect(historyRetry).resolves.toBeUndefined();
+  });
+
+  it("switches a live subscription to fail-closed history recovery", async () => {
+    const transport = new WsTransport();
+    const liveSubscribe = transport.subscribeRun("run-new", 0, "live");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+    firstSocket.respond(0);
+    await expect(liveSubscribe).resolves.toBeUndefined();
+
+    const historySubscribe = transport.subscribeRun("run-new", 8);
+    await flushPromises();
+    firstSocket.respond(1, { error: "history checkpoint rejected" });
+    await expect(historySubscribe).rejects.toThrow("history checkpoint rejected");
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toHaveLength(0);
+  });
+
+  it("automatically retries a new-session subscription after its acknowledgement times out", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-new", 0, "live");
+    const result = expect(subscribing).rejects.toThrow("request timed out");
+    const firstSocket = FakeWebSocket.instances[0];
+    firstSocket.open();
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await result;
+    await vi.advanceTimersByTimeAsync(1_000);
+    const secondSocket = FakeWebSocket.instances[1];
+    secondSocket.open();
+    await flushPromises();
+    expect(secondSocket.requests("_subscribe")).toEqual([
+      expect.objectContaining({ params: { run_id: "run-new", last_seq: 0 } }),
+    ]);
+  });
+
+  it("does not revive a run unsubscribed while its acknowledgement is pending", async () => {
+    const transport = new WsTransport();
+    const subscribing = transport.subscribeRun("run-1", 5);
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    await flushPromises();
+    transport.unsubscribeRun("run-1");
+    socket.respond(0);
+
+    await expect(subscribing).rejects.toThrow("subscription cancelled");
+    socket.emitClose(1006);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const reconnected = FakeWebSocket.instances[1];
+    reconnected.open();
+    await flushPromises();
+    expect(reconnected.requests("_subscribe")).toHaveLength(0);
+  });
+});

--- a/src/lib/transport/websocket.ts
+++ b/src/lib/transport/websocket.ts
@@ -16,6 +16,11 @@ interface PendingRequest {
   reject: (error: Error) => void;
 }
 
+interface SubscriptionAttempt {
+  epoch: number;
+  promise: Promise<void>;
+}
+
 export class WsTransport implements Transport {
   private ws: WebSocket | null = null;
   private reqId = 0;
@@ -25,9 +30,18 @@ export class WsTransport implements Transport {
   private lastSeq = new Map<string, number>();
   /** Runs we've subscribed to on the server */
   private subscribedRuns = new Set<string>();
+  /** Runs that must be acknowledged again on the next healthy connection */
+  private needsResubscribe = new Set<string>();
+  /** Full reload keeps intent but suspends replay until history establishes a new checkpoint */
+  private suspendedRuns = new Set<string>();
+  /** New sessions have no history owner, so initial failures retry on reconnect from seq 0 */
+  private liveRecoveryRuns = new Set<string>();
+  private subscriptionEpochs = new Map<string, number>();
+  private subscriptionAttempts = new Map<string, SubscriptionAttempt>();
   private reconnectDelay = 1000;
   private shouldReconnect = true;
   private connectPromise: Promise<void> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   private buildWsUrl(): string {
     const loc = window.location;
@@ -40,20 +54,41 @@ export class WsTransport implements Transport {
   private connect(): Promise<void> {
     if (this.connectPromise) return this.connectPromise;
 
-    this.connectPromise = new Promise<void>((resolve, reject) => {
+    const attempt = new Promise<void>((resolve, reject) => {
       const url = this.buildWsUrl();
       dbg("transport", "ws.connecting", { url });
 
       const ws = new WebSocket(url);
       this.ws = ws;
+      let settled = false;
+      const timeout = setTimeout(() => {
+        if (this.ws === ws && ws.readyState === WebSocket.CONNECTING) {
+          settle(new Error("WebSocket connection timeout"));
+          ws.close();
+        }
+      }, 10000);
+
+      const settle = (error?: Error) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (this.connectPromise === attempt) this.connectPromise = null;
+        if (error) reject(error);
+        else resolve();
+      };
 
       ws.onopen = () => {
+        if (this.ws !== ws) {
+          ws.close();
+          settle(new Error("WebSocket connection superseded"));
+          return;
+        }
         dbg("transport", "ws.connected");
         this.reconnectDelay = 1000;
-        this.connectPromise = null;
-        // Re-subscribe to all previously subscribed runs
+        settle();
+        // Only runs acknowledged on a previous connection need automatic replay. A first-time
+        // subscribe waiting on this connection resumes through its own subscribeRun call.
         this.resubscribeAll();
-        resolve();
       };
 
       ws.onmessage = (ev) => {
@@ -66,8 +101,13 @@ export class WsTransport implements Transport {
 
       ws.onclose = (ev) => {
         dbg("transport", "ws.closed", { code: ev.code, reason: ev.reason });
-        this.connectPromise = null;
+        settle(new Error(`WebSocket closed before connection opened (code ${ev.code})`));
+        if (this.ws !== ws) return;
         this.ws = null;
+
+        for (const runId of this.subscribedRuns) {
+          if (!this.suspendedRuns.has(runId)) this.needsResubscribe.add(runId);
+        }
 
         // Reject all pending requests
         for (const [id, req] of this.pending) {
@@ -79,31 +119,42 @@ export class WsTransport implements Transport {
           // Auth failure — stop reconnecting, redirect to login
           dbgWarn("transport", "ws.authFailure, redirecting to /login");
           this.shouldReconnect = false;
+          if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
           window.location.href = "/login";
           return;
         }
 
-        if (this.shouldReconnect) {
-          const delay = Math.min(this.reconnectDelay, 30000);
-          dbg("transport", "ws.reconnecting", { delay });
-          setTimeout(() => {
-            this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
-            this.ensureConnected();
-          }, delay);
-        }
+        this.scheduleReconnect();
       };
-
-      // Timeout for initial connection
-      setTimeout(() => {
-        if (ws.readyState === WebSocket.CONNECTING) {
-          ws.close();
-          this.connectPromise = null;
-          reject(new Error("WebSocket connection timeout"));
-        }
-      }, 10000);
     });
 
-    return this.connectPromise;
+    this.connectPromise = attempt;
+    void attempt.then(
+      () => {
+        if (this.connectPromise === attempt) this.connectPromise = null;
+      },
+      (error) => {
+        if (this.connectPromise === attempt) this.connectPromise = null;
+        dbgWarn("transport", "ws.connectFailed", error);
+        this.scheduleReconnect();
+      },
+    );
+    return attempt;
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.shouldReconnect || this.reconnectTimer) return;
+    const delay = Math.min(this.reconnectDelay, 30000);
+    dbg("transport", "ws.reconnecting", { delay });
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000);
+      void this.ensureConnected().catch((error) => {
+        dbgWarn("transport", "ws.reconnectFailed", error);
+        this.scheduleReconnect();
+      });
+    }, delay);
   }
 
   private async ensureConnected(): Promise<void> {
@@ -113,39 +164,100 @@ export class WsTransport implements Transport {
 
   /** Re-subscribe all tracked runs after reconnect */
   private resubscribeAll(): void {
-    for (const runId of this.subscribedRuns) {
+    for (const runId of [...this.needsResubscribe]) {
+      if (!this.subscribedRuns.has(runId) || this.suspendedRuns.has(runId)) {
+        this.needsResubscribe.delete(runId);
+        continue;
+      }
       const lastSeq = this.lastSeq.get(runId) ?? 0;
+      const epoch = this.subscriptionEpochs.get(runId);
+      if (epoch === undefined) continue;
       dbg("transport", "ws.resubscribe", { runId, lastSeq });
-      this.sendRaw({
-        id: `req_${++this.reqId}`,
-        method: "_subscribe",
-        params: { run_id: runId, last_seq: lastSeq },
+      void this.confirmSubscription(runId, lastSeq, epoch).catch((error) => {
+        dbgWarn("transport", "ws.resubscribeFailed", { runId, error });
       });
     }
   }
 
   /** Subscribe to a run's real-time events on the server */
-  subscribeRun(runId: string, lastSeq = 0): void {
-    this.subscribedRuns.add(runId);
+  async subscribeRun(
+    runId: string,
+    lastSeq = 0,
+    recovery: "history" | "live" = "history",
+  ): Promise<void> {
     // Monotonic: prevent checkpoint regression (e.g. accidental lastSeq=0 overwrites)
     const prev = this.lastSeq.get(runId) ?? 0;
     const effectiveSeq = Math.max(prev, lastSeq);
-    this.lastSeq.set(runId, effectiveSeq);
+    const epoch = (this.subscriptionEpochs.get(runId) ?? 0) + 1;
     dbg("transport", "ws.subscribeRun", { runId, lastSeq, effectiveSeq });
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.sendRaw({
-        id: `req_${++this.reqId}`,
-        method: "_subscribe",
-        params: { run_id: runId, last_seq: effectiveSeq },
-      });
+    this.subscribedRuns.add(runId);
+    this.lastSeq.set(runId, effectiveSeq);
+    this.subscriptionEpochs.set(runId, epoch);
+    if (recovery === "live") this.liveRecoveryRuns.add(runId);
+    else this.liveRecoveryRuns.delete(runId);
+    this.suspendedRuns.delete(runId);
+    this.needsResubscribe.delete(runId);
+    try {
+      await this.ensureConnected();
+      if (this.subscriptionEpochs.get(runId) !== epoch || !this.subscribedRuns.has(runId)) {
+        throw new Error(`WebSocket subscription cancelled: ${runId}`);
+      }
+      await this.confirmSubscription(runId, effectiveSeq, epoch);
+    } catch (error) {
+      if (this.subscriptionEpochs.get(runId) === epoch && this.subscribedRuns.has(runId)) {
+        if (this.liveRecoveryRuns.has(runId)) {
+          // A new session has no history owner to retry for it. Preserve the seq-0 intent until a
+          // reconnect acknowledges it; subsequent live events advance the checkpoint normally.
+          this.suspendedRuns.delete(runId);
+          this.needsResubscribe.add(runId);
+        } else {
+          // The explicit caller owns history buffering and retries. Keep its intent, but suspend
+          // automatic replay until that caller establishes a fresh checkpoint on a later attempt.
+          this.needsResubscribe.delete(runId);
+          this.suspendedRuns.add(runId);
+        }
+      }
+      throw error;
     }
+  }
+
+  private confirmSubscription(runId: string, lastSeq: number, epoch: number): Promise<void> {
+    const existing = this.subscriptionAttempts.get(runId);
+    if (existing?.epoch === epoch) return existing.promise;
+
+    const promise = this.request("_subscribe", { run_id: runId, last_seq: lastSeq })
+      .then(() => {
+        if (this.subscriptionEpochs.get(runId) !== epoch || !this.subscribedRuns.has(runId)) {
+          throw new Error(`WebSocket subscription cancelled: ${runId}`);
+        }
+        this.needsResubscribe.delete(runId);
+        dbg("transport", "ws.subscribeConfirmed", { runId, lastSeq, epoch });
+      })
+      .catch((error) => {
+        if (this.subscriptionEpochs.get(runId) === epoch && this.subscribedRuns.has(runId)) {
+          this.needsResubscribe.add(runId);
+          // An error/timeout is acknowledgement-ambiguous. Closing discards the server's
+          // connection-local checkpoint; the desired subscription survives for the next retry.
+          this.ws?.close();
+        }
+        throw error;
+      })
+      .finally(() => {
+        const current = this.subscriptionAttempts.get(runId);
+        if (current?.epoch === epoch) this.subscriptionAttempts.delete(runId);
+      });
+    this.subscriptionAttempts.set(runId, { epoch, promise });
+    return promise;
   }
 
   /** Unsubscribe from a run's events */
   unsubscribeRun(runId: string): void {
-    if (!this.subscribedRuns.has(runId)) return;
     this.subscribedRuns.delete(runId);
     this.lastSeq.delete(runId);
+    this.needsResubscribe.delete(runId);
+    this.suspendedRuns.delete(runId);
+    this.liveRecoveryRuns.delete(runId);
+    this.subscriptionEpochs.set(runId, (this.subscriptionEpochs.get(runId) ?? 0) + 1);
     dbg("transport", "ws.unsubscribeRun", { runId });
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.sendRaw({
@@ -158,8 +270,46 @@ export class WsTransport implements Transport {
 
   private sendRaw(obj: Record<string, unknown>): void {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
-      this.ws.send(JSON.stringify(obj));
+      try {
+        this.ws.send(JSON.stringify(obj));
+      } catch (error) {
+        dbgWarn("transport", "ws.sendFailed", error);
+        this.ws.close();
+      }
     }
+  }
+
+  private request(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const id = `req_${++this.reqId}`;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`WebSocket request timed out: ${method}`));
+      }, 15000);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timeout);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        },
+      });
+      if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        try {
+          this.ws.send(JSON.stringify({ id, method, params }));
+        } catch (error) {
+          const pending = this.pending.get(id);
+          this.pending.delete(id);
+          pending?.reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      } else {
+        const pending = this.pending.get(id);
+        this.pending.delete(id);
+        pending?.reject(new Error("WebSocket not connected"));
+      }
+    });
   }
 
   private handleMessage(raw: string): void {
@@ -197,7 +347,11 @@ export class WsTransport implements Transport {
         if (reloadRunId) {
           dbgWarn("transport", "ws._full_reload", { reloadRunId });
           this.lastSeq.delete(reloadRunId);
-          this.subscribedRuns.delete(reloadRunId);
+          this.needsResubscribe.delete(reloadRunId);
+          // Full reload transfers recovery ownership to the history loader. Clear any previous
+          // new-session policy so a concurrent subscribe failure cannot lift this suspension.
+          this.liveRecoveryRuns.delete(reloadRunId);
+          this.suspendedRuns.add(reloadRunId);
           const handlers = this.listeners.get("_full_reload");
           if (handlers) {
             for (const handler of handlers) handler({ run_id: reloadRunId });

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1103,6 +1103,27 @@ export type BusEvent =
       role?: string;
       parent_thread_id?: string;
     }
+  | {
+      type: "interaction_response_started";
+      run_id: string;
+      request_id: string;
+      interaction_kind: "permission" | "hook" | "elicitation" | "user_input";
+      resolution?: "allow" | "deny" | "defer" | "accept" | "decline" | "cancel";
+    }
+  | {
+      type: "interaction_response_failed";
+      run_id: string;
+      request_id: string;
+      interaction_kind: "permission" | "hook" | "elicitation" | "user_input";
+      error: string;
+    }
+  | {
+      type: "interaction_resolved";
+      run_id: string;
+      request_id: string;
+      interaction_kind?: "permission" | "hook" | "elicitation" | "user_input";
+      resolution?: "allow" | "deny" | "defer" | "accept" | "decline" | "cancel";
+    }
   | { type: "command_output"; run_id: string; content: string }
   | {
       type: "elicitation_prompt";
@@ -1151,7 +1172,17 @@ export type BusEvent =
   | { type: "codex_mcp_status"; run_id: string; name: string; status: string; error?: string }
   // Codex Wave-4: turn-level aggregated unified diff (`turn/diff/updated`). diff is cumulative
   // across the turn; the store keeps the latest (cleared at the next turn). Not replayed.
-  | { type: "codex_turn_diff"; run_id: string; turn_id: string; diff: string };
+  | { type: "codex_turn_diff"; run_id: string; turn_id: string; diff: string }
+  // Resolved identity for a Codex sub-agent thread (via thread/read). Optional fields preserve
+  // compatibility with older Codex versions that omit part of the identity.
+  | {
+      type: "codex_agent_info";
+      run_id: string;
+      thread_id: string;
+      nickname?: string;
+      role?: string;
+      parent_thread_id?: string;
+    };
 
 export type RalphCompleteReason =
   | "max_iterations"
@@ -1218,6 +1249,8 @@ export interface BusToolItem {
     | "ask_pending"
     | "permission_denied"
     | "permission_prompt"
+    | "response_pending"
+    | "response_failed"
     | "rejected";
   /** For permission_prompt status: the control_request ID needed to respond. */
   permission_request_id?: string;
@@ -1246,6 +1279,7 @@ export type TimelineEntry =
       ts: string;
       attachments?: Attachment[];
       cliUuid?: string;
+      historyContent?: HistoryContent;
     }
   | {
       kind: "assistant";
@@ -1255,6 +1289,8 @@ export type TimelineEntry =
       ts: string;
       thinkingText?: string;
       model?: string;
+      historyContent?: HistoryContent;
+      thinkingHistoryContent?: HistoryContent;
     }
   | {
       kind: "tool";
@@ -1265,7 +1301,14 @@ export type TimelineEntry =
       subTimeline?: TimelineEntry[];
     }
   | { kind: "separator"; id: string; anchorId: string; content: string; ts: string }
-  | { kind: "command_output"; id: string; anchorId: string; content: string; ts: string }
+  | {
+      kind: "command_output";
+      id: string;
+      anchorId: string;
+      content: string;
+      ts: string;
+      historyContent?: HistoryContent;
+    }
   // Codex Wave-4: a hook execution timeline entry. Upserted by the `codex_hook_run`
   // reducer — keyed by `hookId` (= Codex run.id), stable across the started→completed
   // pair so the running card updates in place instead of stacking a second entry.
@@ -1280,6 +1323,106 @@ export type TimelineEntry =
       durationMs?: number;
       ts: string;
     };
+
+export interface HistoryContent {
+  preview: string;
+  byteLength: number;
+  truncated: boolean;
+  contentId?: string;
+  encoding: "text" | "json";
+}
+
+interface HistoryEntryBase {
+  id: string;
+  anchorId: string;
+  ts: string;
+  firstSeq: number;
+  lastSeq: number;
+}
+
+export type HistoryEntry =
+  | (HistoryEntryBase & {
+      kind: "user";
+      content: HistoryContent;
+      cliUuid?: string;
+      attachments?: Attachment[];
+    })
+  | (HistoryEntryBase & {
+      kind: "assistant";
+      content: HistoryContent;
+      thinking?: HistoryContent;
+      model?: string;
+    })
+  | (HistoryEntryBase & {
+      kind: "tool";
+      toolUseId: string;
+      toolName: string;
+      status: BusToolItem["status"];
+      input: Record<string, unknown>;
+      output: Record<string, unknown> | null;
+      toolUseResult?: Record<string, unknown>;
+      inputContent?: HistoryContent;
+      outputContent?: HistoryContent;
+      resultContent?: HistoryContent;
+      durationMs?: number;
+      subHistoryId?: string;
+    })
+  | (HistoryEntryBase & {
+      kind: "command_output" | "placeholder";
+      content: HistoryContent;
+    });
+
+export interface HistorySummary {
+  runId: string;
+  generationId: string;
+  pageCount: number;
+  totalEntries: number;
+  totalTurns: number;
+  lastSeq: number;
+  sourceSize: number;
+  sourceMtimeNs: number;
+  latestCursor?: string;
+  stateEvents: BusEvent[];
+}
+
+export interface BusEventPage {
+  events: BusEvent[];
+  lastSeq: number;
+  hasMore: boolean;
+  nextOffset: number;
+}
+
+export interface HistoryPage {
+  runId: string;
+  generationId: string;
+  entries: HistoryEntry[];
+  pageCursor: string;
+  previousCursor?: string;
+  hasMore: boolean;
+  firstSeq: number;
+  lastSeq: number;
+}
+
+export interface HistoryContentChunk {
+  runId: string;
+  generationId: string;
+  contentId: string;
+  offset: number;
+  nextOffset: number;
+  totalBytes: number;
+  eof: boolean;
+  dataBase64: string;
+}
+
+export interface SubHistoryPage {
+  runId: string;
+  generationId: string;
+  subHistoryId: string;
+  entries: HistoryEntry[];
+  pageCursor: string;
+  previousCursor?: string;
+  hasMore: boolean;
+}
 
 /** One row of a TodoWrite checklist (lives in a tool's `tool_use_result.newTodos`). */
 export interface TodoItem {

--- a/src/lib/utils/browser-storage.test.ts
+++ b/src/lib/utils/browser-storage.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  readStorageItem,
+  removeStorageItem,
+  writeStorageItem,
+  type BrowserStorage,
+} from "./browser-storage";
+
+describe("browser storage", () => {
+  it("reads, writes, and removes values", () => {
+    const values = new Map<string, string>();
+    const storage: BrowserStorage = {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: (key) => values.delete(key),
+    };
+
+    expect(writeStorageItem("theme", "light", storage)).toBe(true);
+    expect(readStorageItem("theme", storage)).toBe("light");
+    expect(removeStorageItem("theme", storage)).toBe(true);
+    expect(readStorageItem("theme", storage)).toBeNull();
+  });
+
+  it("returns safe sentinels when WebView storage operations fail", () => {
+    const storage: BrowserStorage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
+
+    expect(readStorageItem("theme", storage)).toBeNull();
+    expect(writeStorageItem("theme", "light", storage)).toBe(false);
+    expect(removeStorageItem("theme", storage)).toBe(false);
+    expect(readStorageItem("theme", null)).toBeNull();
+  });
+});

--- a/src/lib/utils/browser-storage.ts
+++ b/src/lib/utils/browser-storage.ts
@@ -1,0 +1,55 @@
+export interface BrowserStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** Resolve localStorage without letting a restricted WebView abort application startup. */
+export function getBrowserStorage(): BrowserStorage | null {
+  try {
+    if (typeof window !== "undefined") return window.localStorage;
+    if (typeof globalThis.localStorage !== "undefined") return globalThis.localStorage;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function readStorageItem(
+  key: string,
+  storage: BrowserStorage | null = getBrowserStorage(),
+): string | null {
+  if (!storage) return null;
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function writeStorageItem(
+  key: string,
+  value: string,
+  storage: BrowserStorage | null = getBrowserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeStorageItem(
+  key: string,
+  storage: BrowserStorage | null = getBrowserStorage(),
+): boolean {
+  if (!storage) return false;
+  try {
+    storage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/utils/history-content-window.test.ts
+++ b/src/lib/utils/history-content-window.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { appendHistoryChunkWindow } from "./history-content-window";
+
+describe("appendHistoryChunkWindow", () => {
+  it("retains at most the two newest decoded chunks", () => {
+    let state = appendHistoryChunkWindow([], [], "one", 0);
+    state = appendHistoryChunkWindow(state.chunks, state.chunkStarts, "two", 256 * 1024);
+    state = appendHistoryChunkWindow(state.chunks, state.chunkStarts, "three", 512 * 1024);
+
+    expect(state.chunks).toEqual(["two", "three"]);
+    expect(state.windowStart).toBe(256 * 1024);
+  });
+
+  it("uses actual chunk offsets when the preceding chunk is short", () => {
+    let state = appendHistoryChunkWindow([], [], "one", 0);
+    state = appendHistoryChunkWindow(state.chunks, state.chunkStarts, "two", 256 * 1024);
+    state = appendHistoryChunkWindow(state.chunks, state.chunkStarts, "three", 300 * 1024);
+    expect(state.windowStart).toBe(256 * 1024);
+  });
+});

--- a/src/lib/utils/history-content-window.ts
+++ b/src/lib/utils/history-content-window.ts
@@ -1,0 +1,19 @@
+export function appendHistoryChunkWindow(
+  chunks: string[],
+  chunkStarts: number[],
+  chunk: string,
+  chunkStart: number,
+): { chunks: string[]; chunkStarts: number[]; windowStart: number } {
+  const bounded = [...chunks, chunk];
+  const boundedStarts = [...chunkStarts, chunkStart];
+  if (bounded.length <= 2) {
+    return { chunks: bounded, chunkStarts: boundedStarts, windowStart: boundedStarts[0] ?? 0 };
+  }
+  bounded.shift();
+  boundedStarts.shift();
+  return {
+    chunks: bounded,
+    chunkStarts: boundedStarts,
+    windowStart: boundedStarts[0] ?? 0,
+  };
+}

--- a/src/lib/utils/history-request-guard.test.ts
+++ b/src/lib/utils/history-request-guard.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isCurrentContentChunk, isCurrentSubhistoryPage } from "./history-request-guard";
+
+describe("history request guards", () => {
+  it("rejects a content chunk after the viewer identity changes", () => {
+    const request = {
+      token: 1,
+      runId: "run-1",
+      generationId: "generation-1",
+      contentId: "content-1",
+      offset: 0,
+    };
+    const chunk = {
+      runId: "run-1",
+      generationId: "generation-1",
+      contentId: "content-1",
+      offset: 0,
+      nextOffset: 10,
+      totalBytes: 10,
+      eof: true,
+      dataBase64: "",
+    };
+
+    expect(isCurrentContentChunk(request, 1, chunk)).toBe(true);
+    expect(
+      isCurrentContentChunk(request, 1, chunk, {
+        runId: "run-2",
+        generationId: "generation-1",
+        contentId: "content-1",
+      }),
+    ).toBe(false);
+    expect(isCurrentContentChunk(request, 2, chunk)).toBe(false);
+    expect(isCurrentContentChunk(request, 1, { ...chunk, generationId: "generation-2" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects a subhistory page after the tool identity changes", () => {
+    const request = {
+      token: 3,
+      runId: "run-1",
+      generationId: "generation-1",
+      subHistoryId: "sub-1",
+    };
+    const page = {
+      runId: "run-1",
+      generationId: "generation-1",
+      subHistoryId: "sub-1",
+      entries: [],
+      pageCursor: "generation-1:1",
+      hasMore: false,
+    };
+
+    expect(isCurrentSubhistoryPage(request, 3, page)).toBe(true);
+    expect(
+      isCurrentSubhistoryPage(request, 3, page, {
+        runId: "run-1",
+        generationId: "generation-2",
+        subHistoryId: "sub-1",
+      }),
+    ).toBe(false);
+    expect(isCurrentSubhistoryPage(request, 4, page)).toBe(false);
+    expect(isCurrentSubhistoryPage(request, 3, { ...page, subHistoryId: "sub-2" })).toBe(false);
+  });
+});

--- a/src/lib/utils/history-request-guard.ts
+++ b/src/lib/utils/history-request-guard.ts
@@ -1,0 +1,51 @@
+import type { HistoryContentChunk, SubHistoryPage } from "$lib/types";
+
+export interface ContentChunkRequest {
+  token: number;
+  runId: string;
+  generationId: string;
+  contentId: string;
+  offset: number;
+}
+
+export function isCurrentContentChunk(
+  request: ContentChunkRequest,
+  currentToken: number,
+  chunk: HistoryContentChunk,
+  current: Pick<ContentChunkRequest, "runId" | "generationId" | "contentId"> = request,
+): boolean {
+  return (
+    request.token === currentToken &&
+    current.runId === request.runId &&
+    current.generationId === request.generationId &&
+    current.contentId === request.contentId &&
+    chunk.runId === request.runId &&
+    chunk.generationId === request.generationId &&
+    chunk.contentId === request.contentId &&
+    chunk.offset === request.offset
+  );
+}
+
+export interface SubhistoryRequest {
+  token: number;
+  runId: string;
+  generationId: string;
+  subHistoryId: string;
+}
+
+export function isCurrentSubhistoryPage(
+  request: SubhistoryRequest,
+  currentToken: number,
+  page: SubHistoryPage,
+  current: Pick<SubhistoryRequest, "runId" | "generationId" | "subHistoryId"> = request,
+): boolean {
+  return (
+    request.token === currentToken &&
+    current.runId === request.runId &&
+    current.generationId === request.generationId &&
+    current.subHistoryId === request.subHistoryId &&
+    page.runId === request.runId &&
+    page.generationId === request.generationId &&
+    page.subHistoryId === request.subHistoryId
+  );
+}

--- a/src/lib/utils/snapshot-cache.ts
+++ b/src/lib/utils/snapshot-cache.ts
@@ -17,8 +17,8 @@ const DB_NAME = "opencovibe-snapshot";
 const DB_VERSION = 1;
 const STORE_NAME = "snapshots";
 
-/** Bump when reducer logic changes to invalidate all cached snapshots. */
-const SNAPSHOT_VERSION = 2;
+/** Bump because paged history no longer restores full timeline snapshots. */
+const SNAPSHOT_VERSION = 3;
 
 interface SnapshotRecord {
   runId: string; // primary key

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -36,7 +36,6 @@
   } from "$lib/types";
   import { PLATFORM_PRESETS, findCredential } from "$lib/utils/platform-presets";
   import { isKnownAgent, getAgentFeatures } from "$lib/utils/agent-features";
-  import { IS_WEBKIT } from "$lib/utils/platform";
   import {
     detectBatchGroups,
     detectToolBursts,
@@ -51,6 +50,7 @@
   import XTerminal from "$lib/components/XTerminal.svelte";
   import ChatMessage from "$lib/components/ChatMessage.svelte";
   import InlineToolCard from "$lib/components/InlineToolCard.svelte";
+  import HistoryContentPager from "$lib/components/HistoryContentPager.svelte";
   import BatchProgressBar from "$lib/components/BatchProgressBar.svelte";
   import ToolBurstHeader from "$lib/components/ToolBurstHeader.svelte";
   import SessionStatusBar from "$lib/components/SessionStatusBar.svelte";
@@ -86,7 +86,7 @@
     setStoredRemoteCwd,
   } from "$lib/utils/remote-cwd";
   import { shouldAutoName } from "$lib/utils/auto-name";
-  import { resolvePermissionAfterDelivery } from "$lib/utils/resolve-permission";
+  import { resolvePermissionOptimistic } from "$lib/utils/resolve-permission";
   import { getToolColor } from "$lib/utils/tool-colors";
   import { ansiToHtml, hasAnsiCodes } from "$lib/utils/ansi";
   import { randomSpinnerVerb } from "$lib/utils/spinner-verbs";
@@ -133,6 +133,7 @@
   // ── Layout context ──
   const toggleLayoutSidebar = getContext<() => void>("toggleSidebar");
   const keybindingStore = getContext<KeybindingStore>("keybindings");
+  // Global team store (provided by +layout) — fed to the inline agent minimap alongside `store`.
 
   // ── Store + Middleware ──
   const store = new SessionStore();
@@ -404,40 +405,6 @@
   let verboseRetryCount = 0;
   let verboseRetryTimer: ReturnType<typeof setTimeout> | null = null;
   const VERBOSE_MAX_RETRIES = 3;
-
-  // ── Tool result lazy-load cache (Phase 2) ──
-  let toolResultCache = new Map<string, Record<string, unknown>>();
-  let toolResultInflight = new Map<string, Promise<Record<string, unknown> | null>>();
-  // Clear cache on run switch
-  $effect(() => {
-    const _ = store.run?.id;
-    toolResultCache = new Map();
-    toolResultInflight = new Map();
-  });
-
-  async function fetchToolResult(
-    runId: string,
-    toolUseId: string,
-  ): Promise<Record<string, unknown> | null> {
-    const key = `${runId}:${toolUseId}`;
-    const cached = toolResultCache.get(key);
-    if (cached) return cached;
-    let pending = toolResultInflight.get(key);
-    if (!pending) {
-      pending = api.getToolResult(runId, toolUseId);
-      toolResultInflight.set(key, pending);
-    }
-    try {
-      const result = await pending;
-      // Run-gen check: don't write stale results into a different run's cache
-      if (result && store.run?.id === runId) {
-        toolResultCache.set(key, result);
-      }
-      return result;
-    } finally {
-      toolResultInflight.delete(key);
-    }
-  }
 
   // ── Timeline rendering ──
   // Progressive render: start with the most recent N entries, grow on upward scroll.
@@ -877,8 +844,12 @@
         if (!entry?.isIntersecting) return;
         if (!loadMoreArmed || loadingMore) return;
         const hidden = filteredTimeline.length - renderLimit;
-        if (hidden <= 0) return;
-        dbg("chat", "progressive-load-more", { renderLimit, hidden });
+        if (hidden <= 0 && !store.historyHasMore) return;
+        dbg("chat", "progressive-load-more", {
+          renderLimit,
+          hidden,
+          historyHasMore: store.historyHasMore,
+        });
         void loadMoreEarlier();
       },
       { root: chatAreaRef, rootMargin: "200px 0px 0px 0px", threshold: 0 },
@@ -900,15 +871,38 @@
     if (loadingMore || !loadMoreArmed) return;
     loadingMore = true;
     loadMoreArmed = false; // re-armed by handleChatScroll on next user scroll
+    _suppressLoadMoreRearm = true;
+    const gen = progressiveGen;
     try {
       const anchor = chatAreaRef?.querySelector<HTMLElement>("[data-entry-id]") ?? null;
       const anchorId = anchor?.dataset.entryId ?? null;
-      const beforeTop = anchor?.getBoundingClientRect().top ?? 0;
-      const beforeScroll = chatAreaRef?.scrollTop ?? 0;
+      let beforeTop = anchor?.getBoundingClientRect().top ?? 0;
+      let beforeScroll = chatAreaRef?.scrollTop ?? 0;
 
-      renderLimit = Math.min(renderLimit + RENDER_GROWTH_STEP, filteredTimeline.length);
+      const hidden = filteredTimeline.length - renderLimit;
+      if (hidden > 0) {
+        renderLimit = Math.min(renderLimit + RENDER_GROWTH_STEP, filteredTimeline.length);
+      } else if (store.historyHasMore) {
+        const loaded = await store.loadOlderHistory();
+        if (gen !== progressiveGen) return;
+        if (loaded) {
+          renderLimit = Math.min(renderLimit + RENDER_GROWTH_STEP, filteredTimeline.length);
+        }
+      }
+      // The user can keep scrolling while history IPC is in flight. Refresh the anchor baseline
+      // immediately before Svelte commits the prepend so the correction preserves their latest
+      // position instead of snapping back to where the request started.
+      if (anchorId && chatAreaRef) {
+        const currentAnchor = Array.from(
+          chatAreaRef.querySelectorAll<HTMLElement>("[data-entry-id]"),
+        ).find((element) => element.dataset.entryId === anchorId);
+        if (currentAnchor) {
+          beforeTop = currentAnchor.getBoundingClientRect().top;
+          beforeScroll = chatAreaRef.scrollTop;
+        }
+      }
       await tick();
-      await yieldToMain();
+      if (gen !== progressiveGen) return;
 
       if (anchorId && chatAreaRef) {
         let after: HTMLElement | null = null;
@@ -923,36 +917,25 @@
             ) ?? null;
         }
         if (after) {
+          const rendered = Array.from(chatAreaRef.querySelectorAll<HTMLElement>("[data-entry-id]"));
+          const anchorIndex = rendered.indexOf(after);
+          const forced = anchorIndex > 0 ? rendered.slice(0, anchorIndex) : [];
+          const previousVisibility = forced.map((element) => element.style.contentVisibility);
+          // Force the newly prepended entries through layout before measuring. Otherwise
+          // content-visibility contributes its 300px intrinsic estimate and corrects again as
+          // real content approaches the viewport, which presents as a second scroll jump.
+          for (const element of forced) element.style.contentVisibility = "visible";
           const afterTop = after.getBoundingClientRect().top;
-          // Suppress re-arm so the programmatic scrollTop write doesn't immediately
-          // rearm the observer — the sentinel may still be in view post-prepend.
-          _suppressLoadMoreRearm = true;
           chatAreaRef.scrollTop = beforeScroll + (afterTop - beforeTop);
-          // Clear suppression after the scroll event has dispatched + been handled.
-          // yieldToMain has a 50ms timeout fallback so a backgrounded WebView with
-          // throttled rAF can't strand the suppression flag.
           await yieldToMain();
-          _suppressLoadMoreRearm = false;
+          for (let i = 0; i < forced.length; i++) {
+            forced[i].style.contentVisibility = previousVisibility[i];
+          }
         }
       }
     } finally {
+      _suppressLoadMoreRearm = false;
       loadingMore = false;
-    }
-
-    // IntersectionObserver only refires on state changes. If anchor compensation
-    // produced ~zero delta (collapsed/unmeasured entries above the viewport, or
-    // a stable layout where the prepended content all sits within rootMargin),
-    // the sentinel stays "still intersecting" with no new state to deliver — and
-    // the user-scroll re-arm path (handleChatScroll) never fires either because
-    // a same-value scrollTop write may dispatch no scroll event. Re-observing
-    // forces a fresh callback delivery: if the sentinel exited the viewport,
-    // the callback returns early; if still intersecting, it kicks off another
-    // batch, naturally terminating once `filteredTimeline.length <= renderLimit`
-    // or the sentinel exits.
-    if (_topObserver && topSentinel && filteredTimeline.length > renderLimit) {
-      loadMoreArmed = true;
-      _topObserver.unobserve(topSentinel);
-      _topObserver.observe(topSentinel);
     }
   }
 
@@ -1632,11 +1615,11 @@
     const hasResume = hasResumeParam;
     untrack(() => {
       middleware.subscribeCurrent(id, store);
+      const routeInvalidatedOperation = store.invalidateOperationsForRoute(id);
 
-      // Strongest guard: resume operation in progress — don't interfere.
-      // Check both store guard (set inside resumeSession) and local flag
-      // (set at handleResume entry, before store guard is acquired).
-      if (store.resumeInFlight || resuming) {
+      // The same run stays owned by resume/fork until it completes. A different URL is an
+      // explicit navigation: invalidate the old operation and continue loading the new run.
+      if ((store.resumeInFlight || resuming) && !routeInvalidatedOperation) {
         dbg("effect", "skip loadRun — resume in progress");
         return;
       }
@@ -1815,15 +1798,6 @@
         promptRef?.addFiles([file]);
       },
     );
-    const interactiveFollowUpWarningUnlisten = chatTransport.listen<{
-      run_id: string;
-      request_id: string;
-      error: string;
-    }>("interactive-follow-up-warning", (payload) => {
-      if (payload.run_id !== store.run?.id) return;
-      dbgWarn("chat", "interactive follow-up failed after response delivery", payload);
-      showChatToast(t("toast_permissionInterruptFailed"));
-    });
 
     // Tauri native drag-drop listeners (dragDropEnabled: true in tauri.conf.json)
     const dragEnterUnlisten = chatTransport.listen<{ paths: string[] }>(
@@ -1888,7 +1862,6 @@
       keybindingStore.unregisterCallback("app:exportChatHtml");
       window.removeEventListener("ocv:export-html", onExportHtmlEvent);
       screenshotUnlisten.then((fn) => fn());
-      interactiveFollowUpWarningUnlisten.then((fn) => fn());
       dragEnterUnlisten.then((fn) => fn());
       dragLeaveUnlisten.then((fn) => fn());
       dragDropUnlisten.then((fn) => fn());
@@ -2088,6 +2061,10 @@
     // (loadMoreEarlier's anchor compensation) raise `_suppressLoadMoreRearm` so the
     // anchor-correction scroll doesn't immediately re-arm the observer.
     if (!loadMoreArmed && !_suppressLoadMoreRearm) loadMoreArmed = true;
+    const hasEarlier = filteredTimeline.length > renderLimit || store.historyHasMore;
+    if (loadMoreArmed && !loadingMore && hasEarlier && chatAreaRef.scrollTop <= 200) {
+      void loadMoreEarlier();
+    }
   }
 
   function scrollChatToBottom() {
@@ -2244,7 +2221,12 @@
           slashCmdSeenRunning = false;
         }
 
-        const runId = await store.startSession(text, cwd, attachments);
+        const result = await store.startSession(text, cwd, attachments);
+        if (result.status === "cancelled") {
+          dbg("chat", "new session cancelled by route change");
+          return;
+        }
+        const runId = result.runId;
         goto(`/chat?run=${runId}`, { replaceState: true });
         window.dispatchEvent(new Event("ocv:runs-changed"));
         // Re-detect CLI version on new session (picks up external updates)
@@ -2273,7 +2255,11 @@
         // sidebar afterward so its status badge leaves the stale "stopped" state.
         const wasStoppedCodex =
           store.useStreamSession && !store.sessionAlive && store.run?.agent === "codex";
-        await store.sendMessage(text, attachments, skills);
+        const result = await store.sendMessage(text, attachments, skills);
+        if (result.status === "cancelled") {
+          dbg("chat", "send cancelled by route change");
+          return;
+        }
         if (wasStoppedCodex) window.dispatchEvent(new Event("ocv:runs-changed"));
         requestAnimationFrame(() => promptRef?.focus());
       }
@@ -3521,9 +3507,8 @@
         appendCommandOutput(t("init_noCwd"));
         return;
       }
-      // Remote target: sendMessage resolves cwd via getStoredRemoteCwd(host)
-      // (chat/+page.svelte:1968), not localStorage. The handoff below cannot
-      // bridge those paths. Guard remote until wave 4b unifies cwd resolution.
+      // Remote target uses a different cwd source; keep this command local until the handoff is
+      // unified so the file existence check and the session cannot target different projects.
       if (store.remoteHostName) {
         dbgWarn("chat", "init-project blocked: remote not supported", {
           host: store.remoteHostName,
@@ -3709,13 +3694,18 @@
       if (mode !== "fork") {
         middleware.subscribeCurrent(targetRunId, store);
       }
-      const resultId = await store.resumeSession(
+      const result = await store.resumeSession(
         targetRunId,
         mode,
         initialMessage,
         initialAttachments,
       );
-      if (resultId) {
+      if (result.status === "cancelled") {
+        dbg("chat", "resume operation cancelled", { mode, targetRunId });
+        return;
+      }
+      if (result.status === "success") {
+        const resultId = result.runId;
         middleware.subscribeCurrent(resultId, store);
         if (mode === "fork") {
           // Check if user cancelled during fork_oneshot
@@ -3771,6 +3761,8 @@
   async function handleForkCancel() {
     if (!forkOverlay) return;
     const sourceRunId = forkOverlay.sourceRunId;
+    store.cancelResumeOperation();
+    middleware.subscribeCurrent("", store);
     await stopForkProcess(sourceRunId);
     forkOverlay = null;
     store.error = "";
@@ -4118,32 +4110,31 @@
       interrupt,
     });
     try {
-      const modeOverride =
-        behavior === "allow"
-          ? updatedPermissions?.find((permission) => permission.type === "setMode")?.mode
-          : undefined;
+      // Set pending mode override BEFORE responding (so reducer picks it up)
+      if (behavior === "allow" && updatedPermissions) {
+        const modePerm = updatedPermissions.find((p) => p.type === "setMode");
+        if (modePerm && modePerm.mode) {
+          store.pendingPermissionModeOverride = modePerm.mode;
+          dbg("chat", "set pendingPermissionModeOverride", { mode: modePerm.mode });
+        }
+      }
 
-      await resolvePermissionAfterDelivery(
-        store,
+      await api.respondPermission(
         runId,
         requestId,
         behavior,
-        () =>
-          api.respondPermission(
-            runId,
-            requestId,
-            behavior,
-            updatedPermissions,
-            updatedInput,
-            denyMessage,
-            interrupt,
-          ),
-        modeOverride,
+        updatedPermissions,
+        updatedInput,
+        denyMessage,
+        interrupt,
       );
+      // Optimistic resolve + clear attention flag
+      resolvePermissionOptimistic(store, runId, requestId, behavior);
     } catch (e) {
       dbgWarn("chat", "permission respond failed:", e);
-      // The backend retains pending state when primary delivery fails, so keep the card
-      // actionable for both allow and deny retries.
+      if (!String(e).includes("[interaction:not_started]")) {
+        store.markInteractionResponseFailed(requestId, "permission", e);
+      }
       store.error = String(e);
       throw e; // Let component-side wrapper catch and unlock buttons
     }
@@ -4164,7 +4155,11 @@
       resolveElicitationOptimistic(store, runId, requestId);
     } catch (e) {
       dbgWarn("chat", "elicitation respond failed:", e);
+      if (!String(e).includes("[interaction:not_started]")) {
+        store.markInteractionResponseFailed(requestId, "elicitation", e);
+      }
       store.error = String(e);
+      throw e;
     }
   }
 
@@ -4246,24 +4241,18 @@
 
     try {
       // 1. Set flags BEFORE responding
+      store.pendingPermissionModeOverride = "acceptEdits";
       store.pendingClearContextPlan = "__pending__"; // marker: waiting for tool_end
 
       // 2. Allow ExitPlanMode (with setMode) — satisfies the control_response requirement
-      await resolvePermissionAfterDelivery(
-        store,
+      await api.respondPermission(
         runId,
         requestId,
         "allow",
-        () =>
-          api.respondPermission(
-            runId,
-            requestId,
-            "allow",
-            [{ type: "setMode", mode: "acceptEdits", destination: "session" }],
-            exitPlanEntry.tool.input,
-          ),
-        "acceptEdits",
+        [{ type: "setMode", mode: "acceptEdits", destination: "session" }],
+        exitPlanEntry.tool.input,
       );
+      resolvePermissionOptimistic(store, runId, requestId, "allow");
 
       // 3. Wait for tool_end to deliver plan content (via pendingClearContextPlan)
       //    Poll briefly — tool_end should arrive within a few hundred ms
@@ -4297,7 +4286,12 @@
       const planPrompt = `Implement the following plan:\n\n${planContent}`;
       await goto("/chat", { replaceState: true });
       await tick(); // let runId effect run loadRun("") → store.reset()
-      const newRunId = await store.startSession(planPrompt, cwd, [], "acceptEdits");
+      const result = await store.startSession(planPrompt, cwd, [], "acceptEdits");
+      if (result.status === "cancelled") {
+        dbg("chat", "ExitPlanMode restart cancelled by route change");
+        return;
+      }
+      const newRunId = result.runId;
       await goto(`/chat?run=${newRunId}`, { replaceState: true });
       dbg("chat", "ExitPlanMode: new session started", { newRunId });
     } catch (e) {
@@ -4321,6 +4315,9 @@
       );
     } catch (e) {
       dbgWarn("chat", "hook callback respond failed:", e);
+      if (!String(e).includes("[interaction:not_started]")) {
+        store.markInteractionResponseFailed(requestId, "hook", e);
+      }
       store.error = String(e);
       throw e;
     }
@@ -4771,7 +4768,7 @@
         <!-- API / Codex bus-events mode: chat messages -->
         <div
           class="h-full overflow-y-auto"
-          style="overflow-anchor:auto"
+          style="overflow-anchor:none"
           bind:this={chatAreaRef}
           onscroll={handleChatScroll}
         >
@@ -4938,7 +4935,7 @@
                   </div>
                 </div>
               {/if}
-              {#if filteredTimeline.length - renderLimit > 0}
+              {#if filteredTimeline.length - renderLimit > 0 || store.historyHasMore}
                 <div bind:this={topSentinel} aria-hidden="true" class="h-px w-full"></div>
               {/if}
               {#each visibleTimeline as entry, i (entry.id)}
@@ -5009,6 +5006,9 @@
                           timestamp: entry.ts,
                         }}
                         attachments={entry.attachments}
+                        historyContent={entry.historyContent}
+                        historyRunId={store.run?.id}
+                        historyGenerationId={store.historySummary?.generationId}
                         onRewind={store.caps.supportsSnapshots &&
                         entry.cliUuid &&
                         store.sessionAlive &&
@@ -5030,7 +5030,11 @@
                           timestamp: entry.ts,
                         }}
                         thinkingText={entry.thinkingText}
+                        thinkingHistoryContent={entry.thinkingHistoryContent}
                         agent={store.agent}
+                        historyContent={entry.historyContent}
+                        historyRunId={store.run?.id}
+                        historyGenerationId={store.historySummary?.generationId}
                       />
                     {:else if entry.kind === "tool"}
                       {#if claudeTurnStarts.has(i)}
@@ -5043,7 +5047,7 @@
                               tool={entry.tool}
                               subTimeline={entry.subTimeline}
                               runId={store.run?.id ?? ""}
-                              {fetchToolResult}
+                              historyGenerationId={store.historySummary?.generationId}
                               onAnswer={entry.tool.tool_name === "AskUserQuestion" &&
                               (entry.tool.status === "running" ||
                                 entry.tool.status === "ask_pending")
@@ -5089,6 +5093,13 @@
                                 )}</pre>
                             {:else}
                               <MarkdownContent text={entry.content} />
+                            {/if}
+                            {#if entry.historyContent && store.run && store.historySummary}
+                              <HistoryContentPager
+                                runId={store.run.id}
+                                generationId={store.historySummary.generationId}
+                                content={entry.historyContent}
+                              />
                             {/if}
                           </div>
                         </div>
@@ -5198,7 +5209,7 @@
               {/if}
 
               <!-- Pending hook callbacks (runtime UI — excluded from export) -->
-              {#each store.hookEvents.filter((h) => h.status === "hook_pending") as hookEvent (hookEvent.request_id)}
+              {#each store.hookEvents.filter((h) => h.status === "hook_pending" || h.status === "responding" || h.status === "error") as hookEvent (hookEvent.request_id)}
                 <div class="chat-content-width pl-7" data-export-exclude>
                   <HookReviewCard {hookEvent} onRespond={handleHookCallbackRespond} />
                 </div>
@@ -5633,7 +5644,7 @@
     {/if}
 
     <!-- MCP Elicitation dialog (above input bar) -->
-    {#if store.hasElicitation && store.sessionAlive}
+    {#if store.pendingElicitations.size > 0 && store.sessionAlive}
       <ElicitationDialog
         elicitations={store.pendingElicitations}
         onRespond={handleElicitationRespond}


### PR DESCRIPTION
## What changed

- Add a derived, immutable paged-history projection with bounded message pages and content chunks.
- Load large sessions incrementally across the Tauri and WebSocket transports, with bounded catch-up between historical and live events.
- Make projected render IDs globally unique and suppress duplicated assistant/tool entries from overlapping imported Claude ranges.
- Batch sparse historical pages and stabilize prepend anchoring to reduce upward-scroll jitter.
- Preserve pending interaction responses across history/live handoff and reject stale, duplicate, or mismatched responses explicitly.

## Root cause

Large sessions were fully materialized when opened, which caused excessive memory and rendering work. Some imported Claude event ranges also reused render IDs; Svelte keyed rendering then collapsed timeline entries and could show a blank conversation. For sparse history, repeatedly prepending one-entry pages triggered multiple anchor corrections, producing visible upward-scroll jitter.

## Compatibility

Existing `events.jsonl` and `meta.json` files remain the source of truth and are not migrated or rewritten. The new `history-v1` representation is derived data: existing sessions open without migration, and missing or stale derived history is rebuilt automatically.

## Validation

- `npm run lint:fix`
- `npm run format` and `npm run format:check`
- `npm run check` — 0 errors
- `npm test` — 45 files, 1522 tests passed
- `npm run build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- Rust tests — 795 passed, 2 ignored
- `scripts/check-serde-sync.sh`
- User verification: the previously blank session loads normally, and upward scrolling feels substantially smoother.

Closes #183.
