### PR TITLE
chore: refresh README for current platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,43 +27,43 @@
 
 ## Why OpenCovibe?
 
-AI coding CLIs like Claude Code are powerful, but they run inside a terminal. That means no persistent dashboard, no visual diff review, no cross-session history, and no multi-provider switching. OpenCovibe wraps these CLIs with a native desktop UI that adds the layers the terminal can't provide — while keeping all your data **stored locally**. (Remote model APIs require network access; the app itself has no cloud backend.)
+AI coding CLIs like Claude Code and Codex are powerful, but their terminal-first interfaces make long-running work, visual review, and cross-session management harder to follow. OpenCovibe wraps these CLIs with a native desktop UI that adds a persistent dashboard, structured tool activity, visual diffs, and searchable run history — while keeping app data **stored locally**. Remote model APIs still require network access; OpenCovibe itself has no cloud backend.
 
-| Agent | Status |
-|-------|--------|
-| [Claude Code](https://github.com/anthropics/claude-code) | Supported |
-| [Codex](https://github.com/openai/codex) | Supported — interactive `app-server` mode (default) with `exec` fallback |
+| Agent                                                    | Status                                                                                |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Claude Code](https://github.com/anthropics/claude-code) | Supported                                                                             |
+| [Codex](https://github.com/openai/codex)                 | Supported — experimental interactive `app-server` mode (default) with `exec` fallback |
 
-**Platform status**: Currently developed and tested primarily on **macOS**. Windows and Linux builds are functional but have not been thoroughly tested for compatibility — contributions and bug reports are welcome.
+**Platform status**: Pre-built packages are available for **macOS 13+** (Apple Silicon and Intel) and **Windows 10+ x64**. Linux is supported through source builds. Development and testing are still primarily performed on macOS, so Windows and Linux bug reports are especially welcome.
 
 **Core principle**: Wrap the CLI, surface the work, keep it local.
 
 ## Key Capabilities
 
-### What the CLI doesn't give you
+### What OpenCovibe adds
 
-| Capability | What OpenCovibe adds |
-|------------|---------------------|
-| **Visual Tool Cards** | Every tool call (Read, Edit, Bash, Grep, Write, WebFetch, …) rendered as an inline card with syntax-highlighted diffs, structured output, and one-click copy |
-| **Run History & Replay** | Browse all past sessions, full event replay, resume / fork from any point, soft-delete with recovery |
-| **Multi-Provider Switching** | Use Claude Code with 15+ API providers (DeepSeek, Kimi, Zhipu, Bailian, DouBao, MiniMax, OpenRouter, Ollama, …) — hot-switch without restarting |
-| **Remote Browser Access** | Embedded web server for browser-based access over LAN or HTTP tunnels (ngrok / cloudflared) |
-| **File Explorer** | Browse and edit project files with syntax highlighting, markdown preview, image preview, and git diff view |
-| **Memory Editor** | Create and edit CLAUDE.md, project-scoped and user-scoped memory files with live preview |
-| **Agent Management** | Visual editor to create, edit, and manage custom agent definitions (.md files) with form and source modes |
-| **Permission Rules** | Manage CLI permission allow/deny rules at user and project level with a visual rule editor |
-| **Usage Analytics** | Per-model token breakdown, cost tracking, daily heatmap, stacked model chart, session-level stats |
-| **Team Dashboard** | Read-only view into Claude Code multi-agent teams — task lists, teammate status, message flow |
-| **Activity Monitor** | Real-time hook event stream, tool activity timeline, file tracking panel, subagent tracking with nested tool cards |
-| **Plugin Marketplace** | Browse, install, and manage Claude Code plugins and skills from a visual marketplace |
-| **MCP Management** | Discover MCP servers, view per-server status, reconnect / toggle from a panel |
-| **Inline Permissions** | Rich permission review UI with batch Allow/Deny panel, CLI-suggested "Always Allow" rules, and AskUserQuestion rendering |
-| **CLI Session Import** | Discover and import existing Claude Code CLI sessions into OpenCovibe |
-| **Rewind** | Checkpoint and selectively revert file changes with dry-run preview |
-| **Remote Hosts** | Configure SSH hosts for remote CLI execution with key generation wizard and connectivity testing |
+| Capability                   | What OpenCovibe adds                                                                                                                                           |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Visual Tool Cards**        | Every tool call (Read, Edit, Bash, Grep, Write, WebFetch, …) rendered as an inline card with syntax-highlighted diffs, structured output, and one-click copy   |
+| **Run History & Replay**     | Browse all past sessions, full event replay, resume / fork from any point, soft-delete with recovery                                                           |
+| **Multi-Provider Switching** | Use Claude Code with built-in presets for Anthropic-compatible providers, gateways, and local runtimes — hot-switch without restarting                         |
+| **Remote Browser Access**    | Token-protected embedded web server for browser access over LAN or HTTP tunnels (ngrok / cloudflared)                                                          |
+| **File Explorer**            | Browse and edit project files with syntax highlighting, markdown preview, image preview, and git diff view                                                     |
+| **Memory Editor**            | Create and edit CLAUDE.md, project-scoped and user-scoped memory files with live preview                                                                       |
+| **Agent Management**         | Visual editor to create, edit, and manage Claude agent definitions and Codex roles, with form and source modes                                                 |
+| **Permission Rules**         | Manage CLI permission allow/deny rules at user and project level with a visual rule editor                                                                     |
+| **Usage Analytics**          | Per-model token breakdown, cost tracking, daily heatmap, stacked model chart, session-level stats                                                              |
+| **Team Dashboard**           | Read-only view into Claude Code multi-agent teams — task lists, teammate status, message flow                                                                  |
+| **Activity Monitor**         | Real-time hook event stream, tool activity timeline, file tracking panel, subagent tracking with nested tool cards                                             |
+| **Plugin Marketplace**       | Browse, install, and manage Claude Code and Codex plugins and skills from a visual marketplace                                                                 |
+| **MCP Management**           | Discover MCP servers, view per-server status, reconnect / toggle from a panel                                                                                  |
+| **Inline Permissions**       | Rich permission review UI with batch Allow/Deny panel, CLI-suggested "Always Allow" rules, and AskUserQuestion rendering                                       |
+| **CLI Session Import**       | Discover, import, and sync existing Claude Code and Codex CLI sessions into OpenCovibe                                                                         |
+| **Rewind**                   | Claude: selectively restore checkpointed file changes with a dry-run preview. Codex: rewind conversation history without reverting files                       |
+| **Remote Hosts**             | Configure SSH hosts for remote CLI execution with key generation wizard and connectivity testing                                                               |
 | **Preview & Element Picker** | Open a localhost preview in a companion window, interactively pick page elements, and insert structured context (DOM path, styles, HTML snippet) into the chat |
-| **Ralph Loop** | Auto-iterate the same prompt until a completion condition is met — hands-free coding with configurable max iterations |
-| **Doctor Diagnostics** | System health checks for CLI, platform, SSH, and proxy configuration |
+| **Ralph Loop**               | Auto-iterate the same prompt in Claude sessions until a completion condition is met, with a configurable iteration limit                                       |
+| **Doctor Diagnostics**       | System health checks for CLI, platform, SSH, and proxy configuration                                                                                           |
 
 ### Features
 
@@ -77,36 +77,40 @@ AI coding CLIs like Claude Code are powerful, but they run inside a terminal. Th
 - **i18n** — English and Chinese (Simplified) with lightweight reactive runtime
 - **System Tray** — Hide to tray; background sessions keep running with native notifications
 - **Dark / Light Theme** — CSS variable-based theming with UI zoom control
-- **Auto Update** — In-app update checker with download links
+- **Update Check** — In-app release checker with platform-specific download links
 - **Setup Wizard** — Guided CLI detection, authentication, and provider configuration on first launch
 
 ## Quick Start
 
-### Option A: Download Pre-built Binary (macOS)
+### Option A: Download a Pre-built Package
 
-Download the latest `.dmg` from [Releases](https://github.com/AnyiWang/OpenCovibe/releases) — universal binary, supports both Apple Silicon and Intel Macs.
+Download the latest package from [Releases](https://github.com/AnyiWang/OpenCovibe/releases):
 
-> **Note**: The app is not code-signed. On first launch, right-click and select "Open" to bypass macOS Gatekeeper.
+- **macOS 13+**: universal `.dmg` for Apple Silicon and Intel Macs
+- **Windows 10+ x64**: `.msi` or setup `.zip`
 
-### Option B: Automated Setup (macOS)
+> **Unsigned builds**: On macOS, right-click the app and select **Open** on first launch. Windows SmartScreen may require choosing **More info > Run anyway**.
+
+### Option B: Automated Setup (macOS / Linux)
 
 ```bash
 git clone https://github.com/AnyiWang/OpenCovibe.git
 cd OpenCovibe
 ./scripts/setup.sh          # add --yes to skip confirmation prompts
-npm run tauri dev
 ```
 
-The setup script detects missing dependencies (Xcode CLI Tools, Homebrew, Node.js, Rust) and installs them automatically.
+The setup script detects the platform, checks the required build tools, installs missing dependencies with confirmation, and then installs the project packages. On macOS it can set up Xcode CLI Tools and Homebrew; on supported Linux distributions it installs the required WebKit/GTK packages. At the end it offers to start the development app; later runs use `npm run tauri dev`.
 
 ### Option C: Manual Setup
 
 **Prerequisites:**
 
 - [Node.js](https://nodejs.org/) >= 20
-- [Rust](https://rustup.rs/) >= 1.75
+- Current stable [Rust](https://rustup.rs/) toolchain
+- [Git](https://git-scm.com/)
 
-**macOS:**
+**macOS 13+:**
+
 ```bash
 xcode-select --install
 brew install node
@@ -114,17 +118,18 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 **Linux (Debian/Ubuntu):**
+
 ```bash
-sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file git \
+  libgtk-3-dev libssl-dev pkg-config libayatana-appindicator3-dev librsvg2-dev
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-**Windows:**
-```powershell
-# Install Rust from https://rustup.rs
-# Install Node.js from https://nodejs.org
-```
+**Windows 10+ x64:**
+
+1. Install [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with **Desktop development with C++**.
+2. Install the [Microsoft Edge WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/) if it is not already present.
+3. Install Node.js 20+, Git, and the Rust MSVC toolchain from [rustup](https://rustup.rs/).
 
 **Build & Run:**
 
@@ -140,50 +145,28 @@ npm run tauri dev
 On first launch, OpenCovibe guides you through:
 
 1. **CLI Detection** — Auto-detects Claude Code and Codex CLIs, offers installation if missing
-2. **Authentication** — OAuth login or API key for 15+ providers
+2. **Authentication** — CLI login, OAuth, or an API key for a configured provider
 3. **Ready** — Start coding
 
 You can re-run the wizard anytime from **Settings > General > Setup Wizard**.
 
 ## Supported Providers
 
-### LLM Providers
+Provider compatibility differs by agent. The presets shown in **Settings** are the runtime source of truth and may evolve between releases.
 
-| Provider | Endpoint | Auth |
-|----------|----------|------|
-| Anthropic | Official API | API Key |
-| DeepSeek | `api.deepseek.com/anthropic` | Bearer |
-| Kimi (Moonshot) | `api.moonshot.cn/anthropic` | Bearer |
-| Kimi For Coding | `api.kimi.com/coding/` | Bearer |
-| Zhipu (智谱) | `open.bigmodel.cn/api/anthropic` | Bearer |
-| Zhipu (智谱 Intl) | `api.z.ai/api/anthropic` | Bearer |
-| Bailian (Coding Plan) | `coding.dashscope.aliyuncs.com/apps/anthropic` | Bearer |
-| Bailian (百炼 API) | `dashscope.aliyuncs.com/apps/anthropic` | Bearer |
-| DouBao (豆包) | `ark.cn-beijing.volces.com/api/coding` | Bearer |
-| MiniMax | `api.minimax.io/anthropic` | Bearer |
-| MiniMax (China) | `api.minimaxi.com/anthropic` | Bearer |
-| Xiaomi MiMo (小米) | `api.xiaomimimo.com/anthropic` | Bearer |
-| Xiaomi MiMo (Token Plan) | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
-| Tencent Hunyuan (混元) | `api.hunyuan.cloud.tencent.com/anthropic` | Bearer |
-| SiliconFlow (硅基流动) | `api.siliconflow.com/` | Bearer |
+### Claude Code (Anthropic-compatible)
 
-### API Gateway
+| Category          | Built-in presets                                                                                                                                  |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Official          | Claude Code / Anthropic                                                                                                                           |
+| Model providers   | DeepSeek, Kimi, Zhipu, Bailian, DouBao, MiniMax, Xiaomi MiMo, Tencent Hunyuan, SiliconFlow, StepFun, LongCat, iFlytek Astron, Tencent Coding Plan |
+| API gateways      | Vercel AI Gateway, OpenRouter, AiHubMix, Requesty, Fireworks AI, DeepInfra, Novita AI, ZenMux                                                     |
+| Local and routers | Ollama, [CC Switch](https://github.com/farion1231/cc-switch), [Claude Code Router](https://github.com/musistudio/claude-code-router)              |
+| Custom            | Any Anthropic-compatible endpoint                                                                                                                 |
 
-| Platform | Endpoint | Auth |
-|----------|----------|------|
-| Vercel AI Gateway | `ai-gateway.vercel.sh` | Bearer |
-| OpenRouter | `openrouter.ai/api` | Bearer |
-| AiHubMix | `aihubmix.com` | Bearer |
-| ZenMux | `zenmux.ai/api/anthropic` | Bearer |
+### Codex (OpenAI Responses API)
 
-### Local
-
-| Platform | Endpoint |
-|----------|----------|
-| Ollama | `localhost:11434` |
-| [CC Switch](https://github.com/farion1231/cc-switch) | `localhost:15721` |
-| [Claude Code Router](https://github.com/musistudio/claude-code-router) | `localhost:3456` |
-| Custom | Any Anthropic-compatible endpoint |
+Codex can use its native ChatGPT/API-key login or a configured Responses-compatible provider: Vercel AI Gateway, AiHubMix, Requesty, Fireworks AI, ZenMux, Ollama, or a custom endpoint. Providers that only expose Chat Completions require a Responses translation proxy and do not work directly.
 
 ## Architecture
 
@@ -193,23 +176,23 @@ You can re-run the wizard anytime from **Settings > General > Setup Wizard**.
 
 **Tech Stack:**
 
-| Layer | Technology |
-|-------|-----------|
-| Framework | [Tauri v2](https://v2.tauri.app/) (Rust backend + WebView) |
-| Frontend | [Svelte 5](https://svelte.dev/) + [SvelteKit](https://svelte.dev/docs/kit/) (adapter-static) |
-| Styling | [Tailwind CSS](https://tailwindcss.com/) v3 + CSS variables |
-| Terminal | [xterm.js](https://xtermjs.org/) |
-| Markdown | [marked](https://marked.js.org/) + [highlight.js](https://highlightjs.org/) + [DOMPurify](https://github.com/cure53/DOMPurify) |
-| i18n | Custom lightweight runtime (en + zh-CN) |
-| Testing | [Vitest](https://vitest.dev/) |
+| Layer     | Technology                                                                                                                     |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Framework | [Tauri v2](https://v2.tauri.app/) (Rust backend + WebView)                                                                     |
+| Frontend  | [Svelte 5](https://svelte.dev/) + [SvelteKit](https://svelte.dev/docs/kit/) (adapter-static)                                   |
+| Styling   | [Tailwind CSS](https://tailwindcss.com/) v3 + CSS variables                                                                    |
+| Terminal  | [xterm.js](https://xtermjs.org/)                                                                                               |
+| Markdown  | [marked](https://marked.js.org/) + [highlight.js](https://highlightjs.org/) + [DOMPurify](https://github.com/cure53/DOMPurify) |
+| i18n      | Custom lightweight runtime (en + zh-CN)                                                                                        |
+| Testing   | [Vitest](https://vitest.dev/)                                                                                                  |
 
 **Agent Communication:**
 
-Each session is a long-lived, multi-turn process managed by a per-run session actor. **Claude Code** communicates over a bidirectional stream-JSON protocol (stdin/stdout) with an interactive control protocol. **Codex** supports two transports: `codex app-server` (bidirectional JSON-RPC — the **default**, unlocking interactive approvals, mid-turn steer, fork/rewind/compact/goal, image input, and live command output) or `codex exec` (one-shot NDJSON per turn — a fallback, selectable in Settings for older Codex CLIs).
+Interactive sessions are managed by a per-run session actor. **Claude Code** communicates over a long-lived bidirectional stream-JSON protocol (stdin/stdout) with an interactive control protocol. **Codex** supports two transports: experimental `codex app-server` (long-lived bidirectional JSON-RPC — the **default**, unlocking interactive approvals, mid-turn steer, fork/rewind/compact/goal, image input, and live command output) or `codex exec` (a one-shot NDJSON process for each turn — an opt-out fallback selectable in Settings for older or incompatible Codex CLIs).
 
 **Data Storage:**
 
-All data is stored locally at `~/.opencovibe/` — no cloud, no database.
+OpenCovibe-owned state is stored locally at `~/.opencovibe/` — no cloud database.
 
 ```
 ~/.opencovibe/
@@ -217,19 +200,24 @@ All data is stored locally at `~/.opencovibe/` — no cloud, no database.
 ├── runs/                  # Session history
 │   └── {run-id}/
 │       ├── meta.json      # Run metadata
-│       ├── events.jsonl   # Event log
-│       └── artifacts.json # Summary
-└── keybindings.json       # Custom shortcuts
+│       ├── events.jsonl   # Source-of-truth event log
+│       ├── artifacts.json # Derived run summary
+│       ├── attachments/   # Saved message attachments, when present
+│       └── history-v1/    # Rebuildable paged-history projection
+├── prompt-favorites.json  # Saved prompts
+└── *-index / *-cache      # Rebuildable search and usage caches
 ```
+
+OpenCovibe also reads or updates CLI-owned configuration when a feature requires it: Claude Code data under `~/.claude/`, Codex data under `~/.codex/`, and project-scoped files such as `.claude/` or `AGENTS.md`. App shortcut overrides live in `~/.opencovibe/settings.json`; Claude CLI keybindings remain in `~/.claude/keybindings.json`.
 
 ## Development
 
 ```bash
 npm install              # Install dependencies
 npm run tauri dev        # Dev mode with hot-reload
-npm test                 # Run tests
-npm run lint:fix         # Lint
-npm run format           # Format
+npm run verify           # Lint, format check, type-check, tests, frontend build, Rust checks
+npm test                 # Run the Vitest suite only
+npm run fix              # Apply frontend lint/format fixes and cargo fmt
 ```
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,7 +10,7 @@
   <a href="#为什么选择-opencovibe">为什么</a> &middot;
   <a href="#核心能力">核心能力</a> &middot;
   <a href="#快速开始">快速开始</a> &middot;
-  <a href="#支持的平台">平台</a> &middot;
+  <a href="#支持的模型平台">模型平台</a> &middot;
   <a href="#架构">架构</a> &middot;
   <a href="#许可证">许可证</a>
 </p>
@@ -27,43 +27,43 @@
 
 ## 为什么选择 OpenCovibe？
 
-Claude Code 等 AI 编程 CLI 功能强大，但它们运行在终端里。这意味着没有持久化的面板、没有可视化的 Diff 审查、没有跨会话历史、也无法自由切换多个 API 平台。OpenCovibe 用原生桌面 UI 包装这些 CLI，补上终端无法提供的那些能力层 —— 同时保持所有数据**本地存储**。（调用远程模型 API 需要联网；应用本身没有云端后台。）
+Claude Code、Codex 等 AI 编程 CLI 功能强大，但以终端为中心的界面不易持续追踪长时间任务、可视化审查和跨会话管理。OpenCovibe 用原生桌面 UI 包装这些 CLI，提供持久化面板、结构化工具活动、可视化 Diff 和可搜索的运行历史，同时保持应用数据**本地存储**。调用远程模型 API 仍需要联网；OpenCovibe 本身没有云端后台。
 
-| Agent | 状态 |
-|-------|------|
-| [Claude Code](https://github.com/anthropics/claude-code) | 已适配 |
-| [Codex](https://github.com/openai/codex) | 已适配 —— 交互式 `app-server` 模式（默认），`exec` 作为回退 |
+| Agent                                                    | 状态                                                              |
+| -------------------------------------------------------- | ----------------------------------------------------------------- |
+| [Claude Code](https://github.com/anthropics/claude-code) | 已适配                                                            |
+| [Codex](https://github.com/openai/codex)                 | 已适配 —— 实验性交互式 `app-server` 模式（默认），`exec` 作为回退 |
 
-**平台状态**：目前主要在 **macOS** 上开发和测试。Windows 和 Linux 可以构建运行，但尚未进行充分的兼容性调整和测试，欢迎提交问题报告和贡献。
+**平台状态**：提供 **macOS 13+**（Apple Silicon 和 Intel）与 **Windows 10+ x64** 预编译包；Linux 支持源码构建。目前仍主要在 macOS 上开发和测试，尤其欢迎 Windows 和 Linux 用户提交问题报告。
 
 **核心原则**：封装 CLI，可视化工作，数据本地化。
 
 ## 核心能力
 
-### CLI 不提供、OpenCovibe 补上的
+### OpenCovibe 增加的能力
 
-| 能力 | OpenCovibe 增加了什么 |
-|------|----------------------|
+| 能力               | OpenCovibe 增加了什么                                                                                            |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | **可视化工具卡片** | 每个工具调用（Read、Edit、Bash、Grep、Write、WebFetch……）都渲染为内联卡片，带语法高亮 Diff、结构化输出和一键复制 |
-| **运行历史与回放** | 浏览所有历史会话，完整事件回放，从任意节点恢复 / 分叉，支持软删除和恢复 |
-| **多平台热切换** | 用 Claude Code 接入 15+ API 平台（DeepSeek、Kimi、智谱、百炼、豆包、MiniMax、OpenRouter、Ollama……），无需重启即可切换 |
-| **浏览器远程访问** | 内嵌 Web 服务器，支持局域网浏览器访问或通过 HTTP 隧道（ngrok / cloudflared）远程访问 |
-| **文件浏览器** | 浏览和编辑项目文件，支持语法高亮、Markdown 预览、图片预览和 Git Diff 查看 |
-| **Memory 编辑器** | 创建和编辑 CLAUDE.md、项目级和用户级 Memory 文件，支持实时预览 |
-| **Agent 管理** | 可视化编辑器创建、编辑、管理自定义 Agent 定义（.md 文件），支持表单模式和源码模式 |
-| **权限规则管理** | 可视化管理 CLI 权限允许/拒绝规则，支持用户级和项目级配置 |
-| **用量分析** | 按模型的 Token 分解、成本追踪、每日热力图、模型堆叠图表、会话级统计 |
-| **团队面板** | 只读查看 Claude Code 多 Agent 团队协作 —— 任务列表、队友状态、消息流 |
-| **活动监控** | 实时 Hook 事件流、工具活动时间线、文件追踪面板、嵌套工具卡片的子 Agent 追踪 |
-| **插件市场** | 可视化浏览、安装、管理 Claude Code 插件和技能 |
-| **MCP 管理** | 发现 MCP 服务器、查看逐服务器状态、一键重连 / 启停 |
-| **内联权限审查** | 丰富的权限审查 UI，批量允许/拒绝面板、CLI 建议的"始终允许"规则、AskUserQuestion 渲染 |
-| **CLI 会话导入** | 发现并导入已有的 Claude Code CLI 会话到 OpenCovibe |
-| **Rewind 回退** | 检查点式文件回退，支持 dry-run 预览和逐文件选择 |
-| **远程主机** | 配置 SSH 远程主机执行 CLI，支持密钥生成向导和连接测试 |
-| **预览与元素选取** | 在伴侣窗口中打开 localhost 预览，交互式选取页面元素，将结构化上下文（DOM 路径、样式、HTML 片段）插入对话 |
-| **Ralph 循环** | 自动迭代同一提示直到完成条件满足——免手动编码，支持自定义最大迭代次数 |
-| **系统诊断** | CLI、平台、SSH 和代理配置的系统健康检查 |
+| **运行历史与回放** | 浏览所有历史会话，完整事件回放，从任意节点恢复 / 分叉，支持软删除和恢复                                          |
+| **多平台热切换**   | 通过内置预设让 Claude Code 接入 Anthropic 兼容服务、API 网关和本地运行时，无需重启即可切换                       |
+| **浏览器远程访问** | 带 Token 认证的内嵌 Web 服务器，支持局域网浏览器访问或通过 HTTP 隧道（ngrok / cloudflared）远程访问              |
+| **文件浏览器**     | 浏览和编辑项目文件，支持语法高亮、Markdown 预览、图片预览和 Git Diff 查看                                        |
+| **Memory 编辑器**  | 创建和编辑 CLAUDE.md、项目级和用户级 Memory 文件，支持实时预览                                                   |
+| **Agent 管理**     | 可视化创建、编辑和管理 Claude Agent 定义与 Codex 角色，支持表单模式和源码模式                                    |
+| **权限规则管理**   | 可视化管理 CLI 权限允许/拒绝规则，支持用户级和项目级配置                                                         |
+| **用量分析**       | 按模型的 Token 分解、成本追踪、每日热力图、模型堆叠图表、会话级统计                                              |
+| **团队面板**       | 只读查看 Claude Code 多 Agent 团队协作 —— 任务列表、队友状态、消息流                                             |
+| **活动监控**       | 实时 Hook 事件流、工具活动时间线、文件追踪面板、嵌套工具卡片的子 Agent 追踪                                      |
+| **插件市场**       | 可视化浏览、安装和管理 Claude Code、Codex 插件与技能                                                             |
+| **MCP 管理**       | 发现 MCP 服务器、查看逐服务器状态、一键重连 / 启停                                                               |
+| **内联权限审查**   | 丰富的权限审查 UI，批量允许/拒绝面板、CLI 建议的"始终允许"规则、AskUserQuestion 渲染                             |
+| **CLI 会话导入**   | 发现、导入并同步已有的 Claude Code 和 Codex CLI 会话                                                             |
+| **Rewind 回退**    | Claude：通过 dry-run 预览选择性恢复检查点文件；Codex：只回退对话历史，不恢复文件                                 |
+| **远程主机**       | 配置 SSH 远程主机执行 CLI，支持密钥生成向导和连接测试                                                            |
+| **预览与元素选取** | 在伴侣窗口中打开 localhost 预览，交互式选取页面元素，将结构化上下文（DOM 路径、样式、HTML 片段）插入对话         |
+| **Ralph 循环**     | 在 Claude 会话中自动迭代同一提示直到满足完成条件，支持自定义最大迭代次数                                         |
+| **系统诊断**       | CLI、平台、SSH 和代理配置的系统健康检查                                                                          |
 
 ### 更多功能
 
@@ -77,36 +77,40 @@ Claude Code 等 AI 编程 CLI 功能强大，但它们运行在终端里。这�
 - **国际化** — 轻量响应式运行时，支持英文和简体中文
 - **系统托盘** — 最小化到托盘；后台会话持续运行，支持原生通知
 - **深色 / 浅色主题** — 基于 CSS 变量的主题系统，支持 UI 缩放
-- **自动更新** — 应用内更新检测与下载链接
+- **更新检测** — 应用内检查新版本并提供对应平台的下载链接
 - **安装向导** — 首次启动引导 CLI 检测、认证和平台配置
 
 ## 快速开始
 
-### 方式 A：下载预编译包（macOS）
+### 方式 A：下载预编译包
 
-从 [Releases](https://github.com/AnyiWang/OpenCovibe/releases) 下载最新 `.dmg` —— 通用二进制，同时支持 Apple Silicon 和 Intel Mac。
+从 [Releases](https://github.com/AnyiWang/OpenCovibe/releases) 下载最新安装包：
 
-> **注意**：应用未经代码签名。首次启动时，右键点击应用选择"打开"以绕过 macOS Gatekeeper。
+- **macOS 13+**：同时支持 Apple Silicon 和 Intel Mac 的通用 `.dmg`
+- **Windows 10+ x64**：`.msi` 或安装程序 `.zip`
 
-### 方式 B：自动安装（macOS）
+> **未签名构建**：macOS 首次启动时，请右键点击应用并选择**打开**；Windows SmartScreen 可能需要选择**更多信息 > 仍要运行**。
+
+### 方式 B：自动安装（macOS / Linux）
 
 ```bash
 git clone https://github.com/AnyiWang/OpenCovibe.git
 cd OpenCovibe
 ./scripts/setup.sh          # 加 --yes 跳过确认提示
-npm run tauri dev
 ```
 
-安装脚本自动检测并安装缺少的依赖（Xcode CLI Tools、Homebrew、Node.js、Rust）。
+安装脚本会识别当前平台、检查必要构建工具，经确认后安装缺失依赖并安装项目包。在 macOS 上可配置 Xcode CLI Tools 和 Homebrew；在受支持的 Linux 发行版上会安装所需的 WebKit/GTK 软件包。脚本最后会询问是否立即启动开发应用；之后可使用 `npm run tauri dev` 启动。
 
 ### 方式 C：手动安装
 
 **前置条件：**
 
 - [Node.js](https://nodejs.org/) >= 20
-- [Rust](https://rustup.rs/) >= 1.75
+- 当前稳定版 [Rust](https://rustup.rs/) 工具链
+- [Git](https://git-scm.com/)
 
-**macOS：**
+**macOS 13+：**
+
 ```bash
 xcode-select --install
 brew install node
@@ -114,17 +118,18 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
 **Linux (Debian/Ubuntu)：**
+
 ```bash
-sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file \
-  libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+sudo apt install libwebkit2gtk-4.1-dev build-essential curl wget file git \
+  libgtk-3-dev libssl-dev pkg-config libayatana-appindicator3-dev librsvg2-dev
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-**Windows：**
-```powershell
-# 从 https://rustup.rs 安装 Rust
-# 从 https://nodejs.org 安装 Node.js
-```
+**Windows 10+ x64：**
+
+1. 安装 [Microsoft C++ Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/)，勾选 **Desktop development with C++**。
+2. 如果系统尚未安装，请安装 [Microsoft Edge WebView2 Runtime](https://developer.microsoft.com/microsoft-edge/webview2/)。
+3. 安装 Node.js 20+、Git，以及 [rustup](https://rustup.rs/) 提供的 Rust MSVC 工具链。
 
 **构建与运行：**
 
@@ -140,50 +145,28 @@ npm run tauri dev
 首次启动时，OpenCovibe 会引导你完成：
 
 1. **CLI 检测** — 自动检测 Claude Code 和 Codex CLI，未安装则提供安装引导
-2. **认证** — OAuth 登录或 API Key，支持 15+ 平台
+2. **认证** — 根据所选 Agent 使用 CLI 登录、OAuth 或平台 API Key
 3. **就绪** — 开始编程
 
 你可以随时从**设置 > 通用 > 安装向导**重新运行。
 
-## 支持的平台
+## 支持的模型平台
 
-### LLM 厂商
+不同 Agent 的平台兼容性并不相同。运行时以**设置**页面显示的预设为准，具体列表可能随版本调整。
 
-| 厂商 | 端点 | 认证方式 |
-|------|------|---------|
-| Anthropic | 官方 API | API Key |
-| DeepSeek | `api.deepseek.com/anthropic` | Bearer |
-| Kimi（月之暗面） | `api.moonshot.cn/anthropic` | Bearer |
-| Kimi For Coding | `api.kimi.com/coding/` | Bearer |
-| 智谱 | `open.bigmodel.cn/api/anthropic` | Bearer |
-| 智谱（国际） | `api.z.ai/api/anthropic` | Bearer |
-| 百炼（阿里云 Coding Plan） | `coding.dashscope.aliyuncs.com/apps/anthropic` | Bearer |
-| 百炼（阿里云 API） | `dashscope.aliyuncs.com/apps/anthropic` | Bearer |
-| 豆包（字节跳动） | `ark.cn-beijing.volces.com/api/coding` | Bearer |
-| MiniMax | `api.minimax.io/anthropic` | Bearer |
-| MiniMax（中国） | `api.minimaxi.com/anthropic` | Bearer |
-| 小米 MiMo | `api.xiaomimimo.com/anthropic` | Bearer |
-| 小米 MiMo（订阅 Token Plan） | `token-plan-cn.xiaomimimo.com/anthropic` | Bearer |
-| 腾讯混元 | `api.hunyuan.cloud.tencent.com/anthropic` | Bearer |
-| SiliconFlow（硅基流动） | `api.siliconflow.com/` | Bearer |
+### Claude Code（Anthropic 兼容）
 
-### API 代理
+| 分类         | 内置预设                                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| 官方         | Claude Code / Anthropic                                                                                                              |
+| 模型服务商   | DeepSeek、Kimi、智谱、百炼、豆包、MiniMax、小米 MiMo、腾讯混元、硅基流动、阶跃星辰、LongCat、讯飞星辰、腾讯 Coding Plan              |
+| API 网关     | Vercel AI Gateway、OpenRouter、AiHubMix、Requesty、Fireworks AI、DeepInfra、Novita AI、ZenMux                                        |
+| 本地与路由器 | Ollama、[CC Switch](https://github.com/farion1231/cc-switch)、[Claude Code Router](https://github.com/musistudio/claude-code-router) |
+| 自定义       | 任意 Anthropic 兼容端点                                                                                                              |
 
-| 平台 | 端点 | 认证方式 |
-|------|------|---------|
-| Vercel AI Gateway | `ai-gateway.vercel.sh` | Bearer |
-| OpenRouter | `openrouter.ai/api` | Bearer |
-| AiHubMix | `aihubmix.com` | Bearer |
-| ZenMux | `zenmux.ai/api/anthropic` | Bearer |
+### Codex（OpenAI Responses API）
 
-### 本地
-
-| 平台 | 端点 |
-|------|------|
-| Ollama | `localhost:11434` |
-| [CC Switch](https://github.com/farion1231/cc-switch) | `localhost:15721` |
-| [Claude Code Router](https://github.com/musistudio/claude-code-router) | `localhost:3456` |
-| 自定义 | 任何 Anthropic 兼容端点 |
+Codex 可以使用原生 ChatGPT/API Key 登录，也可以配置支持 Responses API 的 Vercel AI Gateway、AiHubMix、Requesty、Fireworks AI、ZenMux、Ollama 或自定义端点。仅提供 Chat Completions 的平台需要 Responses 转换代理，无法直接使用。
 
 ## 架构
 
@@ -193,23 +176,23 @@ npm run tauri dev
 
 **技术栈：**
 
-| 层级 | 技术 |
-|------|------|
-| 框架 | [Tauri v2](https://v2.tauri.app/)（Rust 后端 + WebView） |
-| 前端 | [Svelte 5](https://svelte.dev/) + [SvelteKit](https://svelte.dev/docs/kit/)（adapter-static） |
-| 样式 | [Tailwind CSS](https://tailwindcss.com/) v3 + CSS 变量 |
-| 终端 | [xterm.js](https://xtermjs.org/) |
+| 层级     | 技术                                                                                                                           |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| 框架     | [Tauri v2](https://v2.tauri.app/)（Rust 后端 + WebView）                                                                       |
+| 前端     | [Svelte 5](https://svelte.dev/) + [SvelteKit](https://svelte.dev/docs/kit/)（adapter-static）                                  |
+| 样式     | [Tailwind CSS](https://tailwindcss.com/) v3 + CSS 变量                                                                         |
+| 终端     | [xterm.js](https://xtermjs.org/)                                                                                               |
 | Markdown | [marked](https://marked.js.org/) + [highlight.js](https://highlightjs.org/) + [DOMPurify](https://github.com/cure53/DOMPurify) |
-| 国际化 | 轻量自建运行时 (en + zh-CN) |
-| 测试 | [Vitest](https://vitest.dev/) |
+| 国际化   | 轻量自建运行时 (en + zh-CN)                                                                                                    |
+| 测试     | [Vitest](https://vitest.dev/)                                                                                                  |
 
 **Agent 通信：**
 
-每个会话都是由独立的 session actor 管理的长连接多轮进程。**Claude Code** 通过双向 stream-JSON 协议（stdin/stdout）通信，带交互式控制协议。**Codex** 支持两种传输方式：`codex app-server`（双向 JSON-RPC —— **默认**，解锁交互式审批、turn 中途 steer、fork/rewind/compact/goal、图片输入和实时命令输出）或 `codex exec`（每轮一次性 NDJSON —— 回退方案，可在设置中为旧版 Codex CLI 选用）。
+交互式会话由每个运行独立的 session actor 管理。**Claude Code** 使用长期运行的双向 stream-JSON 协议（stdin/stdout），并带有交互式控制协议。**Codex** 支持两种传输方式：实验性的 `codex app-server`（长期运行的双向 JSON-RPC —— **默认**，支持交互式审批、turn 中途 steer、fork/rewind/compact/goal、图片输入和实时命令输出）或 `codex exec`（每轮启动一次的一次性 NDJSON 进程——可在设置中选择的回退方案，适用于旧版或不兼容的 Codex CLI）。
 
 **数据存储：**
 
-所有数据本地存储在 `~/.opencovibe/` —— 无云端，无数据库。
+OpenCovibe 自有状态本地存储在 `~/.opencovibe/`，不使用云端数据库。
 
 ```
 ~/.opencovibe/
@@ -217,24 +200,33 @@ npm run tauri dev
 ├── runs/                  # 会话历史
 │   └── {run-id}/
 │       ├── meta.json      # 运行元数据
-│       ├── events.jsonl   # 事件日志
-│       └── artifacts.json # 摘要
-└── keybindings.json       # 自定义快捷键
+│       ├── events.jsonl   # 作为事实来源的事件日志
+│       ├── artifacts.json # 派生的运行摘要
+│       ├── attachments/   # 存在附件时保存消息附件
+│       └── history-v1/    # 可重建的分页历史投影
+├── prompt-favorites.json  # 收藏的提示词
+└── *-index / *-cache      # 可重建的搜索索引和用量缓存
 ```
+
+功能需要时，OpenCovibe 也会读取或更新 CLI 自有配置：Claude Code 数据位于 `~/.claude/`，Codex 数据位于 `~/.codex/`，项目级文件包括 `.claude/` 或 `AGENTS.md`。应用快捷键覆盖保存在 `~/.opencovibe/settings.json`；Claude CLI 快捷键仍位于 `~/.claude/keybindings.json`。
 
 ## 开发
 
 ```bash
 npm install              # 安装依赖
 npm run tauri dev        # 热重载开发模式
-npm test                 # 运行测试
-npm run lint:fix         # 代码检查
-npm run format           # 代码格式化
+npm run verify           # 代码检查、格式检查、类型检查、测试、前端构建和 Rust 检查
+npm test                 # 仅运行 Vitest 测试
+npm run fix              # 自动修复前端 lint/格式并运行 cargo fmt
 ```
 
 ## 参与贡献
 
-欢迎贡献！请通过 [Issue](https://github.com/AnyiWang/OpenCovibe/issues) 提交 Bug 报告或功能建议，也欢迎提交 Pull Request。
+欢迎贡献！开发环境、代码规范和 PR 要求请参阅 [CONTRIBUTING.md](CONTRIBUTING.md)。你也可以通过 [Issue](https://github.com/AnyiWang/OpenCovibe/issues) 提交 Bug 报告或功能建议。
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=AnyiWang/OpenCovibe&type=Date)](https://star-history.com/#AnyiWang/OpenCovibe&Date)
 
 ## 许可证
 

--- a/static/architecture-zh.svg
+++ b/static/architecture-zh.svg
@@ -41,9 +41,9 @@
   <!-- Frontend -->
   <rect class="box" x="35" y="60" width="190" height="170" rx="8"/>
   <text class="t-head" x="130" y="90" text-anchor="middle">Svelte 5 前端</text>
-  <text class="t-body" x="130" y="125" text-anchor="middle">9 个路由</text>
-  <text class="t-body" x="130" y="145" text-anchor="middle">72 个组件</text>
-  <text class="t-body" x="130" y="165" text-anchor="middle">1377 个测试</text>
+  <text class="t-body" x="130" y="125" text-anchor="middle">对话工作台</text>
+  <text class="t-body" x="130" y="145" text-anchor="middle">运行历史与回放</text>
+  <text class="t-body" x="130" y="165" text-anchor="middle">活动与文件视图</text>
 
   <!-- Backend -->
   <rect class="box" x="380" y="60" width="285" height="170" rx="8"/>
@@ -56,24 +56,24 @@
 
   <!-- IPC -->
   <line class="ln" x1="225" y1="145" x2="380" y2="145" marker-start="url(#ar)" marker-end="url(#a)"/>
-  <text class="t-sm" x="302" y="136" text-anchor="middle">157 IPC 命令</text>
-  <text class="t-sm" x="302" y="162" text-anchor="middle">+ 12 事件类型</text>
+  <text class="t-sm" x="302" y="136" text-anchor="middle">IPC 命令</text>
+  <text class="t-sm" x="302" y="162" text-anchor="middle">+ 事件流</text>
 
   <!-- Claude transport -->
-  <line class="ln" x1="450" y1="230" x2="450" y2="292" marker-end="url(#a)"/>
-  <text class="t-sm" x="450" y="260" text-anchor="middle">stream-json</text>
+  <line class="ln" x1="450" y1="230" x2="450" y2="292" marker-start="url(#ar)" marker-end="url(#a)"/>
+  <text class="t-sm" x="450" y="260" text-anchor="middle">stream-json（双向）</text>
 
   <!-- Codex transport -->
-  <line class="ln" x1="595" y1="230" x2="595" y2="292" marker-end="url(#a)"/>
+  <line class="ln" x1="595" y1="230" x2="595" y2="292" marker-start="url(#ar)" marker-end="url(#a)"/>
   <text class="t-sm" x="595" y="260" text-anchor="middle">app-server / exec</text>
 
   <!-- Claude CLI -->
   <rect class="box" x="390" y="292" width="120" height="53" rx="8"/>
   <text class="t-head" x="450" y="316" text-anchor="middle">Claude CLI</text>
-  <text class="t-body" x="450" y="335" text-anchor="middle">（会话）</text>
+  <text class="t-body" x="450" y="335" text-anchor="middle">（长连接）</text>
 
   <!-- Codex CLI -->
   <rect class="box" x="535" y="292" width="120" height="53" rx="8"/>
   <text class="t-head" x="595" y="316" text-anchor="middle">Codex CLI</text>
-  <text class="t-body" x="595" y="335" text-anchor="middle">（会话）</text>
+  <text class="t-body" x="595" y="335" text-anchor="middle">（长连接 / 单次）</text>
 </svg>

--- a/static/architecture.svg
+++ b/static/architecture.svg
@@ -41,9 +41,9 @@
   <!-- Frontend -->
   <rect class="box" x="35" y="60" width="190" height="170" rx="8"/>
   <text class="t-head" x="130" y="90" text-anchor="middle">Svelte 5 Frontend</text>
-  <text class="t-body" x="130" y="125" text-anchor="middle">9 routes</text>
-  <text class="t-body" x="130" y="145" text-anchor="middle">72 components</text>
-  <text class="t-body" x="130" y="165" text-anchor="middle">1377 tests</text>
+  <text class="t-body" x="130" y="125" text-anchor="middle">Chat dashboard</text>
+  <text class="t-body" x="130" y="145" text-anchor="middle">Run history and replay</text>
+  <text class="t-body" x="130" y="165" text-anchor="middle">Activity and file views</text>
 
   <!-- Backend -->
   <rect class="box" x="380" y="60" width="285" height="170" rx="8"/>
@@ -56,24 +56,24 @@
 
   <!-- IPC -->
   <line class="ln" x1="225" y1="145" x2="380" y2="145" marker-start="url(#ar)" marker-end="url(#a)"/>
-  <text class="t-sm" x="302" y="136" text-anchor="middle">157 IPC commands</text>
-  <text class="t-sm" x="302" y="162" text-anchor="middle">+ 12 event types</text>
+  <text class="t-sm" x="302" y="136" text-anchor="middle">IPC commands</text>
+  <text class="t-sm" x="302" y="162" text-anchor="middle">+ event stream</text>
 
   <!-- Claude transport -->
-  <line class="ln" x1="450" y1="230" x2="450" y2="292" marker-end="url(#a)"/>
-  <text class="t-sm" x="450" y="260" text-anchor="middle">stream-json</text>
+  <line class="ln" x1="450" y1="230" x2="450" y2="292" marker-start="url(#ar)" marker-end="url(#a)"/>
+  <text class="t-sm" x="450" y="260" text-anchor="middle">stream-json (bidir)</text>
 
   <!-- Codex transport -->
-  <line class="ln" x1="595" y1="230" x2="595" y2="292" marker-end="url(#a)"/>
+  <line class="ln" x1="595" y1="230" x2="595" y2="292" marker-start="url(#ar)" marker-end="url(#a)"/>
   <text class="t-sm" x="595" y="260" text-anchor="middle">app-server / exec</text>
 
   <!-- Claude CLI -->
   <rect class="box" x="390" y="292" width="120" height="53" rx="8"/>
   <text class="t-head" x="450" y="316" text-anchor="middle">Claude CLI</text>
-  <text class="t-body" x="450" y="335" text-anchor="middle">(session)</text>
+  <text class="t-body" x="450" y="335" text-anchor="middle">(long-lived)</text>
 
   <!-- Codex CLI -->
   <rect class="box" x="535" y="292" width="120" height="53" rx="8"/>
   <text class="t-head" x="595" y="316" text-anchor="middle">Codex CLI</text>
-  <text class="t-body" x="595" y="335" text-anchor="middle">(session)</text>
+  <text class="t-sm" x="595" y="335" text-anchor="middle">(long-lived / one-shot)</text>
 </svg>


### PR DESCRIPTION
## Summary

- refresh the English and Chinese quick-start instructions for macOS, Windows, and Linux
- clarify Claude and Codex transport, provider, plugin, import, Ralph, and rewind boundaries
- correct local-storage ownership and development commands
- replace volatile route/component/test/IPC counts in both architecture diagrams with stable responsibility labels

## Why

The README had not been materially refreshed since the first Codex integration. It omitted released Windows packages, described the Linux setup script as macOS-only, conflated Claude and Codex capabilities, and documented an incorrect keybindings path. The architecture diagrams also embedded counts that had already drifted.

## User impact

New users can choose the correct release package and source-build prerequisites, and can see which capabilities and providers apply to Claude versus Codex. The documentation now explains where OpenCovibe-owned and CLI-owned data live.

## Validation

- `npm run lint:fix`
- `npm run format`
- `npm run format:check`
- `npm run check` — 0 errors (73 existing warnings)
- `npm test` — 45 files, 1,522 tests passed
- `npm run build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml`
- README Prettier check, local-link validation, SVG XML validation, and rendered SVG inspection

## Deferred

A fresh product screenshot should be captured separately from a clean released build with non-sensitive demo data.
